### PR TITLE
feat: integrate new reliable my-videos API endpoint

### DIFF
--- a/src/components/Cards/Card3.jsx
+++ b/src/components/Cards/Card3.jsx
@@ -1,6 +1,8 @@
 import { IoChevronUpCircleOutline } from "react-icons/io5";
 import { IoEyeOutline } from "react-icons/io5";
 import { IoCalendarOutline } from "react-icons/io5";
+import { MdDelete, MdError, MdPhoneIphone } from "react-icons/md";
+import { FaCog, FaFileAlt } from "react-icons/fa";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { Link, useNavigate } from "react-router-dom";
@@ -116,10 +118,47 @@ function Card3({ videos = [], loading = false, error = null }) {
                     .padStart(2, "0")}
                 </span>
               </div>
-              {/* Scheduled Post Badge - only show while status is 'scheduled' */}
-              {video.publish_type === 'schedule' && video.status === 'scheduled' && (
-                <div className="scheduled-badge" title={`Scheduled for ${dayjs(video.publish_data?.scheduled_at).format('MMM D, YYYY h:mm A')}`}>
+
+              {/* Status Badges */}
+              {video.status === 'scheduled' && video.publish_type === 'schedule' && (
+                <div className="status-badge scheduled" title={`Scheduled for ${dayjs(video.publish_data?.scheduled_at).format('MMM D, YYYY h:mm A')}`}>
                   <IoCalendarOutline size={18} />
+                  <span>Scheduled</span>
+                </div>
+              )}
+
+              {video.publish_type === 'publish_manual' && (
+                <div className="status-badge manual" title="Uploaded via mobile app">
+                  <MdPhoneIphone size={18} />
+                  <span>Mobile</span>
+                </div>
+              )}
+
+              {video.status === 'encoding' && (
+                <div className="status-badge encoding" title="Video is being processed">
+                  <FaCog size={16} className="spin-icon" />
+                  <span>Processing</span>
+                </div>
+              )}
+
+              {video.status === 'draft' && (
+                <div className="status-badge draft" title="Draft - not published yet">
+                  <FaFileAlt size={16} />
+                  <span>Draft</span>
+                </div>
+              )}
+
+              {video.status === 'deleted' && (
+                <div className="status-badge deleted" title="This video has been deleted">
+                  <MdDelete size={18} />
+                  <span>Deleted</span>
+                </div>
+              )}
+
+              {video.status === 'failed' && (
+                <div className="status-badge failed" title="Video processing failed">
+                  <MdError size={18} />
+                  <span>Failed</span>
                 </div>
               )}
             </div>

--- a/src/components/Cards/Cards.scss
+++ b/src/components/Cards/Cards.scss
@@ -89,6 +89,106 @@
           font-size: 11px;
         }
       }
+
+      // Status badges for different video states
+      .status-badge {
+        position: absolute;
+        top: 8px;
+        right: 8px;
+        backdrop-filter: blur(8px);
+        color: #fff;
+        padding: 6px 10px;
+        border-radius: 6px;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 12px;
+        font-weight: 600;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+        z-index: 2;
+
+        &:hover {
+          transform: translateY(-2px);
+        }
+
+        &.scheduled {
+          background: linear-gradient(135deg, rgba(255, 193, 7, 0.95), rgba(255, 152, 0, 0.95));
+          box-shadow: 0 2px 8px rgba(255, 152, 0, 0.4);
+          
+          &:hover {
+            box-shadow: 0 4px 12px rgba(255, 152, 0, 0.6);
+          }
+        }
+
+        &.manual {
+          background: linear-gradient(135deg, rgba(156, 39, 176, 0.95), rgba(123, 31, 162, 0.95));
+          box-shadow: 0 2px 8px rgba(156, 39, 176, 0.4);
+          
+          &:hover {
+            box-shadow: 0 4px 12px rgba(156, 39, 176, 0.6);
+          }
+        }
+
+        &.encoding {
+          background: linear-gradient(135deg, rgba(33, 150, 243, 0.95), rgba(3, 169, 244, 0.95));
+          box-shadow: 0 2px 8px rgba(33, 150, 243, 0.4);
+          
+          &:hover {
+            box-shadow: 0 4px 12px rgba(33, 150, 243, 0.6);
+          }
+
+          .spin-icon {
+            animation: spin 2s linear infinite;
+          }
+        }
+
+        &.draft {
+          background: linear-gradient(135deg, rgba(158, 158, 158, 0.95), rgba(117, 117, 117, 0.95));
+          box-shadow: 0 2px 8px rgba(117, 117, 117, 0.4);
+          
+          &:hover {
+            box-shadow: 0 4px 12px rgba(117, 117, 117, 0.6);
+          }
+        }
+
+        &.deleted {
+          background: linear-gradient(135deg, rgba(244, 67, 54, 0.95), rgba(211, 47, 47, 0.95));
+          box-shadow: 0 2px 8px rgba(244, 67, 54, 0.4);
+          
+          &:hover {
+            box-shadow: 0 4px 12px rgba(244, 67, 54, 0.6);
+          }
+        }
+
+        &.failed {
+          background: linear-gradient(135deg, rgba(255, 87, 34, 0.95), rgba(230, 74, 25, 0.95));
+          box-shadow: 0 2px 8px rgba(255, 87, 34, 0.4);
+          
+          &:hover {
+            box-shadow: 0 4px 12px rgba(255, 87, 34, 0.6);
+          }
+        }
+
+        @include respond(phone) {
+          padding: 5px 8px;
+          font-size: 11px;
+          gap: 4px;
+
+          span {
+            display: none; // Hide text on mobile, show only icon
+          }
+        }
+      }
+
+      @keyframes spin {
+        from {
+          transform: rotate(0deg);
+        }
+        to {
+          transform: rotate(360deg);
+        }
+      }
     }
     h2{
       padding: 0px 4px;

--- a/src/utils/fixThumbnails.js
+++ b/src/utils/fixThumbnails.js
@@ -24,18 +24,31 @@ const APP_IMAGE_CDN_DOMAIN = "https://media.3speak.tv";
 // }
 
 export function fixVideoThumbnail(video) {
-  let thumbUrl = "";
-
   const thumbnail = video?.images?.thumbnail || video?.thumbUrl || video?.spkvideo?.thumbnail_url;
 
   // 🚧 If no thumbnail, return a fallback image
   if (!thumbnail) {
     return "https://media.3speak.tv/defaults/default_thumbnail.png";
   }
-  // 🧠 Convert old thumbnail to Hive image proxy
-    const encoded = bs58.encode(Buffer.from(thumbnail));
-    thumbUrl = `https://images.hive.blog/p/${encoded}?format=jpeg&mode=cover&width=340&height=191`;
 
-  // console.log(thumbUrl)
-  return thumbUrl;
+  // 🧠 Handle IPFS URLs
+  if (thumbnail.includes("ipfs://")) {
+    const ipfsHash = thumbnail.replace("ipfs://", "");
+    return `${APP_BUNNY_IPFS_CDN}/ipfs/${ipfsHash}`;
+  }
+
+  // 🧠 Handle media.3speak.tv URLs with Hive proxy
+  if (thumbnail.includes(APP_IMAGE_CDN_DOMAIN)) {
+    const encoded = bs58.encode(Buffer.from(thumbnail));
+    return `https://images.hive.blog/p/${encoded}?format=jpeg&mode=cover&width=340&height=191`;
+  }
+
+  // 🧠 Handle regular HTTP URLs with Hive proxy
+  if (thumbnail.startsWith("http")) {
+    const encoded = bs58.encode(Buffer.from(thumbnail));
+    return `https://images.hive.blog/p/${encoded}?format=jpeg&mode=cover&width=340&height=191`;
+  }
+
+  // Return as-is for any other format
+  return thumbnail;
 }


### PR DESCRIPTION
- Replace unstable studio.3speak.tv/mobile/api/my-videos with views.3speak.tv/api/my-videos
- Implement server-side pagination with limit/offset parameters
- Add username query parameter for user-specific video fetching
- Fix IPFS thumbnail handling for proper CDN URL generation
- Add comprehensive status badges for videos:
  * Scheduled posts (calendar icon, orange)
  * Mobile uploads (phone icon, purple)
  * Encoding/processing (spinning cog, blue)
  * Drafts (file icon, gray)
  * Deleted (trash icon, red)
  * Failed (error icon, orange-red)
- Filter out 'uploaded' status videos from display
- Sort videos by newest first
- Improve infinite scroll pagination logic
- Mobile-responsive badges (icon-only on small screens)