### PR TITLE
fix: use HTTPS views API to fix mixed content error

### DIFF
--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,5 +1,5 @@
 
-const API_URL_FROM_WEST = import.meta.env.VITE_API_URL_FROM_WEST; 
+const API_URL_FROM_WEST = import.meta.env.VITE_API_URL_FROM_WEST || 'https://views.3speak.tv'; 
 const GRAPHQL_API_URL = import.meta.env.VITE_GRAPHQL_API_URL; 
 const VIDEO_CDN_DOMAIN = import.meta.env.VITE_APP_VIDEO_CDN_DOMAIN; 
 const HIVE_HOST_API = "https://api.hive.blog/"; // Constant, no need for env variable


### PR DESCRIPTION
Change fallback URL from fly.dev to views.3speak.tv for proper HTTPS support on production