### PR TITLE
fix: Remove hardcoded fake view count from video cards

### DIFF
--- a/src/components/Cards/Card2.jsx
+++ b/src/components/Cards/Card2.jsx
@@ -111,10 +111,7 @@ function Card2({
               {video?.author?.profile?.images?.avatar ? <img className="profile-img" src={video?.author?.profile?.images?.avatar} alt="" /> : <FaCircleUser size={16} />}
               <h2>{video.author.username}</h2>
               </div>
-              <div className="view-wrap">
-              <FaCirclePlay className="icon" />
-              <p>112 views</p>
-              </div>
+              {/* TODO: Add real view count - needs GraphQL schema update to expose views from MongoDB */}
               </div>
               {/* <h3>Vibes</h3> */}
               <div className="bottom-action">


### PR DESCRIPTION
- Removed embarrassing '112 views' placeholder
- Added TODO comment for proper fix (needs GraphQL schema update to expose views from MongoDB)