### PR TITLE
fix: add optional chaining for socialPost.spkvideo to prevent crash w…

### DIFF
--- a/src/components/playVideo/PlayVideo.jsx
+++ b/src/components/playVideo/PlayVideo.jsx
@@ -223,7 +223,7 @@ const calculateVoteValue = async (account, percent) => {
     data: getVideo,
     loading,
   } = useQuery(GET_VIDEO, { variables: { author, permlink }, ssr: true });
-  const spkvideo = getVideo?.socialPost.spkvideo;
+  const spkvideo = getVideo?.socialPost?.spkvideo;
   console.log("hive ---- data" , spkvideo)
   const [videoUrlSelected, setVideoUrlSelected] = useState(null);
 


### PR DESCRIPTION
This fixes the issues with updated CIDs not playing on the new.3speak.tv app. 

Forces an update be made by the backend (union indexer) 