### PR TITLE
feat: Resilient polling with retry tolerance

### DIFF
--- a/src/components/legacy-studio/VideoUploadStatus.jsx
+++ b/src/components/legacy-studio/VideoUploadStatus.jsx
@@ -76,6 +76,15 @@ const canLeavePage = statusMessages.some(msg =>
   ].includes(msg.message)
 );
 
+  // Check if finalize succeeded - if so, don't show retry button even if there are polling errors
+  const hasFinalizeSuccess = statusMessages.some(msg => 
+    msg.message.includes("Upload finalized successfully") || 
+    msg.message.includes("finalized successfully")
+  );
+  
+  // Only show retry if there's an error AND finalize hasn't succeeded yet
+  const shouldShowRetry = hasError && !hasFinalizeSuccess;
+
   return (
     <div className="upload-status-container">
       {statusMessages.some(msg => msg.type === "error") && (
@@ -122,7 +131,7 @@ const canLeavePage = statusMessages.some(msg =>
         </div>
       </div>
 
-      {statusMessages.some(msg => msg.type === "error") && (
+      {shouldShowRetry && (
         <div className="retry-btn-wrapper">
           <button onClick={uploadVideoTo3Speak} className="retry-btn">
             Retry Upload
@@ -167,12 +176,15 @@ const canLeavePage = statusMessages.some(msg =>
               msg.message.includes("🎉") ||
               msg.type === "success";
             
+            const isWarning = msg.type === "warning" || msg.message.includes("⚠️");
             const isEncoding = msg.message.includes("⚙️ Encoding");
             
             const itemClass = isSuccess 
               ? "success" 
               : msg.type === "error" 
               ? "error" 
+              : isWarning
+              ? "warning"
               : "info";
 
             return (

--- a/src/components/legacy-studio/VideoUploadStatus.scss
+++ b/src/components/legacy-studio/VideoUploadStatus.scss
@@ -353,6 +353,22 @@
           }
         }
 
+        &.warning {
+          border-left-color: #f59e0b;
+
+          .activity-icon {
+            color: #f59e0b;
+          }
+        }
+
+        &.error {
+          border-left-color: #ef4444;
+
+          .activity-icon {
+            color: #ef4444;
+          }
+        }
+
         .activity-icon {
           flex-shrink: 0;
         }


### PR DESCRIPTION
Polling improvements:
- Add retry tolerance: only show error after 3 consecutive failures
- Add 10s timeout to status requests
- Clear error messages when connection recovers
- Show 'Connection restored' message on recovery
- Use 'warning' type instead of 'error' for transient issues

UI improvements:
- Hide 'Retry Upload' button if finalize already succeeded
- Polling errors after finalize don't trigger retry button
- Add warning style (orange) for activity log items
- Add error style (red) for activity log items

This fixes the confusing UX where users saw 'Polling error' and 'Retry Upload' even though their video was successfully uploaded and encoding. Mobile network blips no longer cause panic.