### PR TITLE
feat: improve upload UX with clickable icons and edit button

### DIFF
--- a/src/components/legacy-studio/Preview.jsx
+++ b/src/components/legacy-studio/Preview.jsx
@@ -477,6 +477,13 @@ const startEncodingPolling = (vid) => {
 
               <div className="submit-btn-wrap">
                 <button
+                  className="edit-btn"
+                  onClick={() => navigate('/studio/details')}
+                  disabled={isWaitingForUpload}
+                >
+                  Edit Post
+                </button>
+                <button
                   onClick={handlePostVideo}
                   disabled={isWaitingForUpload}
                 >

--- a/src/components/legacy-studio/Preview.scss
+++ b/src/components/legacy-studio/Preview.scss
@@ -99,6 +99,9 @@ $overlay: rgba(15, 23, 42, 0.6);
   .submit-btn-wrap {
     margin-top: 24px;
     text-align: center;
+    display: flex;
+    justify-content: center;
+    gap: 12px;
 
     button {
       background-color: #1c64e0;
@@ -112,6 +115,21 @@ $overlay: rgba(15, 23, 42, 0.6);
       &:disabled {
         background-color: #a1a1aa;
         cursor: not-allowed;
+      }
+    }
+
+    .edit-btn {
+      background-color: transparent;
+      border: 2px solid #1c64e0;
+      color: #1c64e0;
+
+      &:hover:not(:disabled) {
+        background-color: rgba(28, 100, 224, 0.1);
+      }
+
+      &:disabled {
+        border-color: #a1a1aa;
+        color: #a1a1aa;
       }
     }
 

--- a/src/components/legacy-studio/VideoUploadStep1.jsx
+++ b/src/components/legacy-studio/VideoUploadStep1.jsx
@@ -140,7 +140,12 @@ function VideoUploadStep1() {
         <div className="content">
           <div className="file-upload">
             <div className="content">
-              <div className="icon">
+              <div 
+                className="icon" 
+                onClick={() => videoInputRef.current?.click()}
+                style={{ cursor: 'pointer' }}
+                title="Click to select a video file"
+              >
                 <Upload className="w-8 h-8" />
               </div>
 

--- a/src/components/mobile-studio/VideoUploadStep1.jsx
+++ b/src/components/mobile-studio/VideoUploadStep1.jsx
@@ -101,7 +101,12 @@ function VideoUploadStep1() {
       <div className="content">
         <div className="file-upload">
           <div className="content">
-            <div className="icon">
+            <div 
+              className="icon" 
+              onClick={() => videoInputRef.current?.click()}
+              style={{ cursor: 'pointer' }}
+              title="Click to select a video file"
+            >
               <Upload className="w-8 h-8" />
             </div>
             


### PR DESCRIPTION
- Make upload icon clickable to trigger file picker (mobile & legacy studio)
- Add 'Edit Post' button on preview page to go back and fix mistakes
- Style edit button as outline variant to differentiate from primary action