### PR TITLE
Fix: Prevent errors when clicking on unpublished videos

### DIFF
--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -1028,8 +1028,8 @@ export const FIRST_UPLOAD_FEED = gql`
 `;
 
 export const NEW_CONTENT = gql`
-  query MyQuery {
-    socialFeed(spkvideo: { only: true, firstUpload: true }) {
+  query NewContent($limit: Int = 50, $skip: Int = 0) {
+    socialFeed(spkvideo: { only: true, firstUpload: true }, pagination: { limit: $limit, skip: $skip }) {
       items {
         ... on HivePost {
           permlink

--- a/src/page/FirstUploads.scss
+++ b/src/page/FirstUploads.scss
@@ -13,4 +13,27 @@
       }
         
     }
+
+    .load-more-btn {
+        display: block;
+        margin: 30px auto;
+        padding: 12px 40px;
+        background: #E32933;
+        color: #fff;
+        border: none;
+        border-radius: 8px;
+        font-size: 16px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.2s ease;
+
+        &:hover:not(:disabled) {
+            background: #c4242c;
+        }
+
+        &:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+        }
+    }
 }

--- a/src/page/NewVideos.jsx
+++ b/src/page/NewVideos.jsx
@@ -1,27 +1,61 @@
-import React from 'react'
+import React, { useState } from 'react'
 import "./FirstUploads.scss"
 import { useQuery } from '@apollo/client'
 import { NEW_CONTENT } from '../graphql/queries'
 import CardSkeleton from '../components/Cards/CardSkeleton'
 import Card3 from "../components/Cards/Card3";
 
+const VIDEOS_PER_PAGE = 50;
+
 const NewVideos = () => {
-  const { data, loading, error } = useQuery(NEW_CONTENT);
+  const [skip, setSkip] = useState(0);
+  const [allVideos, setAllVideos] = useState([]);
+  
+  const { data, loading, error } = useQuery(NEW_CONTENT, {
+    variables: { limit: VIDEOS_PER_PAGE, skip },
+    onCompleted: (newData) => {
+      const newItems = newData?.socialFeed?.items || [];
+      if (skip === 0) {
+        setAllVideos(newItems);
+      } else {
+        setAllVideos(prev => [...prev, ...newItems]);
+      }
+    }
+  });
 
   // Transform GraphQL response to match Card3 expected format
-  const videos = data?.socialFeed?.items?.map(item => ({
+  const videos = allVideos.map(item => ({
     ...item,
     author: item.author?.username || item.author,
     duration: item.spkvideo?.duration,
     created_at: item.created_at,
-  })) || [];
+  }));
 
-  console.log(videos);
+  const handleLoadMore = () => {
+    setSkip(prev => prev + VIDEOS_PER_PAGE);
+  };
+
+  const hasMore = data?.socialFeed?.items?.length === VIDEOS_PER_PAGE;
 
   return (
     <div className='firstupload-container'>
       <div className='headers'>New VIDEOS</div>
-      {loading ? <CardSkeleton /> : <Card3 videos={videos} loading={false} />}
+      {loading && skip === 0 ? (
+        <CardSkeleton />
+      ) : (
+        <>
+          <Card3 videos={videos} loading={false} />
+          {hasMore && (
+            <button 
+              className="load-more-btn" 
+              onClick={handleLoadMore}
+              disabled={loading}
+            >
+              {loading ? 'Loading...' : 'Load More'}
+            </button>
+          )}
+        </>
+      )}
       {error && <p>Error fetching videos</p>}
     </div>
   );

--- a/src/page/NewVideos.jsx
+++ b/src/page/NewVideos.jsx
@@ -1,93 +1,28 @@
 import React from 'react'
 import "./FirstUploads.scss"
-import { useEffect } from "react"
 import { useQuery } from '@apollo/client'
 import { NEW_CONTENT } from '../graphql/queries'
-import Cards from '../components/Cards/Cards'
 import CardSkeleton from '../components/Cards/CardSkeleton'
-import { useInfiniteQuery } from "@tanstack/react-query"
-import axios from "axios"
 import Card3 from "../components/Cards/Card3";
 
-// const fetchVideos = async ({ pageParam = 1 }) => {
-//   const LIMIT = 300;
-//   const res = await axios.get(
-//     // `https://3speak.tv/apiv2/feeds/new?page=${pageParam}`
-//     `https://3speak.tv/apiv2/feeds/new?limit=${LIMIT}`
-//   );
-//   return res.data;
-// };
-
-const fetchVideos = async ({ pageParam = 0 }) => {
-  let url;
-  const LIMIT = 300;
-
-  // On first load, use /feeds/trending
-  if (pageParam === 0) {
-    url = `https://3speak.tv/apiv2/feeds/new?limit=${LIMIT}`;
-  } 
-  // On later loads, use /feeds/trending/more with skip
-  else {
-    url = `https://3speak.tv/apiv2/feeds/new/more?skip=100`;
-  }
-
-  const res = await axios.get(url);
-  // Notice: trending returns an array, while /more returns { trends: [...] }
-  return res.data.trends || res.data;
-};
-
-
-
 const NewVideos = () => {
-  const {
-      data,
-      fetchNextPage,
-      hasNextPage,
-      isFetchingNextPage,
-      isLoading,
-      isError,
-    } = useInfiniteQuery({
-      queryKey: ["new"],
-      queryFn: fetchVideos,
-      getNextPageParam: (lastPage, allPages) => {
-        // If lastPage returned data, calculate new skip
-        const currentTotal = allPages.flat().length;
-        if (lastPage && lastPage.length > 0) return currentTotal;
-        return undefined; // Stop when no more data
-      },
-    });
+  const { data, loading, error } = useQuery(NEW_CONTENT);
 
-  useEffect(() => {
-      const handleScroll = () => {
-        if (
-          window.innerHeight + window.scrollY >=
-            document.body.offsetHeight - 200 &&
-          !isFetchingNextPage &&
-          hasNextPage
-        ) {
-          fetchNextPage();
-        }
-      };
-  
-      window.addEventListener("scroll", handleScroll);
-      return () => window.removeEventListener("scroll", handleScroll);
-    }, [isFetchingNextPage, hasNextPage, fetchNextPage]);
-  
-    // Flatten all pages into a single array
-    const videos = data?.pages.flat() || [];
-    console.log(videos)
-    
+  // Transform GraphQL response to match Card3 expected format
+  const videos = data?.socialFeed?.items?.map(item => ({
+    ...item,
+    author: item.author?.username || item.author,
+    duration: item.spkvideo?.duration,
+    created_at: item.created_at,
+  })) || [];
 
-  
+  console.log(videos);
 
   return (
     <div className='firstupload-container'>
       <div className='headers'>New VIDEOS</div>
-      {isLoading ? <CardSkeleton /> :  <Card3 videos={videos} loading={isFetchingNextPage} />}
-    {isError && <p>Error fetching videos</p>}
-      {isFetchingNextPage && (
-        <p style={{ textAlign: "center" }}>Loading more...</p>
-      )}
+      {loading ? <CardSkeleton /> : <Card3 videos={videos} loading={false} />}
+      {error && <p>Error fetching videos</p>}
     </div>
   );
 };

--- a/src/utils/fixThumbnails.js
+++ b/src/utils/fixThumbnails.js
@@ -26,7 +26,7 @@ const APP_IMAGE_CDN_DOMAIN = "https://media.3speak.tv";
 export function fixVideoThumbnail(video) {
   let thumbUrl = "";
 
-  const thumbnail = video?.images?.thumbnail || video?.thumbUrl ;
+  const thumbnail = video?.images?.thumbnail || video?.thumbUrl || video?.spkvideo?.thumbnail_url;
 
   // 🚧 If no thumbnail, return a fallback image
   if (!thumbnail) {


### PR DESCRIPTION
### The Problem

Users clicking on videos in the "New" feed would sometimes see an error page. This happened because:

Videos appear in the feed as soon as they're uploaded to 3Speak's database
The watch page fetches post data from Hive blockchain via GraphQL
There's a delay between upload and Hive broadcast (~30 seconds to minutes)
During this window, clicking the video = 💥 error
The Solution
Switch the New Videos page from the REST API to GraphQL.

Before: https://3speak.tv/apiv2/feeds/new → Returns videos from 3Speak DB (includes unpublished)

After: socialFeed GraphQL query with ... on HivePost → Only returns videos that exist on Hive

Since the GraphQL query explicitly requests HivePost types, videos that haven't been broadcast to Hive yet simply won't appear in the feed. No more phantom videos!

Changes
NewVideos.jsx: Replaced REST API + useInfiniteQuery with Apollo GraphQL query
queries.js: Added pagination params (limit/skip) to NEW_CONTENT query
fixThumbnails.js: Added spkvideo.thumbnail_url as fallback (GraphQL returns different structure)
FirstUploads.scss: Added "Load More" button styling

Bonus: Cleaner Pagination
Initial load: 50 videos (was 300 via REST 😬)
"Load More" button fetches 50 more at a time
Simpler code, better caching via Apollo Client

Testing
✅ New videos feed loads correctly
✅ All displayed videos are clickable (no errors)
✅ Load More button works
✅ Thumbnails display properly