### PR TITLE
feat: add real video view counts via middleware API

### DIFF
--- a/src/components/Cards/Card3.jsx
+++ b/src/components/Cards/Card3.jsx
@@ -1,4 +1,5 @@
 import { IoChevronUpCircleOutline } from "react-icons/io5";
+import { IoEyeOutline } from "react-icons/io5";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { Link, useNavigate } from "react-router-dom";
@@ -14,6 +15,7 @@ import { estimate, getVotePower } from "../../utils/hiveUtils";
 import LazyPayout from "../../page/LazyPayout";
 import { fixVideoThumbnail } from "../../utils/fixThumbnails";
 import ProfileModal from "../modal/ProfileModal";
+import useViewCounts from "../../hooks/useViewCounts";
 
 dayjs.extend(relativeTime);
 
@@ -27,12 +29,20 @@ function Card3({ videos = [], loading = false, error = null }) {
   const [hoverTimeout, setHoverTimeout] = useState(null);
   const [hoverPos, setHoverPos] = useState({ x: 0, y: 0 });
   const [modalUser, setModalUser] = useState(null);
+  const { getViewCount } = useViewCounts(videos);
 
   const [selectedPost, setSelectedPost] = useState({
     username: "",
     permlink: "",
   });
   const [voteStatus, setVoteStatus] = useState({})
+
+  const formatViewCount = (views) => {
+    if (views === null || views === undefined) return null;
+    if (views >= 1000000) return `${(views / 1000000).toFixed(1)}M`;
+    if (views >= 1000) return `${(views / 1000).toFixed(1)}K`;
+    return views.toLocaleString();
+  };
 
   useEffect(() => {
     const fetchAccountData = async () => {
@@ -141,6 +151,12 @@ function Card3({ videos = [], loading = false, error = null }) {
                 </h2>
 
               </div>
+              {getViewCount(video.author?.username || video.author || video.owner, video.permlink) !== null && (
+                <div className="view-count">
+                  <IoEyeOutline size={14} />
+                  <span>{formatViewCount(getViewCount(video.author?.username || video.author || video.owner, video.permlink))}</span>
+                </div>
+              )}
             </div>
 
             {/* Bottom actions */}

--- a/src/components/Cards/Cards.scss
+++ b/src/components/Cards/Cards.scss
@@ -114,6 +114,18 @@
         }
 
       }
+
+      .view-count {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        color: var(--text-secondary);
+        font-size: 12px;
+        
+        span {
+          font-size: 11px;
+        }
+      }
   
     }
     

--- a/src/hooks/useViewCounts.js
+++ b/src/hooks/useViewCounts.js
@@ -1,0 +1,87 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import axios from 'axios';
+import { API_URL_FROM_WEST } from '../utils/config';
+
+const BATCH_SIZE = 50;
+
+/**
+ * Hook for fetching video view counts in batches
+ * @param {Array} videos - Array of video objects with author.username and permlink
+ * @returns {Object} - { viewCounts, loading, getViewCount }
+ */
+const useViewCounts = (videos) => {
+  const [viewCounts, setViewCounts] = useState({});
+  const [loading, setLoading] = useState(false);
+  const fetchedRef = useRef(new Set());
+
+  useEffect(() => {
+    if (!videos?.length) return;
+
+    // Extract author from various possible structures
+    const getAuthor = (v) => {
+      return v.author?.username || v.author || v.owner || null;
+    };
+
+    // Filter videos that haven't been fetched yet and have valid data
+    const toFetch = videos.filter((v) => {
+      const author = getAuthor(v);
+      const permlink = v.permlink;
+      if (!author || !permlink) return false;
+      const key = `${author}/${permlink}`;
+      return !fetchedRef.current.has(key);
+    });
+
+    if (toFetch.length === 0) return;
+
+    // Split into batches of BATCH_SIZE
+    const batches = [];
+    for (let i = 0; i < toFetch.length; i += BATCH_SIZE) {
+      batches.push(toFetch.slice(i, i + BATCH_SIZE));
+    }
+
+    const fetchViews = async () => {
+      setLoading(true);
+      
+      for (const batch of batches) {
+        try {
+          const videosPayload = batch.map((v) => ({
+            author: getAuthor(v),
+            permlink: v.permlink,
+          }));
+
+          const response = await axios.post(
+            `${API_URL_FROM_WEST}/views`,
+            { videos: videosPayload },
+            { timeout: 15000 }
+          );
+
+          if (response.data.success) {
+            setViewCounts((prev) => ({ ...prev, ...response.data.data }));
+            // Mark as fetched
+            batch.forEach((v) => {
+              const author = getAuthor(v);
+              fetchedRef.current.add(`${author}/${v.permlink}`);
+            });
+          }
+        } catch (err) {
+          console.error('Failed to fetch view counts:', err.response?.data || err.message);
+        }
+      }
+      
+      setLoading(false);
+    };
+
+    fetchViews();
+  }, [videos]);
+
+  const getViewCount = useCallback(
+    (author, permlink) => {
+      return viewCounts[`${author}/${permlink}`] ?? null;
+    },
+    [viewCounts]
+  );
+
+  return { viewCounts, loading, getViewCount };
+};
+
+export default useViewCounts;


### PR DESCRIPTION
- Add useViewCounts hook for batch fetching view counts
- Integrate view counts into Card2 and Card3 components
- Batch requests in chunks of 50 to respect API limits
- Add view count styling in Cards.scss
- Uses compatibility API at /views endpoint