### PR TITLE
Reactions Module, Shorts player overhaul, vote popup redesign, user shorts feed, and UI polish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,3 +123,7 @@ VITE_HIVE_API_URL=
 # Shorts sorted API endpoint
 # Default: https://3speak-checker.okinoko.io/shortssorted
 VITE_SHORTS_API_URL=
+
+# User shorts API endpoint (for per-user shorts feed)
+# Default: https://3speak-checker.okinoko.io/shorts
+VITE_USER_SHORTS_API_URL=

--- a/.env.example
+++ b/.env.example
@@ -115,3 +115,11 @@ VITE_PLAYLISTS_API_URL=
 # Hive RPC API endpoint (primary node)
 # Default: https://techcoderx.com
 VITE_HIVE_API_URL=
+
+# ===========================================
+# Shorts API Configuration
+# ===========================================
+
+# Shorts sorted API endpoint
+# Default: https://3speak-checker.okinoko.io/shortssorted
+VITE_SHORTS_API_URL=

--- a/.env.example
+++ b/.env.example
@@ -121,9 +121,9 @@ VITE_HIVE_API_URL=
 # ===========================================
 
 # Shorts sorted API endpoint
-# Default: https://3speak-checker.okinoko.io/shortssorted
+# Default: https://tags.3speak.tv/shortssorted
 VITE_SHORTS_API_URL=
 
 # User shorts API endpoint (for per-user shorts feed)
-# Default: https://3speak-checker.okinoko.io/shorts
+# Default: https://tags.3speak.tv/shorts
 VITE_USER_SHORTS_API_URL=

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,6 +43,7 @@ import Details from "./components/legacy-studio/Details";
 import Preview from "./components/legacy-studio/Preview";
 import Test from "./page/Test";
 import Short from "./page/Short";
+import ShortsPreloader from "./components/ShortsPreloader";
 // import Email from "./page/Login/Email"
 // import AuthCallback from "./page/Login/AuthCallback";
 // import {AUTH_JWT_SECRET} from "../src/utils/config";
@@ -221,6 +222,7 @@ function App() {
     <LegacyUploadProvider>
     <div onClick={()=> {setGlobalCloseRender(true)}}>
       <Toaster richColors position="top-right" />
+      <ShortsPreloader />
       <Nav setSideBar={setSideBar} toggleProfileNav={toggleProfileNav} globalClose={globalCloseRender} setGlobalClose={setGlobalCloseRender} openLoginModal={openLoginModal} />
       <div>
         <Sidebar sidebar={sidebar} />

--- a/src/components/AuthorBadge/AuthorBadge.jsx
+++ b/src/components/AuthorBadge/AuthorBadge.jsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { getFollowers } from '../../hive-api/api';
 import './AuthorBadge.scss';
 
-function AuthorBadge({ author, onClick, followersCount, fetchFollowers, showFollow, isFollowing, onFollow, noLink, compact }) {
+function AuthorBadge({ author, onClick, followersCount, fetchFollowers, showFollow, isFollowing, onFollow, noLink, compact, reputation }) {
   const navigate = useNavigate();
   const [localFollowers, setLocalFollowers] = useState(null);
 
@@ -42,7 +42,7 @@ function AuthorBadge({ author, onClick, followersCount, fetchFollowers, showFoll
     <>
       <img src={`https://images.hive.blog/u/${author}/avatar/small`} alt="" />
       <div className="author-text">
-        <span className="author-name">@{author}</span>
+        <span className="author-name">@{author}{reputation != null ? ` (${Math.round(reputation)})` : ''}</span>
         {displayFollowers != null && (
           <span className="followers-count">{displayFollowers} Followers</span>
         )}

--- a/src/components/AuthorBadge/AuthorBadge.scss
+++ b/src/components/AuthorBadge/AuthorBadge.scss
@@ -4,7 +4,12 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 3px 6px 3px 3px;
+  padding: 1px 1px 1px 1px;
+
+  &:not(:has(.follow-btn)) {
+    padding-right: 4px;
+  }
+
   background: var(--bg-tertiary);
   border: 1px solid var(--border-light);
   border-radius: 20px;
@@ -40,8 +45,8 @@
   }
 
   img {
-    width: 26px;
-    height: 26px;
+    width: 30px;
+    height: 30px;
     border-radius: 50%;
     object-fit: cover;
     flex-shrink: 0;
@@ -76,7 +81,8 @@
 
   .follow-btn {
     margin-left: 4px;
-    padding: 4px 14px;
+    padding: 0 14px;
+    align-self: stretch;
     background: var(--text-secondary);
     color: var(--text-inverse);
     border: none;

--- a/src/components/Cards/Card3.jsx
+++ b/src/components/Cards/Card3.jsx
@@ -186,7 +186,7 @@ function Card3({ videos = [], loading = false, error = null, getContentForVideo 
                   })()}
                 />
               </div>
-              <p><TimeAgo date={video.created_at || video.created} /></p>
+              <p><TimeAgo date={video.created_at || video.created} short /></p>
             </div>
           </Link>
         );

--- a/src/components/Cards/Card3.jsx
+++ b/src/components/Cards/Card3.jsx
@@ -17,7 +17,7 @@ import ProfileModal from "../modal/ProfileModal";
 import useViewCounts from "../../hooks/useViewCounts";
 
 
-function Card3({ videos = [], loading = false, error = null, getContentForVideo = null, isWatched = null }) {
+function Card3({ videos = [], loading = false, error = null, getContentForVideo = null, isWatched = null, linkPrefix = '/watch', linkQuery = '' }) {
   const navigate = useNavigate();
   const [modalUser, setModalUser] = useState(null);
   const { getViewCount } = useViewCounts(videos);
@@ -50,9 +50,9 @@ function Card3({ videos = [], loading = false, error = null, getContentForVideo 
 
         return (
           <Link
-            to={`/watch?v=${video.author?.username || video.author || video.owner}/${
+            to={`${linkPrefix}?v=${video.author?.username || video.author || video.owner}/${
               video.permlink
-            }`}
+            }${linkQuery}`}
             className="card"
             // key={postKey}
             key={`${postKey}-${index}`}
@@ -207,6 +207,7 @@ Card3.propTypes = {
   error: PropTypes.string,
   getContentForVideo: PropTypes.func,
   isWatched: PropTypes.func,
+  linkPrefix: PropTypes.string,
 };
 
 export default Card3;

--- a/src/components/PayoutAmount/PayoutAmount.jsx
+++ b/src/components/PayoutAmount/PayoutAmount.jsx
@@ -1,4 +1,4 @@
-import { IoChevronUpCircleOutline } from 'react-icons/io5';
+import { FaHive } from 'react-icons/fa6';
 import './PayoutAmount.scss';
 
 function PayoutAmount({ amount, size, onClick }) {
@@ -7,7 +7,7 @@ function PayoutAmount({ amount, size, onClick }) {
 
   return (
     <div className={`payout-amount-badge${onClick ? ' clickable' : ''}`} style={size ? { fontSize: size } : undefined} onClick={onClick}>
-      <IoChevronUpCircleOutline size={iconSize || undefined} />
+      <FaHive size={iconSize || undefined} />
       <span>${display}</span>
     </div>
   );

--- a/src/components/ReactVideoModal/ReactVideoModal.jsx
+++ b/src/components/ReactVideoModal/ReactVideoModal.jsx
@@ -1,0 +1,400 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { MdUploadFile, MdVideocam, MdStop, MdFiberManualRecord } from 'react-icons/md';
+import * as tus from 'tus-js-client';
+import { toast } from 'sonner';
+import { EMBED_UPLOAD_URL, EMBED_API_KEY } from '../../utils/config';
+import { commentWithAioha } from '../../hive-api/aioha';
+import { useAppStore } from '../../lib/store';
+import './ReactVideoModal.scss';
+
+/**
+ * Inline "React" tab panel — sits inside the comment input container.
+ * Lets users pick a file or record from webcam, add a description,
+ * then uploads via TUS and publishes as a comment under the parent post.
+ */
+function ReactVideoTab({ author, permlink, currentTime, formatTime, onPosted }) {
+  const { user } = useAppStore();
+
+  // Source selection
+  const [source, setSource] = useState(null); // 'upload' | 'record' | null
+  const [videoFile, setVideoFile] = useState(null);
+  const [videoPreviewUrl, setVideoPreviewUrl] = useState(null);
+  const [videoDuration, setVideoDuration] = useState(0);
+
+  // Webcam / recording
+  const [stream, setStream] = useState(null);
+  const [recording, setRecording] = useState(false);
+  const [recordedBlob, setRecordedBlob] = useState(null);
+  const [recordedUrl, setRecordedUrl] = useState(null);
+
+  // Description & options
+  const [description, setDescription] = useState('');
+  const [isShort, setIsShort] = useState(true);
+
+  // Upload state
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const [uploading, setUploading] = useState(false);
+  const [statusText, setStatusText] = useState('');
+
+  const fileInputRef = useRef(null);
+  const recorderRef = useRef(null);
+  const chunksRef = useRef([]);
+  const webcamRef = useRef(null);
+  const tusUploadRef = useRef(null);
+
+  // -- Cleanup helpers --
+  const stopStream = useCallback(() => {
+    if (stream) {
+      stream.getTracks().forEach(t => t.stop());
+      setStream(null);
+    }
+  }, [stream]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      if (stream) stream.getTracks().forEach(t => t.stop());
+    };
+  }, []);
+
+  // Attach stream to webcam video element
+  useEffect(() => {
+    if (webcamRef.current && stream) {
+      webcamRef.current.srcObject = stream;
+    }
+  }, [stream]);
+
+  // Calculate video duration from file
+  const calcDuration = useCallback((file) => {
+    return new Promise((resolve) => {
+      const video = document.createElement('video');
+      video.preload = 'metadata';
+      video.onloadedmetadata = () => {
+        URL.revokeObjectURL(video.src);
+        resolve(video.duration);
+      };
+      video.onerror = () => resolve(0);
+      video.src = URL.createObjectURL(file);
+    });
+  }, []);
+
+  // -- Upload card click --
+  const handleUploadClick = useCallback(() => {
+    stopStream();
+    setRecordedBlob(null);
+    if (recordedUrl) { URL.revokeObjectURL(recordedUrl); setRecordedUrl(null); }
+    setRecording(false);
+    setSource('upload');
+    setTimeout(() => fileInputRef.current?.click(), 0);
+  }, [stopStream, recordedUrl]);
+
+  const handleFileChange = useCallback(async (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setVideoFile(file);
+    if (videoPreviewUrl) URL.revokeObjectURL(videoPreviewUrl);
+    setVideoPreviewUrl(URL.createObjectURL(file));
+    const dur = await calcDuration(file);
+    setVideoDuration(dur);
+    if (dur > 60) {
+      setIsShort(false);
+    } else {
+      setIsShort(true);
+    }
+  }, [videoPreviewUrl, calcDuration]);
+
+  // -- Record card click --
+  const handleRecordClick = useCallback(async () => {
+    setVideoFile(null);
+    if (videoPreviewUrl) { URL.revokeObjectURL(videoPreviewUrl); setVideoPreviewUrl(null); }
+    setRecordedBlob(null);
+    if (recordedUrl) { URL.revokeObjectURL(recordedUrl); setRecordedUrl(null); }
+    setSource('record');
+    try {
+      const mediaStream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+      setStream(mediaStream);
+    } catch (err) {
+      console.error('Webcam access denied:', err);
+      toast.error('Could not access webcam');
+      setSource(null);
+    }
+  }, [videoPreviewUrl, recordedUrl]);
+
+  const startRecording = useCallback(() => {
+    if (!stream) return;
+    chunksRef.current = [];
+    const mimeType = MediaRecorder.isTypeSupported('video/webm;codecs=vp9,opus')
+      ? 'video/webm;codecs=vp9,opus'
+      : MediaRecorder.isTypeSupported('video/webm')
+        ? 'video/webm'
+        : '';
+    const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
+    recorder.ondataavailable = (e) => {
+      if (e.data.size > 0) chunksRef.current.push(e.data);
+    };
+    recorder.onstop = async () => {
+      const blob = new Blob(chunksRef.current, { type: mimeType || 'video/webm' });
+      setRecordedBlob(blob);
+      setRecordedUrl(URL.createObjectURL(blob));
+      // Convert blob to File for TUS upload
+      const file = new File([blob], `reaction-${Date.now()}.webm`, { type: blob.type });
+      setVideoFile(file);
+      const dur = await calcDuration(file);
+      setVideoDuration(dur);
+      setIsShort(dur <= 60);
+      // Stop webcam
+      stream.getTracks().forEach(t => t.stop());
+      setStream(null);
+    };
+    recorderRef.current = recorder;
+    recorder.start();
+    setRecording(true);
+  }, [stream, calcDuration]);
+
+  const stopRecording = useCallback(() => {
+    if (recorderRef.current && recorderRef.current.state !== 'inactive') {
+      recorderRef.current.stop();
+    }
+    setRecording(false);
+  }, []);
+
+  // -- TUS Upload to embed.3speak.tv + Hive comment --
+  const handleSubmit = useCallback(async () => {
+    const file = videoFile;
+    if (!file || !user) return;
+
+    if (isShort && videoDuration > 60) {
+      toast.error('Shorts must be 60 seconds or less. Uncheck "Show in 3Speak Shorts" or use a shorter video.');
+      return;
+    }
+
+    setUploading(true);
+    setStatusText('Uploading video...');
+    setUploadProgress(0);
+
+    try {
+      // 1. Upload video via TUS to embed.3speak.tv
+      //    The X-Embed-URL response header gives us the embed URL
+      let embedUrl = '';
+
+      await new Promise((resolve, reject) => {
+        const upload = new tus.Upload(file, {
+          endpoint: EMBED_UPLOAD_URL,
+          chunkSize: 5 * 1024 * 1024, // 5 MB
+          retryDelays: [0, 2000, 5000, 10000],
+          headers: {
+            ...(EMBED_API_KEY ? { 'X-API-Key': EMBED_API_KEY } : {}),
+          },
+          metadata: {
+            filename: file.name,
+            filetype: file.type,
+            frontend_app: '3speak-tv',
+            owner: user,
+            short: isShort ? 'true' : 'false',
+            duration: String(Math.round(videoDuration)),
+          },
+          onError: (err) => {
+            console.error('TUS upload error:', err);
+            reject(err);
+          },
+          onProgress: (bytesUploaded, bytesTotal) => {
+            setUploadProgress(Math.round((bytesUploaded / bytesTotal) * 100));
+          },
+          onSuccess: () => {
+            // Try to get embed URL from the upload URL
+            // The upload.url is the TUS resource URL; the embed URL
+            // may come from X-Embed-URL header captured during upload
+            resolve();
+          },
+          onAfterResponse: (req, res) => {
+            // Capture X-Embed-URL from any TUS response
+            const header = res.getHeader('X-Embed-URL') || res.getHeader('x-embed-url');
+            if (header) embedUrl = header;
+          },
+        });
+        tusUploadRef.current = upload;
+        upload.start();
+      });
+
+      // If no embed URL from header, construct one from the upload URL
+      if (!embedUrl && tusUploadRef.current?.url) {
+        const uploadUrl = tusUploadRef.current.url;
+        const assetId = uploadUrl.split('/').pop();
+        // Fallback: the embed URL pattern may be like play.3speak.tv/embed?v=user/assetId
+        embedUrl = uploadUrl;
+        console.log('No X-Embed-URL header, using upload URL as reference:', assetId);
+      }
+
+      if (!embedUrl) {
+        throw new Error('Upload succeeded but no embed URL was returned');
+      }
+
+      setStatusText('Publishing comment...');
+
+      // 2. Post Hive comment with video embed URL
+      const timestampSec = currentTime ? Math.round(currentTime) : 0;
+      const commentText = description.trim() || 'Video reaction';
+      // Body: description text + embed URL on its own line
+      const commentBody = `${commentText}\n${embedUrl}`;
+      const newPermlink = `re-${permlink}-${Date.now()}`;
+
+      const metadata = {
+        app: '3speak/new-version',
+        format: 'markdown',
+        tags: ['3speak', 'reaction'],
+        ...(timestampSec > 0 ? { parentTimestamp: timestampSec } : {}),
+        video: {
+          platform: '3speak',
+          url: embedUrl,
+        },
+      };
+
+      const result = await commentWithAioha(
+        author,
+        permlink,
+        newPermlink,
+        '',
+        commentBody,
+        metadata
+      );
+
+      if (result.success) {
+        toast.success('Video reaction posted!');
+        setStatusText('Done!');
+        if (onPosted) onPosted();
+        // Reset
+        setVideoFile(null);
+        setDescription('');
+        setSource(null);
+        setUploadProgress(0);
+        if (videoPreviewUrl) URL.revokeObjectURL(videoPreviewUrl);
+        if (recordedUrl) URL.revokeObjectURL(recordedUrl);
+        setVideoPreviewUrl(null);
+        setRecordedUrl(null);
+        setRecordedBlob(null);
+      } else {
+        throw new Error('Failed to post comment');
+      }
+    } catch (err) {
+      console.error('React upload failed:', err);
+      toast.error(err.message || 'Upload failed');
+      setStatusText('');
+    } finally {
+      setUploading(false);
+    }
+  }, [videoFile, user, videoDuration, currentTime, description, isShort, author, permlink, onPosted, videoPreviewUrl, recordedUrl]);
+
+  const hasVideo = !!(videoFile || recordedBlob);
+  const canSubmit = hasVideo && !uploading;
+
+  return (
+    <div className="react-video-tab">
+      {/* Source selection cards */}
+      <div className="rvt-source-cards">
+        <button
+          className={`rvt-source-card${source === 'upload' ? ' active' : ''}`}
+          onClick={handleUploadClick}
+          disabled={uploading}
+        >
+          <MdUploadFile size={24} />
+          <span>Upload Video</span>
+        </button>
+        <button
+          className={`rvt-source-card${source === 'record' ? ' active' : ''}`}
+          onClick={handleRecordClick}
+          disabled={uploading}
+        >
+          <MdVideocam size={24} />
+          <span>Record Video</span>
+        </button>
+      </div>
+
+      {/* Hidden file input */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="video/*"
+        style={{ display: 'none' }}
+        onChange={handleFileChange}
+      />
+
+      {/* Preview area */}
+      {source === 'upload' && videoFile && videoPreviewUrl && (
+        <div className="rvt-preview">
+          <video src={videoPreviewUrl} controls muted className="rvt-video" />
+          <p className="rvt-filename">{videoFile.name}</p>
+        </div>
+      )}
+
+      {source === 'record' && stream && !recordedBlob && (
+        <div className="rvt-preview">
+          <video ref={webcamRef} autoPlay muted playsInline className="rvt-video" />
+          <div className="rvt-record-controls">
+            {!recording ? (
+              <button className="rvt-rec-btn rvt-rec-btn--start" onClick={startRecording}>
+                <MdFiberManualRecord size={16} />
+                Start Recording
+              </button>
+            ) : (
+              <button className="rvt-rec-btn rvt-rec-btn--stop" onClick={stopRecording}>
+                <MdStop size={16} />
+                Stop Recording
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {source === 'record' && recordedBlob && recordedUrl && (
+        <div className="rvt-preview">
+          <video src={recordedUrl} controls className="rvt-video" />
+          <p className="rvt-filename">Recorded video</p>
+        </div>
+      )}
+
+      {/* Description */}
+      {hasVideo && (
+        <textarea
+          className="rvt-description"
+          placeholder="Add a description for your video reaction..."
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          disabled={uploading}
+        />
+      )}
+
+      {/* Short toggle */}
+      {hasVideo && (
+        <label className="rvt-toggle">
+          <input
+            type="checkbox"
+            checked={isShort}
+            onChange={(e) => setIsShort(e.target.checked)}
+            disabled={uploading}
+          />
+          <span className="rvt-toggle-label">Show in 3Speak Shorts</span>
+        </label>
+      )}
+
+      {/* Upload progress */}
+      {uploading && (
+        <div className="rvt-progress">
+          <div className="rvt-progress-bar">
+            <div className="rvt-progress-fill" style={{ width: `${uploadProgress}%` }} />
+          </div>
+          <span className="rvt-progress-text">{statusText} {uploadProgress > 0 && uploadProgress < 100 ? `${uploadProgress}%` : ''}</span>
+        </div>
+      )}
+
+      {/* Submit */}
+      {hasVideo && (
+        <button className="rvt-submit" onClick={handleSubmit} disabled={!canSubmit}>
+          {uploading ? 'Uploading...' : 'Post Reaction'}
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default ReactVideoTab;

--- a/src/components/ReactVideoModal/ReactVideoModal.jsx
+++ b/src/components/ReactVideoModal/ReactVideoModal.jsx
@@ -12,7 +12,7 @@ import './ReactVideoModal.scss';
  * Lets users pick a file or record from webcam, add a description,
  * then uploads via TUS and publishes as a comment under the parent post.
  */
-function ReactVideoTab({ author, permlink, currentTime, formatTime, onPosted }) {
+function ReactVideoTab({ author, permlink, currentTime, formatTime, onPosted, onRecordStart }) {
   const { user } = useAppStore();
 
   // Source selection
@@ -150,7 +150,8 @@ function ReactVideoTab({ author, permlink, currentTime, formatTime, onPosted }) 
     recorderRef.current = recorder;
     recorder.start();
     setRecording(true);
-  }, [stream, calcDuration]);
+    onRecordStart?.();
+  }, [stream, calcDuration, onRecordStart]);
 
   const stopRecording = useCallback(() => {
     if (recorderRef.current && recorderRef.current.state !== 'inactive') {
@@ -236,7 +237,16 @@ function ReactVideoTab({ author, permlink, currentTime, formatTime, onPosted }) 
       const timestampSec = currentTime ? Math.round(currentTime) : 0;
       const commentText = description.trim() || 'Video reaction';
       // Body: description text + embed URL on its own line
-      const commentBody = `${commentText}\n${embedUrl}`;
+      let commentBody = `${commentText}\n${embedUrl}`;
+      // Append "replied to" timestamp reference
+      if (timestampSec > 0) {
+        const mins = Math.floor(timestampSec / 60);
+        const secs = Math.floor(timestampSec % 60);
+        const tsLabel = `${mins}:${secs.toString().padStart(2, '0')}`;
+        const baseUrl = window.location.origin;
+        const host = window.location.host;
+        commentBody += `\n<sup>replied to [${tsLabel}](${baseUrl}/watch?v=${author}/${permlink}&t=${timestampSec}) on [${host}](${baseUrl})</sup>`;
+      }
       const newPermlink = `re-${permlink}-${Date.now()}`;
 
       const metadata = {

--- a/src/components/ReactVideoModal/ReactVideoModal.scss
+++ b/src/components/ReactVideoModal/ReactVideoModal.scss
@@ -1,0 +1,194 @@
+.react-video-tab {
+  // Source selection cards
+  .rvt-source-cards {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 12px;
+  }
+
+  .rvt-source-card {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    padding: 14px 8px;
+    border: 2px solid var(--border-light, rgba(255, 255, 255, 0.1));
+    border-radius: 10px;
+    background: transparent;
+    color: var(--text-secondary, #aaa);
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 600;
+    font-family: inherit;
+    transition: all 0.2s ease;
+
+    &:hover:not(:disabled) {
+      border-color: var(--accent-primary, #e53935);
+      color: var(--accent-primary, #e53935);
+    }
+
+    &.active {
+      border-color: var(--accent-primary, #e53935);
+      color: var(--accent-primary, #e53935);
+      background: rgba(229, 57, 53, 0.08);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+
+  // Preview
+  .rvt-preview {
+    margin-bottom: 10px;
+  }
+
+  .rvt-video {
+    width: 100%;
+    border-radius: 8px;
+    background: #000;
+    max-height: 240px;
+    object-fit: contain;
+  }
+
+  .rvt-filename {
+    font-size: 11px;
+    color: var(--text-secondary, #888);
+    margin: 6px 0 0;
+    text-align: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  // Recording controls
+  .rvt-record-controls {
+    display: flex;
+    justify-content: center;
+    margin-top: 10px;
+  }
+
+  .rvt-rec-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 6px 14px;
+    border: none;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+    color: #fff;
+    transition: all 0.2s ease;
+
+    &--start {
+      background: var(--accent-primary, #e53935);
+      &:hover { opacity: 0.9; }
+    }
+
+    &--stop {
+      background: #555;
+      &:hover { background: #666; }
+    }
+  }
+
+  // Description textarea
+  .rvt-description {
+    width: 100%;
+    min-height: 60px;
+    padding: 8px 10px;
+    margin-bottom: 10px;
+    font-size: 13px;
+    font-family: inherit;
+    color: var(--text-primary);
+    background: var(--card-bg, #1a1a2e);
+    border: 1px solid var(--border-light, rgba(255, 255, 255, 0.1));
+    border-radius: 8px;
+    resize: vertical;
+    outline: none;
+    transition: border-color 0.15s ease;
+
+    &:focus {
+      border-color: var(--accent-primary, #e53935);
+    }
+
+    &:disabled {
+      opacity: 0.6;
+    }
+  }
+
+  // Short toggle
+  .rvt-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 10px;
+    cursor: pointer;
+
+    input[type="checkbox"] {
+      width: 16px;
+      height: 16px;
+      accent-color: var(--accent-primary, #e53935);
+      cursor: pointer;
+    }
+
+    .rvt-toggle-label {
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--text-secondary, #aaa);
+    }
+  }
+
+  // Progress bar
+  .rvt-progress {
+    margin-bottom: 10px;
+  }
+
+  .rvt-progress-bar {
+    width: 100%;
+    height: 6px;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 3px;
+    overflow: hidden;
+    margin-bottom: 4px;
+  }
+
+  .rvt-progress-fill {
+    height: 100%;
+    background: var(--accent-primary, #e53935);
+    border-radius: 3px;
+    transition: width 0.3s ease;
+  }
+
+  .rvt-progress-text {
+    font-size: 11px;
+    color: var(--text-secondary, #aaa);
+  }
+
+  // Submit button
+  .rvt-submit {
+    width: 100%;
+    padding: 8px;
+    border: none;
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 700;
+    font-family: inherit;
+    color: #fff;
+    background: var(--accent-primary, #e53935);
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover:not(:disabled) {
+      opacity: 0.9;
+    }
+
+    &:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+  }
+}

--- a/src/components/ReactionPlayer/ReactionPlayer.jsx
+++ b/src/components/ReactionPlayer/ReactionPlayer.jsx
@@ -26,16 +26,24 @@ const getRenderer = async () => {
 
 const SIZE_LABELS = { small: 'S', medium: 'M', big: 'L' };
 
-function strip3SpeakEmbeds(html) {
+function stripRepliedTo(html) {
   if (!html) return '';
   return html
+    .replace(/<p>\s*<sup>\s*replied to[\s\S]*?<\/sup>\s*<\/p>/gi, '')
+    .replace(/<sup>\s*replied to[\s\S]*?<\/sup>/gi, '')
+    .replace(/\n?<sup>replied to \[.*?\]\([^)]*\)[^<]*<\/sup>/g, '');
+}
+
+function strip3SpeakEmbeds(html) {
+  if (!html) return '';
+  return stripRepliedTo(html)
     .replace(/<div[^>]*class="[^"]*video-container[^"]*"[^>]*>[\s\S]*?<\/div>/gi, '')
     .replace(/<iframe[^>]*src="[^"]*3speak\.tv[^"]*"[^>]*>[\s\S]*?<\/iframe>/gi, '')
     .replace(/<iframe[^>]*src="[^"]*embed\.3speak\.tv[^"]*"[^>]*>[\s\S]*?<\/iframe>/gi, '');
 }
 
 function CommentNode({ comment, depth }) {
-  const bodyHtml = depth === 0 ? strip3SpeakEmbeds(comment.body) : (comment.body || '');
+  const bodyHtml = depth === 0 ? strip3SpeakEmbeds(comment.body) : stripRepliedTo(comment.body || '');
   return (
     <div className="rct-thread-comment" style={depth > 0 ? { marginLeft: `${Math.min(depth, 4) * 16}px` } : undefined}>
       <div className="rct-thread-header">

--- a/src/components/ReactionPlayer/ReactionPlayer.jsx
+++ b/src/components/ReactionPlayer/ReactionPlayer.jsx
@@ -1,0 +1,343 @@
+import { useRef, useState, useEffect, useCallback } from 'react';
+import { MdChevronLeft, MdChevronRight, MdClose, MdAspectRatio } from 'react-icons/md';
+import { FaPlay, FaPause, FaExpand, FaCompress } from 'react-icons/fa';
+import { TbRewindBackward10, TbRewindForward10 } from 'react-icons/tb';
+import './ReactionPlayer.scss';
+
+const SIZE_LABELS = { small: 'S', medium: 'M', big: 'L' };
+
+function formatTime(seconds) {
+  if (!seconds || isNaN(seconds)) return '0:00';
+  const hrs = Math.floor(seconds / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  const secs = Math.floor(seconds % 60);
+  if (hrs > 0) {
+    return `${hrs}:${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+  }
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+function ReactionPlayer({
+  reactions,
+  selectedIndex,
+  onSelectReaction,
+  onClose,
+  mobile,
+  size,
+  onCycleSize,
+  currentTime: mainCurrentTime,
+  duration: mainDuration,
+}) {
+  const scrollRef = useRef(null);
+  const itemRefs = useRef([]);
+  const userScrolledRef = useRef(false);
+  const programmaticScrollRef = useRef(false);
+  const iframeRefs = useRef([]);
+  const activeIdxRef = useRef(selectedIndex ?? 0);
+  const trackRef = useRef(null);
+
+  // Reaction player's own playback state
+  const [rctTime, setRctTime] = useState(0);
+  const [rctDuration, setRctDuration] = useState(0);
+  const [rctPlaying, setRctPlaying] = useState(false);
+  const [rctFullscreen, setRctFullscreen] = useState(false);
+  const [controlsHovering, setControlsHovering] = useState(false);
+  const [controlsVisible, setControlsVisible] = useState(false);
+  const hideTimerRef = useRef(null);
+
+  const idx = (selectedIndex ?? 0);
+  activeIdxRef.current = idx;
+
+  // Reset playback state when switching reactions
+  const prevIdxRef = useRef(idx);
+  useEffect(() => {
+    if (prevIdxRef.current !== idx) {
+      setRctTime(0);
+      setRctDuration(0);
+      setRctPlaying(false);
+      prevIdxRef.current = idx;
+    }
+  }, [idx]);
+
+  // Listen for postMessage from reaction player iframes
+  useEffect(() => {
+    const handleMessage = (event) => {
+      if (!event.data || !event.data.type) return;
+
+      const activeIframe = iframeRefs.current[activeIdxRef.current];
+
+      // Handle player-ready: auto-play only the active iframe
+      if (event.data.type === '3speak-player-ready') {
+        if (activeIframe && event.source === activeIframe.contentWindow) {
+          setTimeout(() => {
+            activeIframe.contentWindow?.postMessage({ type: 'play' }, '*');
+            setRctPlaying(true);
+          }, 100);
+        }
+        return;
+      }
+
+      // For all other messages, only handle from the active iframe
+      if (!activeIframe || event.source !== activeIframe.contentWindow) return;
+
+      switch (event.data.type) {
+        case '3speak-timeupdate':
+          setRctTime(event.data.currentTime ?? 0);
+          if (event.data.duration) setRctDuration(event.data.duration);
+          break;
+        case '3speak-playstate':
+          setRctPlaying(event.data.isPlaying ?? false);
+          break;
+        case '3speak-durationchange':
+          setRctDuration(event.data.duration ?? 0);
+          break;
+        case '3speak-ended':
+          setRctPlaying(false);
+          break;
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
+
+  // Fullscreen change listener
+  useEffect(() => {
+    const handleFsChange = () => {
+      setRctFullscreen(!!document.fullscreenElement);
+    };
+    document.addEventListener('fullscreenchange', handleFsChange);
+    return () => document.removeEventListener('fullscreenchange', handleFsChange);
+  }, []);
+
+  // Send commands to the active reaction player iframe
+  const sendCmd = useCallback((msg) => {
+    const iframe = iframeRefs.current[activeIdxRef.current];
+    if (iframe?.contentWindow) {
+      iframe.contentWindow.postMessage(msg, '*');
+    }
+  }, []);
+
+  const handleTogglePlay = useCallback(() => {
+    sendCmd({ type: 'toggle-play' });
+    setRctPlaying(prev => !prev);
+  }, [sendCmd]);
+  const handleSeekBackward = useCallback(() => sendCmd({ type: 'seekBackward', seconds: 10 }), [sendCmd]);
+  const handleSeekForward = useCallback(() => sendCmd({ type: 'seekForward', seconds: 10 }), [sendCmd]);
+  const handleRctSeek = useCallback((time) => sendCmd({ type: 'seek', time }), [sendCmd]);
+
+  const handleTrackClick = useCallback((e) => {
+    if (!trackRef.current || !rctDuration) return;
+    const rect = trackRef.current.getBoundingClientRect();
+    const fraction = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+    handleRctSeek(fraction * rctDuration);
+  }, [rctDuration, handleRctSeek]);
+
+  const handleToggleFullscreen = useCallback(() => {
+    const wrapper = document.querySelector('.reaction-video-wrap');
+    if (!wrapper) return;
+    if (!document.fullscreenElement) {
+      wrapper.requestFullscreen?.();
+    } else {
+      document.exitFullscreen?.();
+    }
+  }, []);
+
+  const showControlsTemporarily = useCallback(() => {
+    setControlsVisible(true);
+    if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+    hideTimerRef.current = setTimeout(() => setControlsVisible(false), 3000);
+  }, []);
+
+  // Scroll the list to center a specific item
+  const scrollToItem = useCallback((index) => {
+    const item = itemRefs.current[index];
+    const container = scrollRef.current;
+    if (!item || !container) return;
+
+    programmaticScrollRef.current = true;
+    const containerRect = container.getBoundingClientRect();
+    const itemRect = item.getBoundingClientRect();
+    const scrollOffset = container.scrollLeft;
+    const itemRelativeLeft = itemRect.left - containerRect.left + scrollOffset;
+    const targetScroll = itemRelativeLeft - containerRect.width / 2 + itemRect.width / 2;
+    container.scrollTo({ left: Math.max(0, targetScroll), behavior: 'smooth' });
+
+    setTimeout(() => { programmaticScrollRef.current = false; }, 500);
+  }, []);
+
+  // When user clicks a reaction, reset manual scroll flag
+  const handleItemClick = useCallback((index) => {
+    userScrolledRef.current = false;
+    onSelectReaction(index);
+  }, [onSelectReaction]);
+
+  // Detect manual scroll on the reaction list
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container) return;
+
+    const handleScroll = () => {
+      if (!programmaticScrollRef.current) {
+        userScrolledRef.current = true;
+      }
+    };
+
+    container.addEventListener('scroll', handleScroll);
+    return () => container.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  // Timeline-based auto-scroll
+  useEffect(() => {
+    if (userScrolledRef.current) return;
+    if (!reactions || reactions.length === 0 || !mainDuration || mainDuration <= 0) return;
+
+    const currentPct = mainCurrentTime / mainDuration;
+    let closestIdx = 0;
+    let closestDist = Infinity;
+    for (let i = 0; i < reactions.length; i++) {
+      const dist = Math.abs(reactions[i].pct - currentPct);
+      if (dist < closestDist) {
+        closestDist = dist;
+        closestIdx = i;
+      }
+    }
+
+    scrollToItem(closestIdx);
+  }, [mainCurrentTime, mainDuration, reactions, scrollToItem]);
+
+  // Also scroll when selectedIndex changes (from prev/next buttons)
+  useEffect(() => {
+    if (userScrolledRef.current) return;
+    scrollToItem(selectedIndex ?? 0);
+  }, [selectedIndex, scrollToItem]);
+
+  if (!reactions || reactions.length === 0) return null;
+
+  const current = reactions[idx] ?? reactions[0];
+  const hasPrev = idx > 0;
+  const hasNext = idx < reactions.length - 1;
+  const rctProgress = rctDuration > 0 ? (rctTime / rctDuration) * 100 : 0;
+  const showControls = controlsVisible || controlsHovering;
+
+  return (
+    <div className={`reaction-player${mobile ? ' reaction-player--mobile' : ''}`}>
+      {/* Video player with all iframes preloaded */}
+      <div
+        className="reaction-video-wrap"
+        onMouseMove={showControlsTemporarily}
+        onMouseLeave={() => setControlsVisible(false)}
+      >
+        {/* Render all iframes, show only the active one */}
+        {reactions.map((reaction, i) => (
+          <iframe
+            key={reaction.id}
+            ref={el => { iframeRefs.current[i] = el; }}
+            src={`${reaction.videoUrl}&controls=0`}
+            className={`rct-iframe${i === idx ? ' rct-iframe--active' : ''}`}
+            loading="lazy"
+            allowFullScreen
+          />
+        ))}
+
+        {/* Invisible overlay to capture mouse events above the iframe */}
+        <div className="rct-interact-overlay" onClick={handleTogglePlay} />
+
+        {/* Size overlay button */}
+        {onCycleSize && (
+          <button className="size-overlay-btn" onClick={onCycleSize} title={`Size: ${size || 'small'}`}>
+            <MdAspectRatio />
+            <span>{SIZE_LABELS[size] || 'S'}</span>
+          </button>
+        )}
+
+        {/* Custom player controls */}
+        <div
+          className={`rct-controls${showControls ? ' visible' : ''}`}
+          onMouseEnter={() => setControlsHovering(true)}
+          onMouseLeave={() => setControlsHovering(false)}
+        >
+          <div className="rct-progress-row">
+            <div className="rct-progress-track" ref={trackRef} onClick={handleTrackClick}>
+              <div className="rct-progress-fill" style={{ width: `${rctProgress}%` }} />
+            </div>
+          </div>
+          <div className="rct-controls-row">
+            <div className="rct-controls-left">
+              <button className="rct-btn" onClick={handleSeekBackward} title="Rewind 10s">
+                <TbRewindBackward10 size={14} />
+              </button>
+              <button className="rct-btn rct-btn--play" onClick={handleTogglePlay} title={rctPlaying ? 'Pause' : 'Play'}>
+                {rctPlaying ? <FaPause size={10} /> : <FaPlay size={10} />}
+              </button>
+              <button className="rct-btn" onClick={handleSeekForward} title="Forward 10s">
+                <TbRewindForward10 size={14} />
+              </button>
+              <div className="rct-time">
+                {formatTime(rctTime)} / {formatTime(rctDuration)}
+              </div>
+            </div>
+            <div className="rct-controls-right">
+              <button className="rct-btn" onClick={handleToggleFullscreen} title={rctFullscreen ? 'Exit Fullscreen' : 'Fullscreen'}>
+                {rctFullscreen ? <FaCompress size={10} /> : <FaExpand size={10} />}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Header - below video */}
+      <div className="reaction-player-header">
+        <div className="reaction-info">
+          <img className="reactor-avatar" src={current.avatar} alt="" />
+          <div className="reactor-text">
+            <span className="reactor-name">@{current.author}</span>
+            <span className="reaction-label">Reaction</span>
+          </div>
+        </div>
+        <div className="reaction-controls">
+          <button
+            className="nav-btn"
+            onClick={() => handleItemClick(idx - 1)}
+            disabled={!hasPrev}
+            title="Previous reaction"
+          >
+            <MdChevronLeft />
+          </button>
+          <span className="reaction-count">{idx + 1}/{reactions.length}</span>
+          <button
+            className="nav-btn"
+            onClick={() => handleItemClick(idx + 1)}
+            disabled={!hasNext}
+            title="Next reaction"
+          >
+            <MdChevronRight />
+          </button>
+          <button className="close-btn" onClick={onClose} title="Close reactions">
+            <MdClose />
+          </button>
+        </div>
+      </div>
+
+      {/* Horizontal scrollable list of reactions */}
+      <div className="reaction-list" ref={scrollRef}>
+        {reactions.map((reaction, i) => (
+          <div
+            key={reaction.id}
+            className={`reaction-item${i === idx ? ' active' : ''}`}
+            onClick={() => handleItemClick(i)}
+            ref={el => { itemRefs.current[i] = el; }}
+          >
+            <img className="reaction-item-avatar" src={reaction.avatar} alt="" />
+            <span className="reaction-item-name">@{reaction.author}</span>
+            {reaction.replyCount > 0 && (
+              <span className="reaction-item-count">{reaction.replyCount}</span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ReactionPlayer;

--- a/src/components/ReactionPlayer/ReactionPlayer.jsx
+++ b/src/components/ReactionPlayer/ReactionPlayer.jsx
@@ -35,13 +35,14 @@ function strip3SpeakEmbeds(html) {
 }
 
 function CommentNode({ comment, depth }) {
+  const bodyHtml = depth === 0 ? strip3SpeakEmbeds(comment.body) : (comment.body || '');
   return (
     <div className="rct-thread-comment" style={depth > 0 ? { marginLeft: `${Math.min(depth, 4) * 16}px` } : undefined}>
       <div className="rct-thread-header">
         <img className="rct-thread-avatar" src={comment.avatar} alt="" />
         <span className="rct-thread-author">@{comment.author}</span>
       </div>
-      <div className="rct-thread-body markdown-view" dangerouslySetInnerHTML={{ __html: strip3SpeakEmbeds(comment.body) }} />
+      <div className="rct-thread-body markdown-view" dangerouslySetInnerHTML={{ __html: bodyHtml }} />
       {comment.children?.map((child, i) => (
         <CommentNode key={i} comment={child} depth={depth + 1} />
       ))}

--- a/src/components/ReactionPlayer/ReactionPlayer.jsx
+++ b/src/components/ReactionPlayer/ReactionPlayer.jsx
@@ -1,10 +1,45 @@
 import { useRef, useState, useEffect, useCallback } from 'react';
-import { MdChevronLeft, MdChevronRight, MdClose, MdAspectRatio } from 'react-icons/md';
-import { FaPlay, FaPause, FaExpand, FaCompress } from 'react-icons/fa';
+import { MdChevronLeft, MdChevronRight, MdClose, MdAspectRatio, MdVideocam, MdComment } from 'react-icons/md';
+import { FaPlay, FaPause, FaExpand, FaCompress, FaVolumeUp, FaVolumeMute } from 'react-icons/fa';
 import { TbRewindBackward10, TbRewindForward10 } from 'react-icons/tb';
+import { Client } from '@hiveio/dhive';
+import { HIVE_API_NODES } from '../../utils/config';
 import './ReactionPlayer.scss';
 
+const hiveClient = new Client(HIVE_API_NODES);
+
+// Lazy-load the Hive markdown renderer
+let rendererPromise = null;
+const getRenderer = async () => {
+  if (!rendererPromise) {
+    rendererPromise = import('@snapie/renderer').then(({ createHiveRenderer }) => {
+      return createHiveRenderer({
+        ipfsGateway: 'https://ipfs-3speak.b-cdn.net',
+        convertHiveUrls: true,
+        usertagUrlFn: (account) => `/p/${account}`,
+        hashtagUrlFn: (tag) => `/t/${tag}`,
+      });
+    });
+  }
+  return rendererPromise;
+};
+
 const SIZE_LABELS = { small: 'S', medium: 'M', big: 'L' };
+
+function CommentNode({ comment, depth }) {
+  return (
+    <div className="rct-thread-comment" style={depth > 0 ? { marginLeft: `${Math.min(depth, 4) * 16}px` } : undefined}>
+      <div className="rct-thread-header">
+        <img className="rct-thread-avatar" src={comment.avatar} alt="" />
+        <span className="rct-thread-author">@{comment.author}</span>
+      </div>
+      <div className="rct-thread-body markdown-view" dangerouslySetInnerHTML={{ __html: comment.body }} />
+      {comment.children?.map((child, i) => (
+        <CommentNode key={i} comment={child} depth={depth + 1} />
+      ))}
+    </div>
+  );
+}
 
 function formatTime(seconds) {
   if (!seconds || isNaN(seconds)) return '0:00';
@@ -42,10 +77,15 @@ function ReactionPlayer({
   const [rctTime, setRctTime] = useState(0);
   const [rctDuration, setRctDuration] = useState(0);
   const [rctPlaying, setRctPlaying] = useState(false);
+  const [rctMuted, setRctMuted] = useState(false);
   const [rctFullscreen, setRctFullscreen] = useState(false);
   const [controlsHovering, setControlsHovering] = useState(false);
   const [controlsVisible, setControlsVisible] = useState(false);
   const hideTimerRef = useRef(null);
+
+  // Nested comment tree for comment-type reactions
+  const [nestedComments, setNestedComments] = useState([]);
+  const [loadingComments, setLoadingComments] = useState(false);
 
   const idx = (selectedIndex ?? 0);
   activeIdxRef.current = idx;
@@ -60,6 +100,58 @@ function ReactionPlayer({
       prevIdxRef.current = idx;
     }
   }, [idx]);
+
+  // Fetch nested replies when a comment-type reaction is selected
+  useEffect(() => {
+    const current = reactions?.[idx];
+    if (!current || current.type !== 'comment' || !current.permlink) {
+      setNestedComments([]);
+      return;
+    }
+
+    let cancelled = false;
+    setLoadingComments(true);
+
+    (async () => {
+      try {
+        const render = await getRenderer().catch(() => null);
+
+        const buildTree = async (author, permlink, depth) => {
+          if (depth > 3) return [];
+          const replies = await hiveClient.call('condenser_api', 'get_content_replies', [author, permlink]);
+          return Promise.all(replies.map(async (c) => {
+            let bodyHtml = '';
+            if (render && c.body) {
+              try { bodyHtml = render(c.body); } catch (_) { bodyHtml = c.body; }
+            } else {
+              bodyHtml = c.body || '';
+            }
+            const children = c.children > 0 ? await buildTree(c.author, c.permlink, depth + 1) : [];
+            return {
+              author: c.author,
+              avatar: `https://images.hive.blog/u/${c.author}/avatar`,
+              body: bodyHtml,
+              children,
+            };
+          }));
+        };
+
+        const tree = await buildTree(current.author, current.permlink, 0);
+        if (!cancelled) {
+          setNestedComments(tree);
+          setLoadingComments(false);
+        }
+      } catch (err) {
+        console.error('Failed to fetch nested comments:', err);
+        if (!cancelled) {
+          setNestedComments([]);
+          setLoadingComments(false);
+        }
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [idx, reactions]);
 
   // Ref for onReactionPlay so the message handler can access it without re-registering
   const onReactionPlayRef = useRef(onReactionPlay);
@@ -135,6 +227,10 @@ function ReactionPlayer({
       if (willPlay) onReactionPlayRef.current?.();
       return willPlay;
     });
+  }, [sendCmd]);
+  const handleToggleMute = useCallback(() => {
+    sendCmd({ type: 'toggle-mute' });
+    setRctMuted(prev => !prev);
   }, [sendCmd]);
   const handleSeekBackward = useCallback(() => sendCmd({ type: 'seekBackward', seconds: 10 }), [sendCmd]);
   const handleSeekForward = useCallback(() => sendCmd({ type: 'seekForward', seconds: 10 }), [sendCmd]);
@@ -229,33 +325,53 @@ function ReactionPlayer({
   if (!reactions || reactions.length === 0) return null;
 
   const current = reactions[idx] ?? reactions[0];
+  const isVideo = current.type === 'video';
   const hasPrev = idx > 0;
   const hasNext = idx < reactions.length - 1;
   const rctProgress = rctDuration > 0 ? (rctTime / rctDuration) * 100 : 0;
   const showControls = controlsVisible || controlsHovering;
 
+  // Only video-type reactions get iframes
+  const videoReactions = reactions.filter(r => r.type === 'video');
+
   return (
     <div className={`reaction-player${mobile ? ' reaction-player--mobile' : ''}`}>
-      {/* Video player with all iframes preloaded */}
+      {/* Content area — same 16:9 size for both video and comment */}
       <div
         className="reaction-video-wrap"
-        onMouseMove={showControlsTemporarily}
-        onMouseLeave={() => setControlsVisible(false)}
+        onMouseMove={isVideo ? showControlsTemporarily : undefined}
+        onMouseLeave={isVideo ? () => setControlsVisible(false) : undefined}
       >
-        {/* Render all iframes, show only the active one */}
-        {reactions.map((reaction, i) => (
-          <iframe
-            key={reaction.id}
-            ref={el => { iframeRefs.current[i] = el; }}
-            src={`${reaction.videoUrl}&controls=0`}
-            className={`rct-iframe${i === idx ? ' rct-iframe--active' : ''}`}
-            loading="lazy"
-            allowFullScreen
-          />
-        ))}
+        {/* Preloaded iframes for video reactions only */}
+        {videoReactions.map((reaction) => {
+          const originalIdx = reactions.indexOf(reaction);
+          return (
+            <iframe
+              key={reaction.id}
+              ref={el => { iframeRefs.current[originalIdx] = el; }}
+              src={`${reaction.videoUrl}&controls=0`}
+              className={`rct-iframe${originalIdx === idx ? ' rct-iframe--active' : ''}`}
+              loading="lazy"
+              allowFullScreen
+            />
+          );
+        })}
 
-        {/* Invisible overlay to capture mouse events above the iframe */}
-        <div className="rct-interact-overlay" onClick={handleTogglePlay} />
+        {/* Comment display with nested reply tree */}
+        {!isVideo && (
+          <div className="rct-comment-panel">
+            <div className="rct-comment-thread">
+              <CommentNode comment={{ author: current.author, avatar: current.avatar, body: current.body, children: [] }} depth={0} />
+              {loadingComments && <div className="rct-thread-loading">Loading replies...</div>}
+              {nestedComments.map((reply, i) => (
+                <CommentNode key={i} comment={reply} depth={1} />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Invisible overlay for video items to capture mouse events */}
+        {isVideo && <div className="rct-interact-overlay" onClick={handleTogglePlay} />}
 
         {/* Size overlay button */}
         {onCycleSize && (
@@ -265,48 +381,53 @@ function ReactionPlayer({
           </button>
         )}
 
-        {/* Custom player controls */}
-        <div
-          className={`rct-controls${showControls ? ' visible' : ''}`}
-          onMouseEnter={() => setControlsHovering(true)}
-          onMouseLeave={() => setControlsHovering(false)}
-        >
-          <div className="rct-progress-row">
-            <div className="rct-progress-track" ref={trackRef} onClick={handleTrackClick}>
-              <div className="rct-progress-fill" style={{ width: `${rctProgress}%` }} />
-            </div>
-          </div>
-          <div className="rct-controls-row">
-            <div className="rct-controls-left">
-              <button className="rct-btn" onClick={handleSeekBackward} title="Rewind 10s">
-                <TbRewindBackward10 size={14} />
-              </button>
-              <button className="rct-btn rct-btn--play" onClick={handleTogglePlay} title={rctPlaying ? 'Pause' : 'Play'}>
-                {rctPlaying ? <FaPause size={10} /> : <FaPlay size={10} />}
-              </button>
-              <button className="rct-btn" onClick={handleSeekForward} title="Forward 10s">
-                <TbRewindForward10 size={14} />
-              </button>
-              <div className="rct-time">
-                {formatTime(rctTime)} / {formatTime(rctDuration)}
+        {/* Custom player controls (video only) */}
+        {isVideo && (
+          <div
+            className={`rct-controls${showControls ? ' visible' : ''}`}
+            onMouseEnter={() => setControlsHovering(true)}
+            onMouseLeave={() => setControlsHovering(false)}
+          >
+            <div className="rct-progress-row">
+              <div className="rct-progress-track" ref={trackRef} onClick={handleTrackClick}>
+                <div className="rct-progress-fill" style={{ width: `${rctProgress}%` }} />
               </div>
             </div>
-            <div className="rct-controls-right">
-              <button className="rct-btn" onClick={handleToggleFullscreen} title={rctFullscreen ? 'Exit Fullscreen' : 'Fullscreen'}>
-                {rctFullscreen ? <FaCompress size={10} /> : <FaExpand size={10} />}
-              </button>
+            <div className="rct-controls-row">
+              <div className="rct-controls-left">
+                <button className="rct-btn" onClick={handleSeekBackward} title="Rewind 10s">
+                  <TbRewindBackward10 size={14} />
+                </button>
+                <button className="rct-btn rct-btn--play" onClick={handleTogglePlay} title={rctPlaying ? 'Pause' : 'Play'}>
+                  {rctPlaying ? <FaPause size={10} /> : <FaPlay size={10} />}
+                </button>
+                <button className="rct-btn" onClick={handleSeekForward} title="Forward 10s">
+                  <TbRewindForward10 size={14} />
+                </button>
+                <div className="rct-time">
+                  {formatTime(rctTime)} / {formatTime(rctDuration)}
+                </div>
+              </div>
+              <div className="rct-controls-right">
+                <button className="rct-btn" onClick={handleToggleMute} title={rctMuted ? 'Unmute' : 'Mute'}>
+                  {rctMuted ? <FaVolumeMute size={10} /> : <FaVolumeUp size={10} />}
+                </button>
+                <button className="rct-btn" onClick={handleToggleFullscreen} title={rctFullscreen ? 'Exit Fullscreen' : 'Fullscreen'}>
+                  {rctFullscreen ? <FaCompress size={10} /> : <FaExpand size={10} />}
+                </button>
+              </div>
             </div>
           </div>
-        </div>
+        )}
       </div>
 
-      {/* Header - below video */}
+      {/* Header - below content */}
       <div className="reaction-player-header">
         <div className="reaction-info">
           <img className="reactor-avatar" src={current.avatar} alt="" />
           <div className="reactor-text">
             <span className="reactor-name">@{current.author}</span>
-            <span className="reaction-label">Reaction</span>
+            <span className="reaction-label">{isVideo ? 'Video Reaction' : 'Comment'}</span>
           </div>
         </div>
         <div className="reaction-controls">
@@ -314,7 +435,7 @@ function ReactionPlayer({
             className="nav-btn"
             onClick={() => handleItemClick(idx - 1)}
             disabled={!hasPrev}
-            title="Previous reaction"
+            title="Previous"
           >
             <MdChevronLeft />
           </button>
@@ -323,25 +444,28 @@ function ReactionPlayer({
             className="nav-btn"
             onClick={() => handleItemClick(idx + 1)}
             disabled={!hasNext}
-            title="Next reaction"
+            title="Next"
           >
             <MdChevronRight />
           </button>
-          <button className="close-btn" onClick={onClose} title="Close reactions">
+          <button className="close-btn" onClick={onClose} title="Close">
             <MdClose />
           </button>
         </div>
       </div>
 
-      {/* Horizontal scrollable list of reactions */}
+      {/* Horizontal scrollable list */}
       <div className="reaction-list" ref={scrollRef}>
         {reactions.map((reaction, i) => (
           <div
             key={reaction.id}
-            className={`reaction-item${i === idx ? ' active' : ''}`}
+            className={`reaction-item${i === idx ? ' active' : ''}${reaction.type === 'video' ? ' reaction-item--video' : ' reaction-item--comment'}`}
             onClick={() => handleItemClick(i)}
             ref={el => { itemRefs.current[i] = el; }}
           >
+            <div className="reaction-item-type-badge">
+              {reaction.type === 'video' ? <MdVideocam size={10} /> : <MdComment size={10} />}
+            </div>
             <img className="reaction-item-avatar" src={reaction.avatar} alt="" />
             <span className="reaction-item-name">@{reaction.author}</span>
             {reaction.replyCount > 0 && (

--- a/src/components/ReactionPlayer/ReactionPlayer.jsx
+++ b/src/components/ReactionPlayer/ReactionPlayer.jsx
@@ -1,5 +1,5 @@
-import { useRef, useState, useEffect, useCallback } from 'react';
-import { MdChevronLeft, MdChevronRight, MdClose, MdAspectRatio, MdVideocam, MdComment } from 'react-icons/md';
+import { Fragment, useRef, useState, useEffect, useCallback } from 'react';
+import { MdChevronLeft, MdChevronRight, MdClose, MdAspectRatio, MdVideocam, MdComment, MdKeyboardArrowDown, MdKeyboardArrowUp } from 'react-icons/md';
 import { FaPlay, FaPause, FaExpand, FaCompress, FaVolumeUp, FaVolumeMute } from 'react-icons/fa';
 import { TbRewindBackward10, TbRewindForward10 } from 'react-icons/tb';
 import { Client } from '@hiveio/dhive';
@@ -26,6 +26,14 @@ const getRenderer = async () => {
 
 const SIZE_LABELS = { small: 'S', medium: 'M', big: 'L' };
 
+function strip3SpeakEmbeds(html) {
+  if (!html) return '';
+  return html
+    .replace(/<div[^>]*class="[^"]*video-container[^"]*"[^>]*>[\s\S]*?<\/div>/gi, '')
+    .replace(/<iframe[^>]*src="[^"]*3speak\.tv[^"]*"[^>]*>[\s\S]*?<\/iframe>/gi, '')
+    .replace(/<iframe[^>]*src="[^"]*embed\.3speak\.tv[^"]*"[^>]*>[\s\S]*?<\/iframe>/gi, '');
+}
+
 function CommentNode({ comment, depth }) {
   return (
     <div className="rct-thread-comment" style={depth > 0 ? { marginLeft: `${Math.min(depth, 4) * 16}px` } : undefined}>
@@ -33,7 +41,7 @@ function CommentNode({ comment, depth }) {
         <img className="rct-thread-avatar" src={comment.avatar} alt="" />
         <span className="rct-thread-author">@{comment.author}</span>
       </div>
-      <div className="rct-thread-body markdown-view" dangerouslySetInnerHTML={{ __html: comment.body }} />
+      <div className="rct-thread-body markdown-view" dangerouslySetInnerHTML={{ __html: strip3SpeakEmbeds(comment.body) }} />
       {comment.children?.map((child, i) => (
         <CommentNode key={i} comment={child} depth={depth + 1} />
       ))}
@@ -72,6 +80,7 @@ function ReactionPlayer({
   const iframeRefs = useRef([]);
   const activeIdxRef = useRef(selectedIndex ?? 0);
   const trackRef = useRef(null);
+  const playerRef = useRef(null);
 
   // Reaction player's own playback state
   const [rctTime, setRctTime] = useState(0);
@@ -83,12 +92,65 @@ function ReactionPlayer({
   const [controlsVisible, setControlsVisible] = useState(false);
   const hideTimerRef = useRef(null);
 
-  // Nested comment tree for comment-type reactions
-  const [nestedComments, setNestedComments] = useState([]);
-  const [loadingComments, setLoadingComments] = useState(false);
+  // Mobile collapse — respect manual override from localStorage
+  const [mobileCollapsed, setMobileCollapsed] = useState(() => {
+    const stored = localStorage.getItem('rct-collapsed');
+    if (stored !== null) return stored === '1';
+    // Auto-collapse if only comments without timestamps
+    if (!reactions || reactions.length === 0) return true;
+    const hasVideo = reactions.some(r => r.type === 'video');
+    const hasTimestamped = reactions.some(r => r.pct !== null);
+    return !hasVideo && !hasTimestamped;
+  });
+  const userToggledRef = useRef(false);
+
+  // Dynamic height for scroll area on mobile
+  const [belowMaxHeight, setBelowMaxHeight] = useState(null);
 
   const idx = (selectedIndex ?? 0);
   activeIdxRef.current = idx;
+
+  // Determine sizing mode: 'full' (has videos), 'half' (comments-only with timestamps)
+  const hasVideoReactions = reactions?.some(r => r.type === 'video');
+
+  // Calculate available vertical space once on mount (mobile only)
+  useEffect(() => {
+    if (!mobile || mobileCollapsed) {
+      setBelowMaxHeight(null);
+      return;
+    }
+
+    const rafId = requestAnimationFrame(() => {
+      const player = playerRef.current;
+      if (!player) return;
+
+      const playerTop = player.getBoundingClientRect().top;
+      const viewportH = window.innerHeight;
+      const available = viewportH - playerTop;
+
+      const header = player.querySelector('.reaction-player-header');
+      const list = player.querySelector('.reaction-list');
+
+      const headerH = header?.getBoundingClientRect().height || 0;
+      const listH = list?.getBoundingClientRect().height || 0;
+
+      const buffer = 16; // borders + padding
+      let remaining = available - headerH - listH - buffer;
+
+      // Comments-only with timestamps: half the space
+      if (!hasVideoReactions) {
+        remaining = Math.floor(remaining / 2);
+      }
+
+      setBelowMaxHeight(Math.max(50, Math.floor(remaining)));
+    });
+
+    return () => cancelAnimationFrame(rafId);
+  }, [mobile, mobileCollapsed, hasVideoReactions]);
+
+  // Nested comment tree for comment-type reactions
+  const [nestedComments, setNestedComments] = useState([]);
+  const [loadingComments, setLoadingComments] = useState(false);
 
   // Reset playback state when switching reactions
   const prevIdxRef = useRef(idx);
@@ -101,10 +163,10 @@ function ReactionPlayer({
     }
   }, [idx]);
 
-  // Fetch nested replies when a comment-type reaction is selected
+  // Fetch nested replies when a reaction with a permlink is selected
   useEffect(() => {
     const current = reactions?.[idx];
-    if (!current || current.type !== 'comment' || !current.permlink) {
+    if (!current || !current.permlink) {
       setNestedComments([]);
       return;
     }
@@ -182,7 +244,7 @@ function ReactionPlayer({
 
       const activeIframe = iframeRefs.current[activeIdxRef.current];
 
-      // Handle player-ready: do NOT auto-play reaction iframes (main player has priority)
+      // Handle player-ready: do NOT auto-play
       if (event.data.type === '3speak-player-ready') {
         return;
       }
@@ -302,11 +364,12 @@ function ReactionPlayer({
     if (userScrolledRef.current) return;
     if (!reactions || reactions.length === 0 || !mainDuration || mainDuration <= 0) return;
 
-    const currentPct = mainCurrentTime / mainDuration;
     let closestIdx = 0;
     let closestDist = Infinity;
     for (let i = 0; i < reactions.length; i++) {
-      const dist = Math.abs(reactions[i].pct - currentPct);
+      const r = reactions[i];
+      const rTime = r.pct;
+      const dist = Math.abs(rTime - mainCurrentTime);
       if (dist < closestDist) {
         closestDist = dist;
         closestIdx = i;
@@ -335,7 +398,50 @@ function ReactionPlayer({
   const videoReactions = reactions.filter(r => r.type === 'video');
 
   return (
-    <div className={`reaction-player${mobile ? ' reaction-player--mobile' : ''}`}>
+    <div className={`reaction-player${mobile ? ' reaction-player--mobile' : ''}`} ref={playerRef}>
+      {/* Header - top on mobile */}
+      <div className="reaction-player-header">
+        <div className="reaction-info">
+          <img className="reactor-avatar" src={current.avatar} alt="" />
+          <div className="reactor-text">
+            <span className="reactor-name">@{current.author}</span>
+            <span className="reaction-label">{isVideo ? 'Video Reaction' : 'Comment'}</span>
+          </div>
+        </div>
+        <div className="reaction-controls">
+          <button
+            className="nav-btn"
+            onClick={() => handleItemClick(idx - 1)}
+            disabled={!hasPrev}
+            title="Previous"
+          >
+            <MdChevronLeft />
+          </button>
+          <span className="reaction-count">{idx + 1}/{reactions.length}</span>
+          <button
+            className="nav-btn"
+            onClick={() => handleItemClick(idx + 1)}
+            disabled={!hasNext}
+            title="Next"
+          >
+            <MdChevronRight />
+          </button>
+          <button
+            className="mobile-rct-toggle nav-btn"
+            onClick={() => onClose?.()}
+            title="Hide reactions"
+          >
+            <MdKeyboardArrowUp />
+          </button>
+          <button className="close-btn" onClick={onClose} title="Hide">
+            <MdKeyboardArrowDown />
+          </button>
+        </div>
+      </div>
+
+      <div className={`rct-collapsible${mobileCollapsed ? ' collapsed' : ''}`}>
+      {/* Scrollable area: video + comments scroll together on mobile */}
+      <div className="rct-scroll-area" style={belowMaxHeight != null ? { height: `${belowMaxHeight}px` } : undefined}>
       {/* Content area — same 16:9 size for both video and comment */}
       <div
         className="reaction-video-wrap"
@@ -349,7 +455,7 @@ function ReactionPlayer({
             <iframe
               key={reaction.id}
               ref={el => { iframeRefs.current[originalIdx] = el; }}
-              src={`${reaction.videoUrl}&controls=0`}
+              src={`${reaction.videoUrl}${reaction.videoUrl.includes('?') ? '&' : '?'}layout=desktop&mode=iframe&controls=0`}
               className={`rct-iframe${originalIdx === idx ? ' rct-iframe--active' : ''}`}
               loading="lazy"
               allowFullScreen
@@ -373,13 +479,28 @@ function ReactionPlayer({
         {/* Invisible overlay for video items to capture mouse events */}
         {isVideo && <div className="rct-interact-overlay" onClick={handleTogglePlay} />}
 
-        {/* Size overlay button */}
-        {onCycleSize && (
-          <button className="size-overlay-btn" onClick={onCycleSize} title={`Size: ${size || 'small'}`}>
-            <MdAspectRatio />
-            <span>{SIZE_LABELS[size] || 'S'}</span>
+        {/* Overlay buttons (top-right) */}
+        <div className="overlay-buttons">
+          {/* Mobile-only prev/next nav + count */}
+          <div className="mobile-overlay-nav">
+            <button className="size-overlay-btn size-overlay-btn--nav" onClick={() => handleItemClick(idx - 1)} disabled={!hasPrev} title="Previous">
+              <MdChevronLeft />
+            </button>
+            <span className="overlay-count">{idx + 1}/{reactions.length}</span>
+            <button className="size-overlay-btn size-overlay-btn--nav" onClick={() => handleItemClick(idx + 1)} disabled={!hasNext} title="Next">
+              <MdChevronRight />
+            </button>
+          </div>
+          {onCycleSize && (
+            <button className="size-overlay-btn size-overlay-btn--resize" onClick={onCycleSize} title={`Size: ${size || 'small'}`}>
+              <MdAspectRatio />
+              <span>{SIZE_LABELS[size] || 'S'}</span>
+            </button>
+          )}
+          <button className="size-overlay-btn size-overlay-btn--close" onClick={onClose} title="Hide reactions">
+            <MdKeyboardArrowUp />
           </button>
-        )}
+        </div>
 
         {/* Custom player controls (video only) */}
         {isVideo && (
@@ -421,59 +542,47 @@ function ReactionPlayer({
         )}
       </div>
 
-      {/* Header - below content */}
-      <div className="reaction-player-header">
-        <div className="reaction-info">
-          <img className="reactor-avatar" src={current.avatar} alt="" />
-          <div className="reactor-text">
-            <span className="reactor-name">@{current.author}</span>
-            <span className="reaction-label">{isVideo ? 'Video Reaction' : 'Comment'}</span>
+      {/* Comment thread below video reactions */}
+      {isVideo && current.permlink && (
+        <div className="rct-comment-panel rct-comment-panel--below">
+          <div className="rct-comment-thread">
+            <CommentNode comment={{ author: current.author, avatar: current.avatar, body: current.body, children: [] }} depth={0} />
+            {loadingComments && <div className="rct-thread-loading">Loading replies...</div>}
+            {nestedComments.map((reply, i) => (
+              <CommentNode key={i} comment={reply} depth={1} />
+            ))}
           </div>
         </div>
-        <div className="reaction-controls">
-          <button
-            className="nav-btn"
-            onClick={() => handleItemClick(idx - 1)}
-            disabled={!hasPrev}
-            title="Previous"
-          >
-            <MdChevronLeft />
-          </button>
-          <span className="reaction-count">{idx + 1}/{reactions.length}</span>
-          <button
-            className="nav-btn"
-            onClick={() => handleItemClick(idx + 1)}
-            disabled={!hasNext}
-            title="Next"
-          >
-            <MdChevronRight />
-          </button>
-          <button className="close-btn" onClick={onClose} title="Close">
-            <MdClose />
-          </button>
-        </div>
-      </div>
+      )}
+      </div>{/* end rct-scroll-area */}
 
       {/* Horizontal scrollable list */}
       <div className="reaction-list" ref={scrollRef}>
-        {reactions.map((reaction, i) => (
-          <div
-            key={reaction.id}
-            className={`reaction-item${i === idx ? ' active' : ''}${reaction.type === 'video' ? ' reaction-item--video' : ' reaction-item--comment'}`}
-            onClick={() => handleItemClick(i)}
-            ref={el => { itemRefs.current[i] = el; }}
-          >
-            <div className="reaction-item-type-badge">
-              {reaction.type === 'video' ? <MdVideocam size={10} /> : <MdComment size={10} />}
-            </div>
-            <img className="reaction-item-avatar" src={reaction.avatar} alt="" />
-            <span className="reaction-item-name">@{reaction.author}</span>
-            {reaction.replyCount > 0 && (
-              <span className="reaction-item-count">{reaction.replyCount}</span>
-            )}
-          </div>
-        ))}
+        {reactions.map((reaction, i) => {
+          // Insert divider before the first non-timestamped reaction
+          const showDivider = reaction.pct === null && (i === 0 || reactions[i - 1].pct !== null);
+          return (
+            <Fragment key={reaction.id}>
+              {showDivider && <div className="reaction-list-divider" />}
+              <div
+                className={`reaction-item${i === idx ? ' active' : ''}${reaction.type === 'video' ? ' reaction-item--video' : ' reaction-item--comment'}`}
+                onClick={() => handleItemClick(i)}
+                ref={el => { itemRefs.current[i] = el; }}
+              >
+                <div className="reaction-item-type-badge">
+                  {reaction.type === 'video' ? <MdVideocam size={10} /> : <MdComment size={10} />}
+                </div>
+                <img className="reaction-item-avatar" src={reaction.avatar} alt="" />
+                <span className="reaction-item-name">@{reaction.author}</span>
+                {reaction.replyCount > 0 && (
+                  <span className="reaction-item-count">{reaction.replyCount}</span>
+                )}
+              </div>
+            </Fragment>
+          );
+        })}
       </div>
+      </div>{/* end rct-collapsible */}
     </div>
   );
 }

--- a/src/components/ReactionPlayer/ReactionPlayer.jsx
+++ b/src/components/ReactionPlayer/ReactionPlayer.jsx
@@ -27,6 +27,8 @@ function ReactionPlayer({
   onCycleSize,
   currentTime: mainCurrentTime,
   duration: mainDuration,
+  mainIsPlaying,
+  onReactionPlay,
 }) {
   const scrollRef = useRef(null);
   const itemRefs = useRef([]);
@@ -59,6 +61,28 @@ function ReactionPlayer({
     }
   }, [idx]);
 
+  // Ref for onReactionPlay so the message handler can access it without re-registering
+  const onReactionPlayRef = useRef(onReactionPlay);
+  onReactionPlayRef.current = onReactionPlay;
+
+  // Send commands to the active reaction player iframe
+  const sendCmd = useCallback((msg) => {
+    const iframe = iframeRefs.current[activeIdxRef.current];
+    if (iframe?.contentWindow) {
+      iframe.contentWindow.postMessage(msg, '*');
+    }
+  }, []);
+
+  // When main player starts playing, pause the reaction player
+  const prevMainIsPlaying = useRef(false);
+  useEffect(() => {
+    if (mainIsPlaying && !prevMainIsPlaying.current) {
+      sendCmd({ type: 'pause' });
+      setRctPlaying(false);
+    }
+    prevMainIsPlaying.current = mainIsPlaying;
+  }, [mainIsPlaying, sendCmd]);
+
   // Listen for postMessage from reaction player iframes
   useEffect(() => {
     const handleMessage = (event) => {
@@ -66,14 +90,8 @@ function ReactionPlayer({
 
       const activeIframe = iframeRefs.current[activeIdxRef.current];
 
-      // Handle player-ready: auto-play only the active iframe
+      // Handle player-ready: do NOT auto-play reaction iframes (main player has priority)
       if (event.data.type === '3speak-player-ready') {
-        if (activeIframe && event.source === activeIframe.contentWindow) {
-          setTimeout(() => {
-            activeIframe.contentWindow?.postMessage({ type: 'play' }, '*');
-            setRctPlaying(true);
-          }, 100);
-        }
         return;
       }
 
@@ -110,17 +128,13 @@ function ReactionPlayer({
     return () => document.removeEventListener('fullscreenchange', handleFsChange);
   }, []);
 
-  // Send commands to the active reaction player iframe
-  const sendCmd = useCallback((msg) => {
-    const iframe = iframeRefs.current[activeIdxRef.current];
-    if (iframe?.contentWindow) {
-      iframe.contentWindow.postMessage(msg, '*');
-    }
-  }, []);
-
   const handleTogglePlay = useCallback(() => {
     sendCmd({ type: 'toggle-play' });
-    setRctPlaying(prev => !prev);
+    setRctPlaying(prev => {
+      const willPlay = !prev;
+      if (willPlay) onReactionPlayRef.current?.();
+      return willPlay;
+    });
   }, [sendCmd]);
   const handleSeekBackward = useCallback(() => sendCmd({ type: 'seekBackward', seconds: 10 }), [sendCmd]);
   const handleSeekForward = useCallback(() => sendCmd({ type: 'seekForward', seconds: 10 }), [sendCmd]);

--- a/src/components/ReactionPlayer/ReactionPlayer.scss
+++ b/src/components/ReactionPlayer/ReactionPlayer.scss
@@ -545,7 +545,7 @@
     line-height: 14px;
     text-align: center;
     color: #fff;
-    background: var(--accent-primary, #e53935);
+    background: #6b7280;
     border-radius: 7px;
   }
 

--- a/src/components/ReactionPlayer/ReactionPlayer.scss
+++ b/src/components/ReactionPlayer/ReactionPlayer.scss
@@ -34,6 +34,75 @@
     }
   }
 
+  // Comment panel (same 16:9 space as video)
+  .rct-comment-panel {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: flex-start;
+    background: var(--card-bg, #1a1a2e);
+    overflow-y: auto;
+    z-index: 1;
+  }
+
+  .rct-comment-thread {
+    padding: 12px;
+    width: 100%;
+  }
+
+  .rct-thread-comment {
+    padding: 8px 0;
+
+    & + .rct-thread-comment {
+      border-top: 1px solid var(--border-light, rgba(255, 255, 255, 0.08));
+    }
+  }
+
+  .rct-thread-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 4px;
+  }
+
+  .rct-thread-avatar {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+
+  .rct-thread-author {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-secondary, #aaa);
+  }
+
+  .rct-thread-body {
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--text-primary, #fff);
+    word-break: break-word;
+
+    img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 6px;
+      margin: 4px 0;
+    }
+  }
+
+  .rct-thread-loading {
+    padding: 12px 0;
+    font-size: 12px;
+    color: var(--text-secondary, #aaa);
+    text-align: center;
+  }
+
   // Invisible overlay to capture mouse events above iframe
   .rct-interact-overlay {
     position: absolute;
@@ -335,6 +404,29 @@
     text-overflow: ellipsis;
     max-width: 56px;
     text-align: center;
+  }
+
+  // Type badge (video camera or comment icon) on reaction list items
+  .reaction-item-type-badge {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-size: 10px;
+  }
+
+  .reaction-item--video .reaction-item-type-badge {
+    background: var(--accent-primary, #e53935);
+  }
+
+  .reaction-item--comment .reaction-item-type-badge {
+    background: #6b7280;
   }
 
   .reaction-item-count {

--- a/src/components/ReactionPlayer/ReactionPlayer.scss
+++ b/src/components/ReactionPlayer/ReactionPlayer.scss
@@ -7,7 +7,12 @@
   margin-bottom: 12px;
   overflow: hidden;
 
-  // 16:9 video container (first, above header)
+  // Scrollable area containing video + comment-below
+  .rct-scroll-area {
+    // Desktop: no scroll, comment panel handles its own overflow
+  }
+
+  // 16:9 video container (player handles vertical internally)
   .reaction-video-wrap {
     position: relative;
     width: 100%;
@@ -46,6 +51,20 @@
     background: var(--card-bg, #1a1a2e);
     overflow-y: auto;
     z-index: 1;
+
+    // Below-video variant: flows in document, not absolute
+    &--below {
+      position: relative;
+      top: auto;
+      left: auto;
+      height: auto;
+      max-height: 300px;
+      border-top: 1px solid var(--border-light, #333);
+
+      .rct-comment-thread {
+        padding-top: 4px;
+      }
+    }
   }
 
   .rct-comment-thread {
@@ -114,12 +133,37 @@
     cursor: pointer;
   }
 
-  // Size overlay button on the video
-  .size-overlay-btn {
+  // Overlay buttons container (top-right of video)
+  .overlay-buttons {
     position: absolute;
     top: 8px;
     right: 8px;
-    z-index: 12;
+    z-index: 8;
+    display: flex;
+    gap: 4px;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+  }
+
+  .reaction-video-wrap:hover .overlay-buttons {
+    opacity: 1;
+  }
+
+  // Mobile nav controls inside overlay — hidden on desktop
+  .mobile-overlay-nav {
+    display: none;
+    align-items: center;
+    gap: 2px;
+  }
+
+  .overlay-count {
+    font-size: 11px;
+    font-weight: 600;
+    color: #fff;
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+  }
+
+  .size-overlay-btn {
     display: flex;
     align-items: center;
     gap: 4px;
@@ -132,7 +176,6 @@
     font-size: 11px;
     font-weight: 600;
     transition: all 0.2s ease;
-    opacity: 0;
 
     &:hover {
       background: rgba(0, 0, 0, 0.85);
@@ -141,11 +184,63 @@
     svg {
       font-size: 16px;
     }
-  }
 
-  // Show overlay on hover
-  .reaction-video-wrap:hover .size-overlay-btn {
-    opacity: 1;
+    // Mobile-only nav arrows (prev/next) in overlay
+    &--nav {
+      display: none;
+
+      @include mix.respond(phone) {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        padding: 0;
+        gap: 0;
+        border-radius: 50%;
+        background: rgba(255, 255, 255, 0.1);
+        color: var(--text-primary);
+
+        svg {
+          font-size: 20px;
+        }
+
+        &:hover:not(:disabled) {
+          background: rgba(255, 255, 255, 0.2);
+        }
+
+        &:disabled {
+          opacity: 0.3;
+          cursor: not-allowed;
+        }
+      }
+    }
+
+    // Hide overlay close button on desktop (header has its own close)
+    &--close {
+      display: none;
+
+      @include mix.respond(phone) {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        padding: 0;
+        gap: 0;
+        border-radius: 50%;
+        background: rgba(255, 255, 255, 0.1);
+        color: var(--text-primary);
+
+        svg {
+          font-size: 20px;
+        }
+
+        &:hover {
+          background: rgba(255, 255, 255, 0.2);
+        }
+      }
+    }
   }
 
   // Custom player controls (overlay at bottom of video)
@@ -160,7 +255,7 @@
     padding: 16px 8px 4px;
     opacity: 0;
     transition: opacity 0.3s ease;
-    z-index: 11;
+    z-index: 7;
     pointer-events: none;
 
     &.visible {
@@ -337,8 +432,17 @@
       }
     }
 
-    .close-btn:hover {
-      background: #ef4444;
+    .close-btn {
+      border-radius: 50%;
+      display: none;
+
+      @media (max-width: 767px) {
+        display: flex;
+      }
+
+      &:hover {
+        background: rgba(255, 255, 255, 0.2);
+      }
     }
   }
 
@@ -445,9 +549,82 @@
     border-radius: 7px;
   }
 
+  // Divider between timestamped and non-timestamped reactions
+  .reaction-list-divider {
+    width: 1px;
+    align-self: stretch;
+    flex-shrink: 0;
+    background: var(--border-light, rgba(255, 255, 255, 0.15));
+    margin: 4px 2px;
+  }
+
+  // Collapse/hide toggle button
+  .mobile-rct-toggle {
+    // Visible on all screen sizes (nav-btn styles apply)
+  }
+
+  // Collapsible wrapper for content + list
+  .rct-collapsible {
+    // Desktop: always visible (collapse = hide entire panel via onClose)
+  }
+
   // Mobile variant
   &--mobile {
     border-radius: 10px;
     margin: 8px 0;
+
+    // Hide the full header on mobile
+    .reaction-player-header {
+      display: none;
+    }
+
+    // Scroll area: video + comments scroll together
+    .rct-scroll-area {
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
+      scrollbar-width: thin;
+      scrollbar-color: var(--accent-primary, #e53935) transparent;
+    }
+
+    // Comment panel inside scroll area: no own scroll
+    .rct-comment-panel--below {
+      max-height: none;
+      overflow-y: visible;
+    }
+
+    // Always show overlay buttons on mobile (no hover needed)
+    .overlay-buttons {
+      opacity: 1;
+    }
+
+    // Show mobile nav controls in overlay
+    .mobile-overlay-nav {
+      display: flex;
+    }
+
+    // Hide resize button on mobile
+    .size-overlay-btn--resize {
+      display: none;
+    }
+
+    // Smaller avatars in reaction list
+    .reaction-item {
+      min-width: 48px;
+      padding: 4px;
+    }
+
+    .reaction-item-avatar {
+      width: 28px;
+      height: 28px;
+    }
+
+    .reaction-item-name {
+      max-width: 44px;
+    }
+
+    .reaction-list {
+      padding: 6px 8px;
+      gap: 6px;
+    }
   }
 }

--- a/src/components/ReactionPlayer/ReactionPlayer.scss
+++ b/src/components/ReactionPlayer/ReactionPlayer.scss
@@ -1,0 +1,361 @@
+@use "../../mixins.scss" as mix;
+
+.reaction-player {
+  background: var(--card-bg, #1a1a2e);
+  border: 1px solid var(--border-light, #333);
+  border-radius: 12px;
+  margin-bottom: 12px;
+  overflow: hidden;
+
+  // 16:9 video container (first, above header)
+  .reaction-video-wrap {
+    position: relative;
+    width: 100%;
+    padding-top: 56.25%;
+    background: #000;
+    border-radius: 12px 12px 0 0;
+    overflow: hidden;
+  }
+
+  // Preloaded iframes: all absolute, only active one visible
+  .rct-iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+    visibility: hidden;
+    pointer-events: none;
+
+    &--active {
+      visibility: visible;
+      pointer-events: auto;
+    }
+  }
+
+  // Invisible overlay to capture mouse events above iframe
+  .rct-interact-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 5;
+    cursor: pointer;
+  }
+
+  // Size overlay button on the video
+  .size-overlay-btn {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 12;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 8px;
+    border: none;
+    border-radius: 6px;
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    cursor: pointer;
+    font-size: 11px;
+    font-weight: 600;
+    transition: all 0.2s ease;
+    opacity: 0;
+
+    &:hover {
+      background: rgba(0, 0, 0, 0.85);
+    }
+
+    svg {
+      font-size: 16px;
+    }
+  }
+
+  // Show overlay on hover
+  .reaction-video-wrap:hover .size-overlay-btn {
+    opacity: 1;
+  }
+
+  // Custom player controls (overlay at bottom of video)
+  .rct-controls {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    flex-direction: column;
+    background: linear-gradient(transparent, rgba(0, 0, 0, 0.85));
+    padding: 16px 8px 4px;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    z-index: 11;
+    pointer-events: none;
+
+    &.visible {
+      opacity: 1;
+      pointer-events: auto;
+    }
+  }
+
+  .rct-progress-row {
+    padding: 0 2px;
+    margin-bottom: 4px;
+  }
+
+  .rct-progress-track {
+    width: 100%;
+    height: 3px;
+    background: rgba(255, 255, 255, 0.3);
+    border-radius: 2px;
+    cursor: pointer;
+    position: relative;
+    transition: height 0.15s ease;
+
+    &:hover {
+      height: 5px;
+    }
+  }
+
+  .rct-progress-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    background: var(--accent-primary, #e53935);
+    border-radius: 2px;
+    transition: width 0.15s linear;
+    pointer-events: none;
+  }
+
+  .rct-controls-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .rct-controls-left,
+  .rct-controls-right {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+  }
+
+  .rct-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: rgba(255, 255, 255, 0.85);
+    cursor: pointer;
+    transition: all 0.15s ease;
+
+    &:hover {
+      color: #fff;
+      background: rgba(255, 255, 255, 0.15);
+    }
+
+    &:active {
+      transform: scale(0.92);
+    }
+
+    &--play {
+      width: 28px;
+      height: 28px;
+    }
+  }
+
+  .rct-time {
+    font-size: 10px;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.9);
+    margin-left: 4px;
+    white-space: nowrap;
+    user-select: none;
+  }
+
+  // Header - below the video
+  .reaction-player-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--border-light, #333);
+
+    .reaction-info {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+    }
+
+    .reactor-avatar {
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      object-fit: cover;
+      flex-shrink: 0;
+    }
+
+    .reactor-text {
+      display: flex;
+      flex-direction: column;
+      line-height: 1.2;
+      min-width: 0;
+    }
+
+    .reactor-name {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text-primary, #fff);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .reaction-label {
+      font-size: 11px;
+      color: var(--text-secondary, #aaa);
+    }
+
+    .reaction-controls {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-shrink: 0;
+    }
+
+    .reaction-count {
+      font-size: 12px;
+      color: var(--text-secondary, #aaa);
+      background: rgba(255, 255, 255, 0.1);
+      padding: 2px 8px;
+      border-radius: 12px;
+      white-space: nowrap;
+    }
+
+    .nav-btn,
+    .close-btn {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 28px;
+      border: none;
+      border-radius: 6px;
+      background: rgba(255, 255, 255, 0.1);
+      color: var(--text-primary, #fff);
+      cursor: pointer;
+      transition: all 0.2s ease;
+
+      &:hover:not(:disabled) {
+        background: rgba(255, 255, 255, 0.2);
+      }
+
+      &:disabled {
+        opacity: 0.3;
+        cursor: not-allowed;
+      }
+
+      svg {
+        font-size: 18px;
+      }
+    }
+
+    .close-btn:hover {
+      background: #ef4444;
+    }
+  }
+
+  // Horizontal scrollable reaction list
+  .reaction-list {
+    display: flex;
+    gap: 8px;
+    padding: 10px 12px;
+    overflow-x: auto;
+    scrollbar-width: thin;
+    scrollbar-color: var(--accent-primary, #e53935) transparent;
+
+    &::-webkit-scrollbar {
+      height: 4px;
+    }
+
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: var(--accent-primary, #e53935);
+      border-radius: 2px;
+    }
+  }
+
+  .reaction-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    min-width: 60px;
+    padding: 6px;
+    border-radius: 8px;
+    cursor: pointer;
+    background: rgba(255, 255, 255, 0.05);
+    border: 2px solid transparent;
+    transition: all 0.2s ease;
+    position: relative;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.1);
+    }
+
+    &.active {
+      border-color: var(--accent-primary, #e53935);
+      background: rgba(229, 57, 53, 0.15);
+    }
+  }
+
+  .reaction-item-avatar {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    object-fit: cover;
+    margin-bottom: 4px;
+  }
+
+  .reaction-item-name {
+    font-size: 10px;
+    color: var(--text-secondary, #aaa);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 56px;
+    text-align: center;
+  }
+
+  .reaction-item-count {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    min-width: 14px;
+    height: 14px;
+    padding: 0 3px;
+    font-size: 9px;
+    font-weight: 700;
+    line-height: 14px;
+    text-align: center;
+    color: #fff;
+    background: var(--accent-primary, #e53935);
+    border-radius: 7px;
+  }
+
+  // Mobile variant
+  &--mobile {
+    border-radius: 10px;
+    margin: 8px 0;
+  }
+}

--- a/src/components/ShortsPreloader.jsx
+++ b/src/components/ShortsPreloader.jsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { preloadShorts } from '../hive-api/hiveApi';
+
+/**
+ * Invisible component that kicks off shorts preloading as soon as the app mounts.
+ * By the time the user navigates to /shorts, the first batch is usually ready.
+ */
+function ShortsPreloader() {
+  useEffect(() => {
+    preloadShorts(10);
+  }, []);
+
+  return null;
+}
+
+export default ShortsPreloader;

--- a/src/components/TimeAgo/TimeAgo.jsx
+++ b/src/components/TimeAgo/TimeAgo.jsx
@@ -1,12 +1,25 @@
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import utc from 'dayjs/plugin/utc';
 import './TimeAgo.scss';
 
 dayjs.extend(relativeTime);
+dayjs.extend(utc);
+
+// Ensure date is treated as UTC (Hive dates have no "Z" suffix)
+function toUtc(date) {
+  if (dayjs.isDayjs(date)) return date.isUTC() ? date : date.utc();
+  const s = typeof date === 'string' ? date : '';
+  // If no timezone indicator, treat as UTC
+  if (s && !/Z$/.test(s) && !/[+-]\d{2}:\d{2}$/.test(s)) {
+    return dayjs.utc(date);
+  }
+  return dayjs(date).utc();
+}
 
 function shortTime(date) {
-  const now = dayjs();
-  const d = dayjs(date);
+  const now = dayjs.utc();
+  const d = toUtc(date);
   const seconds = now.diff(d, 'second');
   if (seconds < 60) return `${seconds}s ago`;
   const minutes = now.diff(d, 'minute');
@@ -21,11 +34,29 @@ function shortTime(date) {
   return `${years}y ago`;
 }
 
-function TimeAgo({ date, unix }) {
-  const d = unix ? dayjs.unix(date) : dayjs(date);
+function longTime(date) {
+  const now = dayjs.utc();
+  const d = toUtc(date);
+  const seconds = now.diff(d, 'second');
+  if (seconds < 60) return 'just now';
+  const minutes = now.diff(d, 'minute');
+  if (minutes < 60) return `${minutes} minute${minutes !== 1 ? 's' : ''} ago`;
+  const hours = now.diff(d, 'hour');
+  if (hours < 24) return `${hours} hour${hours !== 1 ? 's' : ''} ago`;
+  const days = now.diff(d, 'day');
+  if (days < 30) return `${days} day${days !== 1 ? 's' : ''} ago`;
+  const months = now.diff(d, 'month');
+  if (months < 12) return `${months} month${months !== 1 ? 's' : ''} ago`;
+  const years = now.diff(d, 'year');
+  return `${years} year${years !== 1 ? 's' : ''} ago`;
+}
+
+function TimeAgo({ date, unix, short }) {
+  const d = unix ? dayjs.unix(date).utc() : toUtc(date);
+  if (short) return <span>{shortTime(d)}</span>;
   return (
     <span className="time-ago-wrap">
-      <span className="time-long">{d.fromNow()}</span>
+      <span className="time-long">{longTime(d)}</span>
       <span className="time-short">{shortTime(d)}</span>
     </span>
   );

--- a/src/components/Userprofilepage/UserProfilePage.jsx
+++ b/src/components/Userprofilepage/UserProfilePage.jsx
@@ -20,6 +20,7 @@ import { createPlaylist } from '../../utils/playlistOperations';
 import { toast } from 'sonner';
 import { useContentBatch } from '../../hooks/useContentBatch';
 import { useWatchHistory } from '../../hooks/useWatchHistory';
+import { fetchUserShortsWithDetails } from '../../hive-api/hiveApi';
 
 
 
@@ -31,9 +32,10 @@ function UserProfilePage() {
     const { user: authenticatedUser } = useAppStore();
     const [follower, setFollower] = useState(null)
     const [show, setShow] = useState(() => {
-      // Initialize show based on URL tab parameter
       const tab = searchParams.get('tab');
-      return tab === 'playlists' ? 'playlists' : 'video';
+      if (tab === 'playlists') return 'playlists';
+      if (tab === 'shorts') return 'shorts';
+      return 'video';
     });
     const [showCreateModal, setShowCreateModal] = useState(false);
     const [newPlaylistName, setNewPlaylistName] = useState('');
@@ -123,23 +125,64 @@ const {
   },
 });
 
-      
+            // Shorts feed for this user
+            const fetchUserShorts = async ({ pageParam = 1 }) => {
+              const data = await fetchUserShortsWithDetails(user, pageParam, 20);
+              return data;
+            };
+
+            const {
+              data: shortsData,
+              fetchNextPage: fetchNextShortsPage,
+              hasNextPage: hasNextShortsPage,
+              isFetchingNextPage: isFetchingNextShortsPage,
+              isLoading: isShortsLoading,
+            } = useInfiniteQuery({
+              queryKey: ["UserShorts", user],
+              queryFn: fetchUserShorts,
+              getNextPageParam: (lastPage) => {
+                if (lastPage?.page < lastPage?.totalPages) {
+                  return lastPage.page + 1;
+                }
+                return undefined;
+              },
+              enabled: show === 'shorts',
+            });
+
+            // Flatten shorts pages and map to Card3 format
+            const shortsVideos = (shortsData?.pages || []).flatMap(page =>
+              (page?.shorts || []).map(s => ({
+                author: s.author,
+                permlink: s.permlink,
+                title: (s.caption || s.title || '').slice(0, 80),
+                images: { thumbnail: s.thumbnailUrl },
+                duration: 0,
+                stats: {
+                  total_hive_reward: parseFloat(s.stats?.payout) || 0,
+                  num_votes: s.stats?.likes || 0,
+                },
+                created_at: s.createdAt,
+              }))
+            );
+
         useEffect(() => {
               const handleScroll = () => {
                 if (
                   window.innerHeight + window.scrollY >=
-                    document.body.offsetHeight - 200 &&
-                  !isFetchingNextPage &&
-                  hasNextPage
+                    document.body.offsetHeight - 200
                 ) {
-                  fetchNextPage();
+                  if (show === 'shorts' && !isFetchingNextShortsPage && hasNextShortsPage) {
+                    fetchNextShortsPage();
+                  } else if (show === 'video' && !isFetchingNextPage && hasNextPage) {
+                    fetchNextPage();
+                  }
                 }
               };
-          
+
               window.addEventListener("scroll", handleScroll);
               return () => window.removeEventListener("scroll", handleScroll);
-            }, [isFetchingNextPage, hasNextPage, fetchNextPage]);
-          
+            }, [show, isFetchingNextPage, hasNextPage, fetchNextPage, isFetchingNextShortsPage, hasNextShortsPage, fetchNextShortsPage]);
+
             // Flatten all pages into a single array
             const videos = data?.pages.flat() || [];
 
@@ -230,6 +273,7 @@ const {
       <div className="toggle-wrap">
         <div className="wrap">
           <span className={show === "video" ? "active" : ""} onClick={() => setShow("video")}>Videos</span>
+          <span className={show === "shorts" ? "active" : ""} onClick={() => setShow("shorts")}>Shorts</span>
           <span className={show === "playlists" ? "active" : ""} onClick={() => setShow("playlists")}>
             Playlists {playlists.length > 0 && `(${playlists.length})`}
           </span>
@@ -247,6 +291,17 @@ const {
       </div>
     ) : (
       <Card3 videos={videos} loading={isFetchingNextPage} getContentForVideo={getContentForVideo} isWatched={isWatched} />
+    )
+  ) : show === "shorts" ? (
+    isShortsLoading ? (
+      <BarLoader />
+    ) : shortsVideos.length === 0 ? (
+      <div className='empty-wrap'>
+        <img src={icon} alt="" />
+        <span>No Shorts Available</span>
+      </div>
+    ) : (
+      <Card3 videos={shortsVideos} loading={isFetchingNextShortsPage} linkPrefix="/shorts" linkQuery={`&user=${user}`} />
     )
   ) : show === "playlists" ? (
     <>

--- a/src/components/VideoControls/VideoControls.jsx
+++ b/src/components/VideoControls/VideoControls.jsx
@@ -1,0 +1,127 @@
+import { useState, useCallback, useRef } from 'react';
+import { FaPlay, FaPause, FaExpand, FaCompress } from 'react-icons/fa';
+import { TbRewindBackward10, TbRewindForward10 } from 'react-icons/tb';
+import './VideoControls.scss';
+
+function formatTime(seconds) {
+  if (!seconds || isNaN(seconds)) return '0:00';
+  const hrs = Math.floor(seconds / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  const secs = Math.floor(seconds % 60);
+  if (hrs > 0) {
+    return `${hrs}:${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+  }
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+
+function VideoControls({
+  currentTime,
+  duration,
+  isPlaying,
+  isFullscreen,
+  onSeekBackward,
+  onSeekForward,
+  onTogglePlay,
+  onToggleFullscreen,
+  onSeek,
+  isVisible,
+  markers,
+  onMarkerSelect,
+}) {
+  const resolvedMarkers = markers || [];
+
+  const [hovering, setHovering] = useState(false);
+  const [hoveredMarker, setHoveredMarker] = useState(null);
+  const trackRef = useRef(null);
+  const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
+
+  const handleTrackClick = useCallback((e) => {
+    if (!trackRef.current || !duration) return;
+    const rect = trackRef.current.getBoundingClientRect();
+    const fraction = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+    onSeek?.(fraction * duration);
+  }, [duration, onSeek]);
+
+  const handleMarkerClick = useCallback((e, time, index) => {
+    e.stopPropagation();
+    onSeek?.(time);
+    onMarkerSelect?.(index);
+  }, [onSeek, onMarkerSelect]);
+
+  const show = isVisible || hovering;
+
+  return (
+    <div
+      className={`video-controls${show ? ' visible' : ''}`}
+      onMouseEnter={() => setHovering(true)}
+      onMouseLeave={() => setHovering(false)}
+    >
+      {/* Progress bar */}
+      <div className="vc-progress-row">
+        <div className="vc-progress-track" ref={trackRef} onClick={handleTrackClick}>
+          <div className="vc-progress-fill" style={{ width: `${progress}%` }} />
+
+          {/* Timeline markers */}
+          {duration > 0 && resolvedMarkers.map((marker, i) => {
+            const pos = (marker.time / duration) * 100;
+            if (pos < 0 || pos > 100) return null;
+            return (
+              <div
+                key={i}
+                className={`vc-marker${hoveredMarker === i ? ' vc-marker--active' : ''}`}
+                style={{ left: `${pos}%` }}
+                onClick={(e) => handleMarkerClick(e, marker.time, i)}
+                onMouseEnter={() => setHoveredMarker(i)}
+                onMouseLeave={() => setHoveredMarker(null)}
+              >
+                <div className="vc-marker-line" />
+                <div className="vc-marker-avatar-wrap">
+                  <img
+                    className="vc-marker-avatar"
+                    src={marker.avatar}
+                    alt={marker.label || ''}
+                  />
+                  {marker.replyCount > 0 && (
+                    <span className="vc-marker-reply-count">{marker.replyCount}</span>
+                  )}
+                </div>
+                {hoveredMarker === i && marker.label && (
+                  <div className="vc-marker-tooltip">
+                    {marker.label}
+                    {marker.replyCount > 0 && ` (${marker.replyCount} ${marker.replyCount === 1 ? 'reply' : 'replies'})`}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Controls row */}
+      <div className="vc-controls-row">
+        <div className="vc-controls-left">
+          <button className="vc-btn" onClick={onSeekBackward} title="Rewind 10s">
+            <TbRewindBackward10 size={18} />
+          </button>
+          <button className="vc-btn vc-btn--play" onClick={onTogglePlay} title={isPlaying ? 'Pause' : 'Play'}>
+            {isPlaying ? <FaPause size={14} /> : <FaPlay size={14} />}
+          </button>
+          <button className="vc-btn" onClick={onSeekForward} title="Forward 10s">
+            <TbRewindForward10 size={18} />
+          </button>
+          <div className="vc-time">
+            {formatTime(currentTime)} / {formatTime(duration)}
+          </div>
+        </div>
+        <div className="vc-controls-right">
+          <button className="vc-btn" onClick={onToggleFullscreen} title={isFullscreen ? 'Exit Fullscreen' : 'Fullscreen'}>
+            {isFullscreen ? <FaCompress size={14} /> : <FaExpand size={14} />}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default VideoControls;

--- a/src/components/VideoControls/VideoControls.jsx
+++ b/src/components/VideoControls/VideoControls.jsx
@@ -34,6 +34,7 @@ function VideoControls({
   const resolvedMarkers = markers || [];
 
   const [hovering, setHovering] = useState(false);
+  const isTouchDevice = typeof window !== 'undefined' && 'ontouchstart' in window;
   const [hoveredMarker, setHoveredMarker] = useState(null);
   const trackRef = useRef(null);
   const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
@@ -56,8 +57,8 @@ function VideoControls({
   return (
     <div
       className={`video-controls${show ? ' visible' : ''}`}
-      onMouseEnter={() => setHovering(true)}
-      onMouseLeave={() => setHovering(false)}
+      onMouseEnter={() => { if (!isTouchDevice) setHovering(true); }}
+      onMouseLeave={() => { if (!isTouchDevice) setHovering(false); }}
     >
       {/* Progress bar */}
       <div className="vc-progress-row">

--- a/src/components/VideoControls/VideoControls.jsx
+++ b/src/components/VideoControls/VideoControls.jsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef } from 'react';
-import { FaPlay, FaPause, FaExpand, FaCompress } from 'react-icons/fa';
+import { FaPlay, FaPause, FaExpand, FaCompress, FaVolumeUp, FaVolumeMute } from 'react-icons/fa';
 import { TbRewindBackward10, TbRewindForward10 } from 'react-icons/tb';
 import './VideoControls.scss';
 
@@ -19,10 +19,12 @@ function VideoControls({
   currentTime,
   duration,
   isPlaying,
+  isMuted,
   isFullscreen,
   onSeekBackward,
   onSeekForward,
   onTogglePlay,
+  onToggleMute,
   onToggleFullscreen,
   onSeek,
   isVisible,
@@ -69,7 +71,7 @@ function VideoControls({
             return (
               <div
                 key={i}
-                className={`vc-marker${hoveredMarker === i ? ' vc-marker--active' : ''}`}
+                className={`vc-marker${hoveredMarker === i ? ' vc-marker--active' : ''}${marker.isVideo ? ' vc-marker--video' : ' vc-marker--comment'}`}
                 style={{ left: `${pos}%` }}
                 onClick={(e) => handleMarkerClick(e, marker.time, i)}
                 onMouseEnter={() => setHoveredMarker(i)}
@@ -115,6 +117,9 @@ function VideoControls({
           </div>
         </div>
         <div className="vc-controls-right">
+          <button className="vc-btn" onClick={onToggleMute} title={isMuted ? 'Unmute' : 'Mute'}>
+            {isMuted ? <FaVolumeMute size={14} /> : <FaVolumeUp size={14} />}
+          </button>
           <button className="vc-btn" onClick={onToggleFullscreen} title={isFullscreen ? 'Exit Fullscreen' : 'Fullscreen'}>
             {isFullscreen ? <FaCompress size={14} /> : <FaExpand size={14} />}
           </button>

--- a/src/components/VideoControls/VideoControls.jsx
+++ b/src/components/VideoControls/VideoControls.jsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef } from 'react';
-import { FaPlay, FaPause, FaExpand, FaCompress, FaVolumeUp, FaVolumeMute } from 'react-icons/fa';
+import { FaPlay, FaPause, FaExpand, FaCompress, FaVolumeUp, FaVolumeMute, FaVideo } from 'react-icons/fa';
 import { TbRewindBackward10, TbRewindForward10 } from 'react-icons/tb';
 import './VideoControls.scss';
 
@@ -30,6 +30,7 @@ function VideoControls({
   isVisible,
   markers,
   onMarkerSelect,
+  onReactToMoment,
 }) {
   const resolvedMarkers = markers || [];
 
@@ -38,6 +39,26 @@ function VideoControls({
   const [hoveredMarker, setHoveredMarker] = useState(null);
   const trackRef = useRef(null);
   const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
+
+  // Build a heatmap gradient showing where reactions cluster
+  const heatmapStyle = duration > 0 && resolvedMarkers.length > 0 ? (() => {
+    // Create soft gaussian-like glows at each marker position
+    const stops = resolvedMarkers.map(m => {
+      const pos = (m.time / duration) * 100;
+      const color = m.isVideo ? 'rgba(229,57,53,0.25)' : 'rgba(255,255,255,0.12)';
+      return `${color} ${pos}%`;
+    });
+    // Interleave transparent stops to create isolated glows
+    const gradient = [];
+    for (const m of resolvedMarkers) {
+      const pos = (m.time / duration) * 100;
+      const color = m.isVideo ? 'rgba(229,57,53,0.25)' : 'rgba(255,255,255,0.12)';
+      gradient.push(`transparent ${Math.max(0, pos - 3)}%`);
+      gradient.push(`${color} ${pos}%`);
+      gradient.push(`transparent ${Math.min(100, pos + 3)}%`);
+    }
+    return { background: `linear-gradient(to right, ${gradient.join(', ')})` };
+  })() : null;
 
   const handleTrackClick = useCallback((e) => {
     if (!trackRef.current || !duration) return;
@@ -63,6 +84,7 @@ function VideoControls({
       {/* Progress bar */}
       <div className="vc-progress-row">
         <div className="vc-progress-track" ref={trackRef} onClick={handleTrackClick}>
+          {heatmapStyle && <div className="vc-heatmap" style={heatmapStyle} />}
           <div className="vc-progress-fill" style={{ width: `${progress}%` }} />
 
           {/* Timeline markers */}
@@ -118,6 +140,11 @@ function VideoControls({
           </div>
         </div>
         <div className="vc-controls-right">
+          {onReactToMoment && (
+            <button className="vc-btn vc-btn--react" onClick={onReactToMoment} title="React to this moment">
+              <FaVideo size={13} />
+            </button>
+          )}
           <button className="vc-btn" onClick={onToggleMute} title={isMuted ? 'Unmute' : 'Mute'}>
             {isMuted ? <FaVolumeMute size={14} /> : <FaVolumeUp size={14} />}
           </button>

--- a/src/components/VideoControls/VideoControls.scss
+++ b/src/components/VideoControls/VideoControls.scss
@@ -118,6 +118,20 @@
       pointer-events: none;
     }
 
+    // Video reaction markers — red accent
+    &--video .vc-marker-avatar {
+      border-color: var(--accent-primary, #e53935);
+    }
+
+    // Comment markers — muted border
+    &--comment .vc-marker-avatar {
+      border-color: #6b7280;
+    }
+
+    &--comment .vc-marker-line {
+      background: rgba(255, 255, 255, 0.4);
+    }
+
     &--active, &:hover {
       .vc-marker-line {
         height: 18px;

--- a/src/components/VideoControls/VideoControls.scss
+++ b/src/components/VideoControls/VideoControls.scss
@@ -1,0 +1,187 @@
+.video-controls {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(transparent, rgba(0, 0, 0, 0.85));
+  padding: 20px 12px 8px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 10;
+  pointer-events: none;
+
+  &.visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  // Progress bar
+  .vc-progress-row {
+    padding: 0 4px;
+    margin-bottom: 6px;
+  }
+
+  .vc-progress-track {
+    width: 100%;
+    height: 4px;
+    background: rgba(255, 255, 255, 0.3);
+    border-radius: 2px;
+    cursor: pointer;
+    position: relative;
+    transition: height 0.15s ease;
+
+    &:hover {
+      height: 6px;
+    }
+  }
+
+  .vc-progress-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    background: var(--accent-primary, #e53935);
+    border-radius: 2px;
+    transition: width 0.15s linear;
+    pointer-events: none;
+  }
+
+  // Timeline markers
+  .vc-marker {
+    position: absolute;
+    top: 0;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    cursor: pointer;
+    z-index: 2;
+
+    .vc-marker-line {
+      width: 2px;
+      height: 14px;
+      background: rgba(255, 255, 255, 0.7);
+      border-radius: 1px;
+      position: absolute;
+      bottom: 0;
+      transition: height 0.15s ease, background 0.15s ease;
+    }
+
+    .vc-marker-avatar-wrap {
+      position: absolute;
+      bottom: 16px;
+      transition: transform 0.15s ease;
+    }
+
+    .vc-marker-avatar {
+      width: 24px;
+      height: 24px;
+      min-width: 24px;
+      min-height: 24px;
+      border-radius: 50%;
+      border: 2px solid rgba(255, 255, 255, 0.7);
+      object-fit: cover;
+      aspect-ratio: 1 / 1;
+      display: block;
+      transition: border-color 0.15s ease;
+    }
+
+    .vc-marker-reply-count {
+      position: absolute;
+      top: -4px;
+      right: -6px;
+      min-width: 14px;
+      height: 14px;
+      padding: 0 3px;
+      font-size: 9px;
+      font-weight: 700;
+      line-height: 14px;
+      text-align: center;
+      color: #fff;
+      background: var(--accent-primary, #e53935);
+      border-radius: 7px;
+      pointer-events: none;
+    }
+
+    .vc-marker-tooltip {
+      position: absolute;
+      bottom: 44px;
+      white-space: nowrap;
+      font-size: 11px;
+      font-weight: 500;
+      color: #fff;
+      background: rgba(0, 0, 0, 0.8);
+      padding: 3px 8px;
+      border-radius: 4px;
+      pointer-events: none;
+    }
+
+    &--active, &:hover {
+      .vc-marker-line {
+        height: 18px;
+        background: var(--accent-primary, #e53935);
+      }
+
+      .vc-marker-avatar-wrap {
+        transform: scale(1.2);
+      }
+
+      .vc-marker-avatar {
+        border-color: var(--accent-primary, #e53935);
+      }
+    }
+  }
+
+  // Controls
+  .vc-controls-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .vc-controls-left,
+  .vc-controls-right {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .vc-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: rgba(255, 255, 255, 0.85);
+    cursor: pointer;
+    transition: all 0.15s ease;
+
+    &:hover {
+      color: #fff;
+      background: rgba(255, 255, 255, 0.15);
+    }
+
+    &:active {
+      transform: scale(0.92);
+    }
+
+    &--play {
+      width: 36px;
+      height: 36px;
+    }
+  }
+
+  .vc-time {
+    font-size: 12px;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.9);
+    margin-left: 8px;
+    white-space: nowrap;
+    user-select: none;
+  }
+}

--- a/src/components/VideoControls/VideoControls.scss
+++ b/src/components/VideoControls/VideoControls.scss
@@ -199,3 +199,128 @@
     user-select: none;
   }
 }
+
+// Mobile controls layout
+@media (max-width: 767px) {
+  // Container always visible (for progress bar) but non-interactive
+  .video-controls,
+  .video-controls.visible {
+    top: 0;
+    padding: 0;
+    opacity: 1;
+    background: none;
+    pointer-events: none;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .video-controls {
+    // Gradient overlay — fades in/out with controls
+    &::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(
+        rgba(0, 0, 0, 0.3) 0%,
+        rgba(0, 0, 0, 0.12) 30%,
+        rgba(0, 0, 0, 0.12) 60%,
+        rgba(0, 0, 0, 0.55) 100%
+      );
+      opacity: 0;
+      transition: opacity 0.3s ease;
+      pointer-events: none;
+    }
+
+    // Progress bar — always visible at very bottom
+    .vc-progress-row {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      margin-bottom: 0;
+      padding: 0 8px 3px;
+      pointer-events: auto;
+      z-index: 1;
+    }
+
+    // Playback buttons — fade in/out, centered
+    .vc-controls-row {
+      justify-content: center;
+      opacity: 0;
+      transition: opacity 0.3s ease;
+      z-index: 1;
+    }
+
+    .vc-controls-left {
+      gap: 20px;
+    }
+
+    .vc-btn {
+      width: 44px;
+      height: 44px;
+      background: rgba(0, 0, 0, 0.35);
+    }
+
+    .vc-btn--play {
+      width: 52px;
+      height: 52px;
+      background: rgba(0, 0, 0, 0.45);
+    }
+
+    // Time display — fade in/out, bottom-left
+    .vc-time {
+      position: absolute;
+      bottom: 12px;
+      left: 8px;
+      margin-left: 0;
+      font-size: 11px;
+      background: rgba(0, 0, 0, 0.45);
+      padding: 2px 6px;
+      border-radius: 4px;
+      opacity: 0;
+      transition: opacity 0.3s ease;
+      z-index: 1;
+    }
+
+    // Mute + fullscreen — fade in/out, bottom-right
+    .vc-controls-right {
+      position: absolute;
+      bottom: 10px;
+      right: 8px;
+      opacity: 0;
+      transition: opacity 0.3s ease;
+      z-index: 1;
+    }
+
+    // When visible: show gradient + controls (not progress bar — already visible)
+    &.visible {
+      &::before { opacity: 1; }
+
+      .vc-controls-row {
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      .vc-time {
+        opacity: 1;
+      }
+
+      .vc-controls-right {
+        opacity: 1;
+        pointer-events: auto;
+      }
+    }
+
+    // Simplify markers on mobile — hide avatars, keep colored lines
+    .vc-marker {
+      .vc-marker-avatar-wrap { display: none; }
+      .vc-marker-tooltip { display: none; }
+      .vc-marker-line { height: 10px; }
+
+      &--active .vc-marker-line,
+      &:hover .vc-marker-line {
+        height: 14px;
+      }
+    }
+  }
+}

--- a/src/components/VideoControls/VideoControls.scss
+++ b/src/components/VideoControls/VideoControls.scss
@@ -37,6 +37,14 @@
     }
   }
 
+  .vc-heatmap {
+    position: absolute;
+    inset: 0;
+    border-radius: 2px;
+    pointer-events: none;
+    z-index: 0;
+  }
+
   .vc-progress-fill {
     position: absolute;
     top: 0;
@@ -187,6 +195,15 @@
     &--play {
       width: 36px;
       height: 36px;
+    }
+
+    &--react {
+      color: var(--accent-primary, #e53935);
+
+      &:hover {
+        color: #fff;
+        background: var(--accent-primary, #e53935);
+      }
     }
   }
 

--- a/src/components/nav/Nav.jsx
+++ b/src/components/nav/Nav.jsx
@@ -125,7 +125,7 @@ function Nav({ setSideBar, toggleProfileNav, openLoginModal }) {
               <Link to="/new" className="side-link-n" onClick={handleNav}>
                 <LuNewspaper className="icon" /> <span>New Content</span>
               </Link>
-            <Link to="/shorts" className="side-link-n">
+            <Link to="/shorts" className="side-link-n" onClick={handleNav}>
               <SiYoutubeshorts className="icon" /> <span>Shorts</span>
             </Link>
               <Link to="/communities" className="side-link-n" onClick={handleNav}>

--- a/src/components/nav/nav.scss
+++ b/src/components/nav/nav.scss
@@ -8,7 +8,7 @@
   background: var(--nav-bg);
   position: sticky;
   top: 0px;
-  z-index: 10;
+  z-index: 1000;
   transition: background-color 0.3s ease, box-shadow 0.3s ease;
 
   .nav-left {

--- a/src/components/playVideo/BlogContent.scss
+++ b/src/components/playVideo/BlogContent.scss
@@ -339,6 +339,33 @@
       font-style: italic;
       margin: 10px 0;
     }
+
+    // 3Speak video embed container (from @snapie/renderer)
+    .video-container {
+      position: relative;
+      width: 100%;
+      max-width: 720px;
+      aspect-ratio: 16 / 9;
+      background: #000;
+      border-radius: 8px;
+      overflow: hidden;
+      margin: 8px 0;
+
+      iframe {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        border: 0;
+        max-height: none;
+      }
+
+      &.vertical {
+        aspect-ratio: 9 / 16;
+        max-width: 320px;
+      }
+    }
   }
   .youtube-embed {
     position: relative;

--- a/src/components/playVideo/CommentSection.jsx
+++ b/src/components/playVideo/CommentSection.jsx
@@ -4,7 +4,8 @@ import './BlogContent.scss';
 import { BiDislike } from 'react-icons/bi';
 import { ImSpinner9 } from 'react-icons/im';
 import { TailChase } from 'ldrs/react';
-import { MdVideocam } from 'react-icons/md';
+import { MdVideocam, MdComment } from 'react-icons/md';
+import ReactVideoTab from '../ReactVideoModal/ReactVideoModal';
 import dayjs from 'dayjs';
 import { useAppStore } from '../../lib/store';
 import { Client } from '@hiveio/dhive';
@@ -60,9 +61,10 @@ function parseTimeInput(str) {
   return null;
 }
 
-function CommentSection({ videoDetails, author, permlink, currentTime, duration }) {
+function CommentSection({ videoDetails, author, permlink, currentTime, duration, onSeek, onRefreshReactions }) {
   const { user } = useAppStore();
   const [commentInfo, setCommentInfo] = useState('');
+  const [activeTab, setActiveTab] = useState('comment'); // 'comment' | 'react'
   const [replyText, setReplyText] = useState("");
   const [activeReply, setActiveReply] = useState(null);
   const [replyToComment, setReplyToComment] = useState(null);
@@ -115,8 +117,28 @@ function CommentSection({ videoDetails, author, permlink, currentTime, duration 
     setTimelineOverride(false);
   }, []);
 
+  // Listen for 3speak player ready messages to detect vertical videos in comments
+  useEffect(() => {
+    const handleMessage = (event) => {
+      if (!event.data || event.data.type !== '3speak-player-ready') return;
+      if (!event.data.isVertical) return;
 
-      
+      // Find the iframe in comment containers that sent this message
+      const wrap = document.querySelector('.vid-comment-wrap');
+      if (!wrap) return;
+
+      const iframes = wrap.querySelectorAll('.video-container iframe');
+      for (const iframe of iframes) {
+        if (iframe.contentWindow === event.source) {
+          iframe.parentElement.classList.add('vertical');
+          break;
+        }
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
 
   useEffect(() => {
     const fetchComments = async () => {
@@ -189,6 +211,11 @@ function CommentSection({ videoDetails, author, permlink, currentTime, duration 
       comments.map(async (comment) => {
         const children = await client.call('condenser_api', 'get_content_replies', [comment.author, comment.permlink]);
         const has_voted = comment.active_votes?.some(v => v.voter === user) ?? false;
+        let parentTimestamp = null;
+        try {
+          const meta = typeof comment.json_metadata === 'string' ? JSON.parse(comment.json_metadata) : comment.json_metadata;
+          if (meta?.parentTimestamp != null) parentTimestamp = meta.parentTimestamp;
+        } catch (_) {}
         return {
           author: {
             username: comment.author,
@@ -201,6 +228,7 @@ function CommentSection({ videoDetails, author, permlink, currentTime, duration 
           permlink: comment.permlink,
           created_at: comment.created,
           body: comment.body,
+          parentTimestamp,
           stats: {
             num_likes: comment.active_votes?.filter((v) => v.percent > 0).length || 0,
             num_dislikes: comment.active_votes?.filter((v) => v.percent < 0).length || 0,
@@ -237,6 +265,15 @@ function CommentSection({ videoDetails, author, permlink, currentTime, duration 
     const new_permlink = `re-${parent_permlink}-${Date.now()}`;
 
     try {
+      // Build json_metadata with optional timestamp
+      const metadata = { app: '3speak/new-version' };
+      if (isReplyingToMainPost) {
+        const timestampSec = parseTimeInput(timelineInput);
+        if (timestampSec !== null && timestampSec > 0) {
+          metadata.parentTimestamp = timestampSec;
+        }
+      }
+
       // Use aioha for comment broadcasting (works with all providers: Keychain, HiveAuth, etc.)
       const result = await commentWithAioha(
         parent_author,
@@ -244,7 +281,7 @@ function CommentSection({ videoDetails, author, permlink, currentTime, duration 
         new_permlink,
         '', // title (empty for comments)
         textToPost,
-        { app: '3speak/new-version' } // json_metadata
+        metadata
       );
 
       if (result.success) {
@@ -295,6 +332,7 @@ function CommentSection({ videoDetails, author, permlink, currentTime, duration 
         setReplyText('');
         setActiveReply(null);
         setReplyToComment(null);
+        onRefreshReactions?.();
       } else {
         toast.error('Comment failed, please try again');
       }
@@ -350,47 +388,74 @@ function CommentSection({ videoDetails, author, permlink, currentTime, duration 
     <div className="vid-comment-wrap">
       
       
-      {/* Main comment form */}
-      <div className="add-comment-wrap">
-        <div className="comment-header-row">
-          Add a comment:
-          <button className="add-reaction-btn" type="button" title="Add Video Reaction">
+      {/* Tab headers + shared timestamp */}
+      <div className="comment-tabs-bar">
+        <div className="comment-tabs">
+          <button
+            className={`comment-tab${activeTab === 'comment' ? ' active' : ''}`}
+            onClick={() => setActiveTab('comment')}
+          >
+            <MdComment size={14} />
+            Comment
+          </button>
+          <button
+            className={`comment-tab${activeTab === 'react' ? ' active' : ''}`}
+            onClick={() => setActiveTab('react')}
+          >
             <MdVideocam size={14} />
             React
           </button>
         </div>
-        <textarea
-          placeholder="Write your comment here..."
-          className="textarea-box"
-          value={commentInfo}
-          onChange={(e) => setCommentInfo(e.target.value)}
-          onFocus={handleTextareaFocus}
-        />
-        <div className="comment-form-row">
-          <div className="comment-timeline-input">
-            <label htmlFor="comment-timestamp">Timestamp:</label>
-            <input
-              id="comment-timestamp"
-              type="text"
-              className="timeline-input"
-              value={timelineInput}
-              onChange={handleTimelineInputChange}
-              onBlur={handleTimelineInputBlur}
-              placeholder="0:00"
-            />
-          </div>
-          <div className="btn-wrap">
-            <Button text="Cancel" onClick={() => {
-              setCommentInfo('');
-              setReplyToComment(null);
-            }} />
-            <Button text="Comment" prominent onClick={() => {
-              setReplyToComment(null);
-              handlePostComment();
-            }} />
-          </div>
+        <div className="comment-timestamp">
+          <span className="comment-timestamp-label">at</span>
+          <input
+            type="text"
+            className="comment-timestamp-input"
+            value={timelineInput}
+            onChange={handleTimelineInputChange}
+            onBlur={handleTimelineInputBlur}
+            placeholder="0:00"
+          />
         </div>
       </div>
+
+      {/* Comment tab */}
+      {activeTab === 'comment' && (
+        <div className="add-comment-wrap">
+          <textarea
+            placeholder="Write your comment here..."
+            className="textarea-box"
+            value={commentInfo}
+            onChange={(e) => setCommentInfo(e.target.value)}
+            onFocus={handleTextareaFocus}
+          />
+          <div className="comment-form-row">
+            <div className="btn-wrap">
+              <Button text="Cancel" onClick={() => {
+                setCommentInfo('');
+                setReplyToComment(null);
+              }} />
+              <Button text="Comment" prominent onClick={() => {
+                setReplyToComment(null);
+                handlePostComment();
+              }} />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* React tab */}
+      {activeTab === 'react' && (
+        <div className="add-comment-wrap">
+          <ReactVideoTab
+            author={author}
+            permlink={permlink}
+            currentTime={currentTime}
+            formatTime={formatTimeInput}
+            onPosted={() => { setActiveTab('comment'); onRefreshReactions?.(); }}
+          />
+        </div>
+      )}
 
       <h4>{countComments(commentList)} Comments</h4>
 
@@ -430,7 +495,8 @@ function CommentSection({ videoDetails, author, permlink, currentTime, duration 
       setVoteValue={setVoteValue}
       accountData={accountData}
       setAccountData={setAccountData}
-          
+      onSeek={onSeek}
+
         />
       )) )}
     </div>
@@ -465,6 +531,7 @@ function Comment({
       setVoteValue,
       accountData,
       setAccountData,
+      onSeek,
 }) {
   const isReplying = activeReply === comment.permlink;
 
@@ -475,6 +542,9 @@ function Comment({
           <div className="comment-header">
             <AuthorBadge author={comment?.author?.username} noLink />
             <span className="comment-date"><TimeAgo date={comment?.created_at} /></span>
+            {comment?.parentTimestamp != null && (
+              <span className="comment-timestamp-badge" onClick={() => onSeek?.(comment.parentTimestamp)}>at {formatTimeInput(comment.parentTimestamp)}</span>
+            )}
           </div>
           <div className="markdown-view" dangerouslySetInnerHTML={{ __html: processedBody(comment?.body || '', comment?.permlink) }} />
           <div className="comment-action">
@@ -551,11 +621,12 @@ function Comment({
               activeTooltipPermlink={activeTooltipPermlink}
               setActiveTooltipPermlink={setActiveTooltipPermlink}
               weight={weight}
-             setWeight={setWeight}      
+             setWeight={setWeight}
       voteValue={voteValue}
       setVoteValue={setVoteValue}
       accountData={accountData}
       setAccountData={setAccountData}
+      onSeek={onSeek}
             />
           ))}
         </div>

--- a/src/components/playVideo/CommentSection.jsx
+++ b/src/components/playVideo/CommentSection.jsx
@@ -13,7 +13,7 @@ import UpvoteTooltip from '../tooltip/UpvoteTooltip';
 import CommentVoteTooltip from '../tooltip/CommentVoteTooltip';
 import {  toast } from 'sonner'
 import { estimate, getVotePower } from '../../utils/hiveUtils';
-import { filterByReputation } from '../../utils/reputation';
+import { filterByReputation, getUserReputation } from '../../utils/reputation';
 import Button from '../Button/Button';
 import AuthorBadge from '../AuthorBadge/AuthorBadge';
 import UpvoteCount from '../UpvoteCount/UpvoteCount';
@@ -147,8 +147,16 @@ function CommentSection({ videoDetails, author, permlink, currentTime, duration,
       try {
         const replies = await client.call('condenser_api', 'get_content_replies', [author, permlink]);
         const commentsWithChildren = await loadNestedComments(replies);
-        // Filter out spam accounts (negative reputation)
+        // Filter out spam accounts (negative reputation) — also caches reputations
         const filteredComments = await filterByReputation(commentsWithChildren);
+        // Attach cached reputations to comment authors (all cache hits after filtering)
+        const attachRep = async (comments) => {
+          for (const c of comments) {
+            if (c.author?.username) c.author.reputation = await getUserReputation(c.author.username);
+            if (c.children?.length) await attachRep(c.children);
+          }
+        };
+        await attachRep(filteredComments);
         setCommentList(filteredComments);
         
         // Pre-render all comment bodies (createHiveRenderer returns a function directly)
@@ -627,7 +635,7 @@ function Comment({
       <div className="comment">
         <div className="comment-content">
           <div className="comment-header">
-            <AuthorBadge author={comment?.author?.username} noLink />
+            <AuthorBadge author={comment?.author?.username} reputation={comment?.author?.reputation} noLink />
             <span className="comment-date"><TimeAgo date={comment?.created_at} /></span>
             {comment?.parentTimestamp != null && (
               <span className="comment-timestamp-badge" onClick={() => onSeek?.(comment.parentTimestamp)}>at {formatTimeInput(comment.parentTimestamp)}</span>
@@ -641,21 +649,23 @@ function Comment({
               onClick={() => toggleTooltip(comment?.author?.username, comment.permlink, commentIndex)}
             />
             <PayoutAmount amount={comment?.stats?.total_hive_reward} />
-            <Button text="Reply" onClick={() => {
-                setCommentInfo("");
-                setReplyText("")
-                setActiveReply(comment.permlink);
-                setReplyToComment(comment);
-              }} />
-            {comment.hasVideo && (
-              <Link
-                to={`/shorts?v=${comment.shortAuthor || comment.author?.username}/${comment.shortPermlink || comment.permlink}`}
-                className="btn-default comment-shorts-link"
-              >
-                <MdVideocam size={13} />
-                <span>Open in Shorts</span>
-              </Link>
-            )}
+            <div className="comment-action-right">
+              {comment.hasVideo && (
+                <Link
+                  to={`/shorts?v=${comment.shortAuthor || comment.author?.username}/${comment.shortPermlink || comment.permlink}`}
+                  className="comment-shorts-link"
+                >
+                  <MdVideocam size={13} />
+                  <span>Open in Shorts</span>
+                </Link>
+              )}
+              <Button text="Reply" onClick={() => {
+                  setCommentInfo("");
+                  setReplyText("")
+                  setActiveReply(comment.permlink);
+                  setReplyToComment(comment);
+                }} />
+            </div>
             <CommentVoteTooltip
              author={comment?.author?.username}
              permlink={comment.permlink}

--- a/src/components/playVideo/CommentSection.jsx
+++ b/src/components/playVideo/CommentSection.jsx
@@ -21,6 +21,7 @@ import PayoutAmount from '../PayoutAmount/PayoutAmount';
 import { commentWithAioha } from '../../hive-api/aioha';
 import { HIVE_API_NODES } from '../../utils/config';
 import TimeAgo from '../TimeAgo/TimeAgo';
+import { Link } from 'react-router-dom';
 
 const client = new Client(HIVE_API_NODES);
 
@@ -61,7 +62,7 @@ function parseTimeInput(str) {
   return null;
 }
 
-function CommentSection({ videoDetails, author, permlink, currentTime, duration, onSeek, onRefreshReactions }) {
+function CommentSection({ videoDetails, author, permlink, currentTime, duration, onSeek, onPause, onRefreshReactions }) {
   const { user } = useAppStore();
   const [commentInfo, setCommentInfo] = useState('');
   const [activeTab, setActiveTab] = useState('comment'); // 'comment' | 'react'
@@ -212,9 +213,50 @@ function CommentSection({ videoDetails, author, permlink, currentTime, duration,
         const children = await client.call('condenser_api', 'get_content_replies', [comment.author, comment.permlink]);
         const has_voted = comment.active_votes?.some(v => v.voter === user) ?? false;
         let parentTimestamp = null;
+        let hasVideo = false;
+        let shortAuthor = null;
+        let shortPermlink = null;
         try {
           const meta = typeof comment.json_metadata === 'string' ? JSON.parse(comment.json_metadata) : comment.json_metadata;
           if (meta?.parentTimestamp != null) parentTimestamp = meta.parentTimestamp;
+          if (meta?.video?.url || meta?.video?.platform === '3speak') {
+            hasVideo = true;
+            // Try extracting player permlink from video.url
+            const videoUrl = meta.video?.url || '';
+            // Handle full URLs like https://3speak.tv/watch?v=author/perm or https://play.3speak.tv/embed?v=author/perm
+            const urlMatch = videoUrl.match(/[?&]v=([^&\s"']+)/);
+            if (urlMatch) {
+              const cleaned = urlMatch[1].startsWith('@') ? urlMatch[1].slice(1) : urlMatch[1];
+              const parts = cleaned.split('/');
+              if (parts.length >= 2 && parts[0] && parts[1]) {
+                shortAuthor = parts[0];
+                shortPermlink = parts[1];
+              }
+            }
+            // Handle simple @author/permlink format
+            if (!shortAuthor) {
+              const cleaned = videoUrl.startsWith('@') ? videoUrl.slice(1) : videoUrl;
+              const parts = cleaned.split('/');
+              if (parts.length >= 2 && parts[0] && parts[1]) {
+                shortAuthor = parts[0];
+                shortPermlink = parts[1];
+              }
+            }
+          }
+          // Also scan the comment body for 3speak embed/watch URLs
+          if (!shortAuthor && comment.body) {
+            const bodyMatch = comment.body.match(/https?:\/\/[^\s]*3speak[^\s]*[?&]v=([^&\s"')]+)/);
+            if (bodyMatch) {
+              hasVideo = true;
+              const cleaned = bodyMatch[1].startsWith('@') ? bodyMatch[1].slice(1) : bodyMatch[1];
+              const parts = cleaned.split('/');
+              if (parts.length >= 2 && parts[0] && parts[1]) {
+                shortAuthor = parts[0];
+                shortPermlink = parts[1];
+              }
+            }
+          }
+
         } catch (_) {}
         return {
           author: {
@@ -229,6 +271,9 @@ function CommentSection({ videoDetails, author, permlink, currentTime, duration,
           created_at: comment.created,
           body: comment.body,
           parentTimestamp,
+          hasVideo,
+          shortAuthor,
+          shortPermlink,
           stats: {
             num_likes: comment.active_votes?.filter((v) => v.percent > 0).length || 0,
             num_dislikes: comment.active_votes?.filter((v) => v.percent < 0).length || 0,
@@ -244,12 +289,21 @@ function CommentSection({ videoDetails, author, permlink, currentTime, duration,
 
   const processedBody = (content, permlink) => {
     if (!content) return '';
+    let html;
     // Use pre-rendered body if available
     if (permlink && renderedBodies[permlink]) {
-      return renderedBodies[permlink];
+      html = renderedBodies[permlink];
+    } else {
+      // Fallback - return raw content (will be rendered on next fetch)
+      html = content;
     }
-    // Fallback - return raw content (will be rendered on next fetch)
-    return content;
+    // Strip "replied to [timestamp](link)" lines (raw markdown or rendered HTML)
+    html = html
+      .replace(/<p>\s*<sup>\s*replied to\s*<a[^>]*>.*?<\/a>\s*<\/sup>\s*<\/p>/gi, '')
+      .replace(/<sup>\s*replied to\s*<a[^>]*>.*?<\/a>\s*<\/sup>/gi, '')
+      .replace(/\n?<sup>replied to \[.*?\]\([^)]*\)<\/sup>/g, '');
+
+    return html;
   };
 
   const handlePostComment = async (replyTimestamp) => {
@@ -279,13 +333,23 @@ function CommentSection({ videoDetails, author, permlink, currentTime, duration,
         }
       }
 
+      // Append "replied to" timestamp reference if we have a timestamp
+      let body = textToPost;
+      if (metadata.parentTimestamp > 0) {
+        const ts = metadata.parentTimestamp;
+        const tsLabel = formatTimeInput(ts);
+        const baseUrl = window.location.origin;
+        const host = window.location.host;
+        body += `\n<sup>replied to [${tsLabel}](${baseUrl}/watch?v=${author}/${permlink}&t=${ts}) on [${host}](${baseUrl})</sup>`;
+      }
+
       // Use aioha for comment broadcasting (works with all providers: Keychain, HiveAuth, etc.)
       const result = await commentWithAioha(
         parent_author,
         parent_permlink,
         new_permlink,
         '', // title (empty for comments)
-        textToPost,
+        body,
         metadata
       );
 
@@ -460,6 +524,7 @@ function CommentSection({ videoDetails, author, permlink, currentTime, duration,
             currentTime={currentTime}
             formatTime={formatTimeInput}
             onPosted={() => { setActiveTab('comment'); onRefreshReactions?.(); }}
+            onRecordStart={onPause}
           />
         </div>
       )}
@@ -582,6 +647,15 @@ function Comment({
                 setActiveReply(comment.permlink);
                 setReplyToComment(comment);
               }} />
+            {comment.hasVideo && (
+              <Link
+                to={`/shorts?v=${comment.shortAuthor || comment.author?.username}/${comment.shortPermlink || comment.permlink}`}
+                className="btn-default comment-shorts-link"
+              >
+                <MdVideocam size={13} />
+                <span>Open in Shorts</span>
+              </Link>
+            )}
             <CommentVoteTooltip
              author={comment?.author?.username}
              permlink={comment.permlink}
@@ -653,6 +727,7 @@ function Comment({
               currentTime={replyTimestamp ?? currentTime}
               formatTime={formatTimeInput}
               onPosted={() => { setReplyTab('comment'); setActiveReply(null); onRefreshReactions?.(); }}
+              onRecordStart={onPause}
             />
           )}
         </div>

--- a/src/components/playVideo/CommentSection.jsx
+++ b/src/components/playVideo/CommentSection.jsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
 import './CommentSection.scss';
 import './BlogContent.scss';
 import { BiDislike } from 'react-icons/bi';
 import { ImSpinner9 } from 'react-icons/im';
 import { TailChase } from 'ldrs/react';
+import { MdVideocam } from 'react-icons/md';
 import dayjs from 'dayjs';
 import { useAppStore } from '../../lib/store';
 import { Client } from '@hiveio/dhive';
@@ -38,7 +39,28 @@ const getRenderer = async () => {
   return rendererPromise;
 };
 
-function CommentSection({ videoDetails, author, permlink }) {
+function formatTimeInput(seconds) {
+  if (!seconds || isNaN(seconds)) return '0:00';
+  const hrs = Math.floor(seconds / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  const secs = Math.floor(seconds % 60);
+  if (hrs > 0) {
+    return `${hrs}:${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+  }
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+function parseTimeInput(str) {
+  if (!str) return 0;
+  const parts = str.split(':').map(Number);
+  if (parts.some(isNaN)) return null;
+  if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2];
+  if (parts.length === 2) return parts[0] * 60 + parts[1];
+  if (parts.length === 1) return parts[0];
+  return null;
+}
+
+function CommentSection({ videoDetails, author, permlink, currentTime, duration }) {
   const { user } = useAppStore();
   const [commentInfo, setCommentInfo] = useState('');
   const [replyText, setReplyText] = useState("");
@@ -55,6 +77,43 @@ function CommentSection({ videoDetails, author, permlink }) {
       const [accountData, setAccountData] = useState(null);
   // Cache for rendered comment bodies
   const [renderedBodies, setRenderedBodies] = useState({});
+
+  // Timeline position state — auto-follows playhead unless manually edited
+  const [timelineInput, setTimelineInput] = useState('0:00');
+  const [timelineOverride, setTimelineOverride] = useState(false);
+  const prevTimeRef = useRef(0);
+
+  // Auto-update timeline input from playhead position (unless user overrode it)
+  useEffect(() => {
+    if (timelineOverride) return;
+    const rounded = Math.floor(currentTime || 0);
+    if (rounded !== prevTimeRef.current) {
+      prevTimeRef.current = rounded;
+      setTimelineInput(formatTimeInput(rounded));
+    }
+  }, [currentTime, timelineOverride]);
+
+  const handleTimelineInputChange = useCallback((e) => {
+    setTimelineInput(e.target.value);
+    setTimelineOverride(true);
+  }, []);
+
+  const handleTimelineInputBlur = useCallback(() => {
+    // Validate and normalize on blur
+    const parsed = parseTimeInput(timelineInput);
+    if (parsed === null || (duration && parsed > duration)) {
+      // Invalid or out of range — reset to current playhead
+      setTimelineInput(formatTimeInput(Math.floor(currentTime || 0)));
+      setTimelineOverride(false);
+    } else {
+      setTimelineInput(formatTimeInput(parsed));
+    }
+  }, [timelineInput, currentTime, duration]);
+
+  // Reset override when user focuses back on textarea (start following again)
+  const handleTextareaFocus = useCallback(() => {
+    setTimelineOverride(false);
+  }, []);
 
 
       
@@ -293,22 +352,43 @@ function CommentSection({ videoDetails, author, permlink }) {
       
       {/* Main comment form */}
       <div className="add-comment-wrap">
-        <span>Add a comment:</span>
+        <div className="comment-header-row">
+          Add a comment:
+          <button className="add-reaction-btn" type="button" title="Add Video Reaction">
+            <MdVideocam size={14} />
+            React
+          </button>
+        </div>
         <textarea
           placeholder="Write your comment here..."
           className="textarea-box"
           value={commentInfo}
           onChange={(e) => setCommentInfo(e.target.value)}
+          onFocus={handleTextareaFocus}
         />
-        <div className="btn-wrap">
-          <Button text="Cancel" onClick={() => {
-            setCommentInfo('');
-            setReplyToComment(null);
-          }} />
-          <Button text="Comment" prominent onClick={() => {
-            setReplyToComment(null);
-            handlePostComment();
-          }} />
+        <div className="comment-form-row">
+          <div className="comment-timeline-input">
+            <label htmlFor="comment-timestamp">Timestamp:</label>
+            <input
+              id="comment-timestamp"
+              type="text"
+              className="timeline-input"
+              value={timelineInput}
+              onChange={handleTimelineInputChange}
+              onBlur={handleTimelineInputBlur}
+              placeholder="0:00"
+            />
+          </div>
+          <div className="btn-wrap">
+            <Button text="Cancel" onClick={() => {
+              setCommentInfo('');
+              setReplyToComment(null);
+            }} />
+            <Button text="Comment" prominent onClick={() => {
+              setReplyToComment(null);
+              handlePostComment();
+            }} />
+          </div>
         </div>
       </div>
 

--- a/src/components/playVideo/CommentSection.jsx
+++ b/src/components/playVideo/CommentSection.jsx
@@ -252,7 +252,7 @@ function CommentSection({ videoDetails, author, permlink, currentTime, duration,
     return content;
   };
 
-  const handlePostComment = async () => {
+  const handlePostComment = async (replyTimestamp) => {
     const textToPost = replyToComment ? replyText : commentInfo;
 
     if (!textToPost.trim()) return;
@@ -269,6 +269,11 @@ function CommentSection({ videoDetails, author, permlink, currentTime, duration,
       const metadata = { app: '3speak/new-version' };
       if (isReplyingToMainPost) {
         const timestampSec = parseTimeInput(timelineInput);
+        if (timestampSec !== null && timestampSec > 0) {
+          metadata.parentTimestamp = timestampSec;
+        }
+      } else if (replyTimestamp != null) {
+        const timestampSec = typeof replyTimestamp === 'string' ? parseTimeInput(replyTimestamp) : replyTimestamp;
         if (timestampSec !== null && timestampSec > 0) {
           metadata.parentTimestamp = timestampSec;
         }
@@ -298,6 +303,8 @@ function CommentSection({ videoDetails, author, permlink, currentTime, duration,
           permlink: new_permlink,
           created_at: new Date().toISOString(),
           body: textToPost,
+          parentTimestamp: metadata.parentTimestamp ?? null,
+          has_voted: false,
           stats: {
             num_likes: 0,
             num_dislikes: 0,
@@ -496,6 +503,9 @@ function CommentSection({ videoDetails, author, permlink, currentTime, duration,
       accountData={accountData}
       setAccountData={setAccountData}
       onSeek={onSeek}
+      currentTime={currentTime}
+      duration={duration}
+      onRefreshReactions={onRefreshReactions}
 
         />
       )) )}
@@ -532,8 +542,20 @@ function Comment({
       accountData,
       setAccountData,
       onSeek,
+      currentTime,
+      duration,
+      onRefreshReactions,
 }) {
   const isReplying = activeReply === comment.permlink;
+  const [replyTab, setReplyTab] = useState('comment');
+
+  // Inherit timestamp from the parent comment (not editable)
+  const replyTimestamp = comment?.parentTimestamp ?? null;
+
+  // Reset reply tab when reply opens
+  useEffect(() => {
+    if (isReplying) setReplyTab('comment');
+  }, [isReplying]);
 
   return (
     <div className="comment-container" style={{ marginLeft: depth > 0 ? '40px' : '0px' }} >
@@ -581,18 +603,58 @@ function Comment({
       </div>
 
       {isReplying && (
-        <div className="add-comment-wrap sub">
-          <span>Reply:</span>
-          <textarea
-            placeholder="Write your reply here..."
-            className="textarea-box sub"
-            value={replyText}
-            onChange={(e) => setReplyText(e.target.value)}
-          />
-          <div className="btn-wrap">
-            <Button text="Cancel" onClick={() => {setReplyText(""); setActiveReply(null)}} />
-            <Button text="Comment" prominent onClick={handlePostComment} />
+        <div className="add-comment-wrap sub" style={{ marginLeft: '40px' }}>
+          {/* Tab headers + timestamp */}
+          <div className="comment-tabs-bar">
+            <div className="comment-tabs">
+              <button
+                className={`comment-tab${replyTab === 'comment' ? ' active' : ''}`}
+                onClick={() => setReplyTab('comment')}
+              >
+                <MdComment size={14} />
+                Comment
+              </button>
+              <button
+                className={`comment-tab${replyTab === 'react' ? ' active' : ''}`}
+                onClick={() => setReplyTab('react')}
+              >
+                <MdVideocam size={14} />
+                React
+              </button>
+            </div>
+            {replyTimestamp != null && (
+              <div className="comment-timestamp">
+                <span className="comment-timestamp-label">at {formatTimeInput(replyTimestamp)}</span>
+              </div>
+            )}
           </div>
+
+          {/* Comment tab */}
+          {replyTab === 'comment' && (
+            <>
+              <textarea
+                placeholder="Write your reply here..."
+                className="textarea-box sub"
+                value={replyText}
+                onChange={(e) => setReplyText(e.target.value)}
+              />
+              <div className="btn-wrap">
+                <Button text="Cancel" onClick={() => {setReplyText(""); setActiveReply(null)}} />
+                <Button text="Comment" prominent onClick={() => handlePostComment(replyTimestamp)} />
+              </div>
+            </>
+          )}
+
+          {/* React tab */}
+          {replyTab === 'react' && (
+            <ReactVideoTab
+              author={comment?.author?.username}
+              permlink={comment.permlink}
+              currentTime={replyTimestamp ?? currentTime}
+              formatTime={formatTimeInput}
+              onPosted={() => { setReplyTab('comment'); setActiveReply(null); onRefreshReactions?.(); }}
+            />
+          )}
         </div>
       )}
 
@@ -627,6 +689,9 @@ function Comment({
       accountData={accountData}
       setAccountData={setAccountData}
       onSeek={onSeek}
+      currentTime={currentTime}
+      duration={duration}
+      onRefreshReactions={onRefreshReactions}
             />
           ))}
         </div>

--- a/src/components/playVideo/CommentSection.scss
+++ b/src/components/playVideo/CommentSection.scss
@@ -71,6 +71,18 @@
       color: var(--text-secondary);
       font-weight: 500;
     }
+    .comment-timestamp-badge {
+      margin-left: auto;
+      font-size: 11px;
+      font-weight: 400;
+      color: var(--text-muted);
+      white-space: nowrap;
+      cursor: pointer;
+
+      &:hover {
+        color: var(--text-secondary);
+      }
+    }
   }
   .comment-action {
     display: flex;
@@ -90,77 +102,90 @@
   gap: 8px;
 }
 
-// Header row: "Add a comment:" on left, React button on right
-.comment-header-row {
+// Give the tab content some breathing room
+.comment-tabs-bar + .add-comment-wrap {
+  padding-top: 10px;
+}
+
+// Tab bar: tabs on left, timestamp on right
+.comment-tabs-bar {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  border-bottom: 2px solid var(--border-light, rgba(255, 255, 255, 0.1));
 }
 
-// Row below textarea: timestamp input on left, buttons on right
-.comment-form-row {
+.comment-tabs {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-top: 8px;
-  flex-wrap: wrap;
+  gap: 0;
 }
 
-.comment-timeline-input {
+.comment-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  color: var(--text-secondary, #aaa);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    color: var(--text-primary, #fff);
+  }
+
+  &.active {
+    color: var(--accent-primary, #e53935);
+    border-bottom-color: var(--accent-primary, #e53935);
+  }
+}
+
+// Prominent timestamp — right side of tab bar
+.comment-timestamp {
   display: flex;
   align-items: center;
   gap: 6px;
-
-  label {
-    font-size: 12px;
-    font-weight: 500;
-    color: var(--text-secondary);
-    white-space: nowrap;
-  }
-
-  .timeline-input {
-    width: 64px;
-    padding: 4px 8px;
-    font-size: 12px;
-    font-weight: 500;
-    font-family: inherit;
-    color: var(--text-primary);
-    background: var(--card-bg, #1a1a2e);
-    border: 1px solid var(--border-light, rgba(255, 255, 255, 0.1));
-    border-radius: 6px;
-    text-align: center;
-    outline: none;
-    transition: border-color 0.15s ease;
-
-    &:focus {
-      border-color: var(--accent-primary, #e53935);
-    }
-  }
+  padding: 0 4px 2px 0;
 }
 
-.add-reaction-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 5px 10px;
-  font-size: 12px;
+.comment-timestamp-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary, #aaa);
+}
+
+.comment-timestamp-input {
+  width: 72px;
+  padding: 5px 8px;
+  font-size: 14px;
   font-weight: 600;
   font-family: inherit;
-  color: #fff;
-  background: var(--accent-primary, #e53935);
-  border: none;
+  color: var(--text-primary, #fff);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1.5px solid var(--border-light, #333);
   border-radius: 6px;
-  cursor: pointer;
-  white-space: nowrap;
-  line-height: 1;
-  transition: opacity 0.15s ease, transform 0.15s ease;
+  text-align: center;
+  outline: none;
+  transition: all 0.15s ease;
 
-  &:hover {
-    opacity: 0.9;
-  }
-
-  &:active {
-    transform: scale(0.97);
+  &:focus {
+    background: rgba(255, 255, 255, 0.1);
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.1);
   }
 }
+
+// Row below textarea: buttons on right
+.comment-form-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}
+

--- a/src/components/playVideo/CommentSection.scss
+++ b/src/components/playVideo/CommentSection.scss
@@ -91,21 +91,26 @@
     margin: 8px 0;
     font-size: 13px;
     color: var(--text-secondary);
-    .btn-default {
-      margin-left: auto;
-    }
+  }
+
+  .comment-action-right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-left: auto;
   }
 
   .comment-shorts-link {
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    font-size: 11px;
-    font-weight: 500;
+    font-size: 13px;
+    font-weight: 400;
     color: var(--text-secondary, #aaa);
     text-decoration: none;
-    padding: 2px 8px;
-    border-radius: 4px;
+    padding: 4px 16px;
+    border: 1px solid var(--border-light);
+    border-radius: 6px;
     white-space: nowrap;
     transition: background 0.15s ease, color 0.15s ease;
 

--- a/src/components/playVideo/CommentSection.scss
+++ b/src/components/playVideo/CommentSection.scss
@@ -88,5 +88,79 @@
 .btn-wrap {
   display: flex;
   gap: 8px;
+}
+
+// Header row: "Add a comment:" on left, React button on right
+.comment-header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+// Row below textarea: timestamp input on left, buttons on right
+.comment-form-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
   margin-top: 8px;
+  flex-wrap: wrap;
+}
+
+.comment-timeline-input {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+
+  label {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    white-space: nowrap;
+  }
+
+  .timeline-input {
+    width: 64px;
+    padding: 4px 8px;
+    font-size: 12px;
+    font-weight: 500;
+    font-family: inherit;
+    color: var(--text-primary);
+    background: var(--card-bg, #1a1a2e);
+    border: 1px solid var(--border-light, rgba(255, 255, 255, 0.1));
+    border-radius: 6px;
+    text-align: center;
+    outline: none;
+    transition: border-color 0.15s ease;
+
+    &:focus {
+      border-color: var(--accent-primary, #e53935);
+    }
+  }
+}
+
+.add-reaction-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  font-family: inherit;
+  color: #fff;
+  background: var(--accent-primary, #e53935);
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  white-space: nowrap;
+  line-height: 1;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+
+  &:hover {
+    opacity: 0.9;
+  }
+
+  &:active {
+    transform: scale(0.97);
+  }
 }

--- a/src/components/playVideo/CommentSection.scss
+++ b/src/components/playVideo/CommentSection.scss
@@ -95,6 +95,25 @@
       margin-left: auto;
     }
   }
+
+  .comment-shorts-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--text-secondary, #aaa);
+    text-decoration: none;
+    padding: 2px 8px;
+    border-radius: 4px;
+    white-space: nowrap;
+    transition: background 0.15s ease, color 0.15s ease;
+
+    &:hover {
+      color: var(--text-primary, #fff);
+      background: rgba(255, 255, 255, 0.08);
+    }
+  }
 }
 
 .btn-wrap {

--- a/src/components/playVideo/CommentSection.scss
+++ b/src/components/playVideo/CommentSection.scss
@@ -180,6 +180,15 @@
   }
 }
 
+// Compact reply variant — constrain to parent width despite the margin-left inset
+.add-comment-wrap.sub {
+  max-width: calc(100% - 40px);
+
+  .comment-tabs-bar {
+    border-bottom-width: 1px;
+  }
+}
+
 // Row below textarea: buttons on right
 .comment-form-row {
   display: flex;

--- a/src/components/playVideo/PlayVideo.jsx
+++ b/src/components/playVideo/PlayVideo.jsx
@@ -363,9 +363,11 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
                     currentTime={videoControls.currentTime}
                     duration={videoControls.duration}
                     isPlaying={videoControls.isPlaying}
+                    isMuted={videoControls.isMuted}
                     isFullscreen={videoControls.isFullscreen}
                     isVisible={videoControls.isVisible}
                     onTogglePlay={videoControls.onTogglePlay}
+                    onToggleMute={videoControls.onToggleMute}
                     onSeekBackward={videoControls.onSeekBackward}
                     onSeekForward={videoControls.onSeekForward}
                     onSeek={videoControls.onSeek}
@@ -510,6 +512,8 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
           author={author}
           permlink={permlink}
           setIsVoted={setIsVoted}
+          currentTime={videoControls?.currentTime}
+          duration={videoControls?.duration}
         />
       </div>
       

--- a/src/components/playVideo/PlayVideo.jsx
+++ b/src/components/playVideo/PlayVideo.jsx
@@ -14,6 +14,7 @@ import BlogContent from "./BlogContent";
 import CommentSection from "./CommentSection";
 import { useAppStore } from '../../lib/store';
 import { estimate, getUersContent, getVotePower } from "../../utils/hiveUtils";
+import { getUserReputation } from "../../utils/reputation";
 import ToolTip from "../tooltip/ToolTip";
 import { ImSpinner9 } from "react-icons/im";
 import { useNavigate } from "react-router-dom";
@@ -23,7 +24,7 @@ import { toast } from 'sonner';
 import { TailChase } from 'ldrs/react';
 import 'ldrs/react/TailChase.css';
 import { getFollowers, getRelationshipBetweenAccounts } from "../../hive-api/api";
-import UpvoteTooltip from "../tooltip/UpvoteTooltip";
+import CommentVoteTooltip from "../tooltip/CommentVoteTooltip";
 import axios from "axios";
 import { FEED_URL, PLAYER_URL, HIVE_API_URL } from '../../utils/config';
 import { followWithAioha, isLoggedIn } from "../../hive-api/aioha";
@@ -68,6 +69,7 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
   const [isRemovingWatchLater, setIsRemovingWatchLater] = useState(false);
   const [communityData, setCommunityData] = useState(null);
   const [isFollowing, setIsFollowing] = useState(false);
+  const [authorReputation, setAuthorReputation] = useState(null);
 
   // Watch Later detection
   const { data: myPlaylists = [], refetch: refetchPlaylists } = useMyPlaylists({ enabled: !!user });
@@ -234,12 +236,13 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
     fetchAccountData();
   }, [user, calculateVoteValue, weight]);
 
-  // Effect: Fetch speak data and followers (only when author/permlink changes)
+  // Effect: Fetch speak data, followers, and reputation (only when author/permlink changes)
   useEffect(() => {
     if (!author || !permlink) return;
-    
+
     speakWatchData();
     getFollowersCount(author);
+    getUserReputation(author).then(rep => setAuthorReputation(rep)).catch(() => {});
   }, [author, permlink, speakWatchData, getFollowersCount]);
 
   // Effect: Check if current user follows the author
@@ -416,6 +419,7 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
           <div className="badges-row">
             <AuthorBadge
               author={videoDetails?.author?.id}
+              reputation={authorReputation}
               followersCount={followData?.follower_count}
               showFollow={author !== user}
               isFollowing={isFollowing}
@@ -498,19 +502,22 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
                 </>
               )}
 
-              <UpvoteTooltip
+              <CommentVoteTooltip
                 showTooltip={showTooltip}
                 setShowTooltip={setShowTooltip}
                 author={author}
                 permlink={permlink}
-                setIsVoted={setIsVoted}
-                setOptimisticVoteCount={setOptimisticVoteCount}
                 weight={weight}
                 setWeight={setWeight}
                 voteValue={voteValue}
                 setVoteValue={setVoteValue}
-                setAccountData={setAccountData}
                 accountData={accountData}
+                setAccountData={setAccountData}
+                compact
+                onVoteSuccess={(a, p, isNewVote) => {
+                  setIsVoted(true);
+                  if (isNewVote) setOptimisticVoteCount(prev => prev + 1);
+                }}
               />
             </div>
           </div>

--- a/src/components/playVideo/PlayVideo.jsx
+++ b/src/components/playVideo/PlayVideo.jsx
@@ -5,7 +5,7 @@ import ViewCount from "../ViewCount/ViewCount";
 import { LuTimer } from "react-icons/lu";
 import UpvoteCount from "../UpvoteCount/UpvoteCount";
 import PayoutAmount from "../PayoutAmount/PayoutAmount";
-import { useEffect, useState, useCallback, useMemo } from "react";
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import { useQuery } from "@apollo/client";
 import { GET_PROFILE } from "../../graphql/queries";
 import dayjs from "dayjs";
@@ -27,7 +27,7 @@ import UpvoteTooltip from "../tooltip/UpvoteTooltip";
 import axios from "axios";
 import { FEED_URL, PLAYER_URL, HIVE_API_URL } from '../../utils/config';
 import { followWithAioha, isLoggedIn } from "../../hive-api/aioha";
-import { MdPlaylistAdd, MdWatchLater } from "react-icons/md";
+import { MdPlaylistAdd, MdWatchLater, MdKeyboardArrowDown, MdKeyboardArrowUp } from "react-icons/md";
 import AddToPlaylistModal from "../AddToPlaylistModal/AddToPlaylistModal";
 import VideoPlaylists from "../VideoPlaylists/VideoPlaylists";
 import PlaylistBar from "../PlaylistBar/PlaylistBar";
@@ -39,11 +39,17 @@ import Button from "../Button/Button";
 
 dayjs.extend(relativeTime);
 
-const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlaylist, videoControls }) => {
+const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlaylist, videoControls, mobileReactionPanel }) => {
   const { user, authenticated } = useAppStore();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  
+
+  const lastTouchRef = useRef(0); // prevent touch+mouse double-fire
+
+  // Mobile collapsible details
+  const [mobileDetailsExpanded, setMobileDetailsExpanded] = useState(false);
+  const [descriptionExpanded, setDescriptionExpanded] = useState(false);
+
   // State
   const [openTooltip, setOpenToolTip] = useState(false);
   const [tooltipVoters, setTooltipVoters] = useState([]);
@@ -356,8 +362,19 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
                 <>
                   <div
                     className="video-interact-overlay"
-                    onMouseMove={videoControls.onMouseMove}
-                    onClick={videoControls.onTogglePlay}
+                    onMouseMove={() => {
+                      if (window.innerWidth > 767) videoControls.onMouseMove();
+                    }}
+                    onMouseDown={() => {
+                      if (Date.now() - lastTouchRef.current < 500) return;
+                      if (window.innerWidth <= 767) videoControls.onToggleControls();
+                      else videoControls.onTogglePlay();
+                    }}
+                    onTouchStart={(e) => {
+                      lastTouchRef.current = Date.now();
+                      e.preventDefault();
+                      videoControls.onToggleControls();
+                    }}
                   />
                   <VideoControls
                     currentTime={videoControls.currentTime}
@@ -384,8 +401,17 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
             </div>
           )}
 
-          <h3>{videoDetails?.title}</h3>
-          
+          <div className="video-title-row">
+            <h3>{videoDetails?.title}</h3>
+            <button
+              className="mobile-title-toggle"
+              onClick={() => setMobileDetailsExpanded(prev => !prev)}
+            >
+              {mobileDetailsExpanded ? <MdKeyboardArrowUp size={20} /> : <MdKeyboardArrowDown size={20} />}
+            </button>
+          </div>
+
+          <div className={`video-details-collapsible${mobileDetailsExpanded ? '' : ' collapsed'}`}>
           <div className="badges-row">
             <AuthorBadge
               author={videoDetails?.author?.id}
@@ -418,7 +444,7 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
               ))}
             </div>
           </div>
-          
+
           <div className="play-video-info">
             <div className="wrap-left">
               <ViewCount views={view} author={author} permlink={permlink} size={13} />
@@ -487,7 +513,6 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
               />
             </div>
           </div>
-        </div>
 
         {/* Show PlaylistBar when watching from a playlist, otherwise show VideoPlaylists */}
         {playlistData ? (
@@ -502,10 +527,27 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
         )}
 
         <div className="description-wrap">
-          <div className="blog-content">
-            <BlogContent author={author} permlink={permlink} />
+          <div className={`description-collapsible${descriptionExpanded ? '' : ' collapsed'}`}>
+            <div className="blog-content">
+              <BlogContent author={author} permlink={permlink} />
+            </div>
           </div>
+          <button
+            className="description-toggle-btn"
+            onClick={() => setDescriptionExpanded(prev => !prev)}
+          >
+            {descriptionExpanded ? 'Show less' : 'Show more'}
+          </button>
         </div>
+        </div>{/* end video-details-collapsible */}
+        </div>{/* end top-container */}
+
+        {/* Mobile reactions slot — between description and comments */}
+        {mobileReactionPanel && (
+          <div className="mobile-reactions-slot">
+            {mobileReactionPanel}
+          </div>
+        )}
 
         <CommentSection
           videoDetails={videoDetails}
@@ -514,6 +556,8 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
           setIsVoted={setIsVoted}
           currentTime={videoControls?.currentTime}
           duration={videoControls?.duration}
+          onSeek={videoControls?.onSeek}
+          onRefreshReactions={videoControls?.onRefreshReactions}
         />
       </div>
       
@@ -566,6 +610,7 @@ PlayVideo.propTypes = {
     currentIndex: PropTypes.number,
   }),
   onClosePlaylist: PropTypes.func,
+  mobileReactionPanel: PropTypes.node,
 };
 
 export default PlayVideo;

--- a/src/components/playVideo/PlayVideo.jsx
+++ b/src/components/playVideo/PlayVideo.jsx
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import "./PlayVideo.scss";
+import VideoControls from "../VideoControls/VideoControls";
 import ViewCount from "../ViewCount/ViewCount";
 import { LuTimer } from "react-icons/lu";
 import UpvoteCount from "../UpvoteCount/UpvoteCount";
@@ -38,7 +39,7 @@ import Button from "../Button/Button";
 
 dayjs.extend(relativeTime);
 
-const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlaylist }) => {
+const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlaylist, videoControls }) => {
   const { user, authenticated } = useAppStore();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -337,7 +338,7 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
           {(author && permlink) ? (
             <div className="video-iframe-wrapper">
               <iframe
-                src={`${PLAYER_URL}/watch?v=${author}/${permlink}&layout=desktop&mode=iframe`}
+                src={`${PLAYER_URL}/watch?v=${author}/${permlink}&layout=desktop&mode=iframe&controls=0`}
                 style={{
                   position: "absolute",
                   top: 0,
@@ -351,6 +352,29 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
                 scrolling="no"
                 allowFullScreen
               />
+              {videoControls && (
+                <>
+                  <div
+                    className="video-interact-overlay"
+                    onMouseMove={videoControls.onMouseMove}
+                    onClick={videoControls.onTogglePlay}
+                  />
+                  <VideoControls
+                    currentTime={videoControls.currentTime}
+                    duration={videoControls.duration}
+                    isPlaying={videoControls.isPlaying}
+                    isFullscreen={videoControls.isFullscreen}
+                    isVisible={videoControls.isVisible}
+                    onTogglePlay={videoControls.onTogglePlay}
+                    onSeekBackward={videoControls.onSeekBackward}
+                    onSeekForward={videoControls.onSeekForward}
+                    onSeek={videoControls.onSeek}
+                    onToggleFullscreen={videoControls.onToggleFullscreen}
+                    markers={videoControls.markers}
+                    onMarkerSelect={videoControls.onMarkerSelect}
+                  />
+                </>
+              )}
             </div>
           ) : (
             <div className="video-loader">

--- a/src/components/playVideo/PlayVideo.jsx
+++ b/src/components/playVideo/PlayVideo.jsx
@@ -391,6 +391,7 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
                     onToggleFullscreen={videoControls.onToggleFullscreen}
                     markers={videoControls.markers}
                     onMarkerSelect={videoControls.onMarkerSelect}
+                    onReactToMoment={videoControls.onReactToMoment}
                   />
                 </>
               )}
@@ -558,6 +559,7 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
           duration={videoControls?.duration}
           onSeek={videoControls?.onSeek}
           onRefreshReactions={videoControls?.onRefreshReactions}
+          onPause={videoControls?.onPause}
         />
       </div>
       

--- a/src/components/playVideo/PlayVideo.scss
+++ b/src/components/playVideo/PlayVideo.scss
@@ -1,10 +1,12 @@
 @use "../../mixins.scss" as mix;
 .play-video{
     flex-basis: 69%;
-    // max-width: 69%; // Prevents overflow
+    max-width: 69%;
+    min-width: 0;
     @include mix.respond(phone) {
         flex-basis: 100%;
         width: 100%;
+        max-width: 100%;
       }
     
     video{
@@ -287,6 +289,16 @@
   height: 100%;
   border: none;
   overflow: hidden; // prevent inside scroll
+}
+
+.video-interact-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 5;
+  cursor: pointer;
 }
 
 

--- a/src/components/playVideo/PlayVideo.scss
+++ b/src/components/playVideo/PlayVideo.scss
@@ -407,18 +407,27 @@
         color: var(--text-primary);
         transition: background-color 0.3s ease;
         overflow: hidden;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
 
         .description-collapsible {
+            width: 100%;
+
             &.collapsed {
                 max-height: 0;
                 overflow: hidden;
+
+                @include mix.respond(desktop) {
+                    max-height: none;
+                    overflow: visible;
+                }
             }
         }
 
         .description-toggle-btn {
-            display: block;
-            width: 100%;
-            padding: 8px;
+            display: inline-block;
+            padding: 8px 16px;
             border: none;
             background: transparent;
             color: var(--text-secondary);
@@ -430,6 +439,10 @@
 
             &:hover {
                 color: var(--text-primary);
+            }
+
+            @include mix.respond(desktop) {
+                display: none;
             }
         }
     }

--- a/src/components/playVideo/PlayVideo.scss
+++ b/src/components/playVideo/PlayVideo.scss
@@ -19,6 +19,10 @@
         border-radius: 10px;
         box-shadow: var(--card-shadow);
         transition: background-color 0.3s ease, box-shadow 0.3s ease;
+
+        @include mix.respond(phone) {
+            display: contents;
+        }
         .video-loader {
             display: flex;
             align-items: center;
@@ -37,6 +41,66 @@
   }
           }
           
+        .video-title-row {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            gap: 6px;
+            margin-top: 10px;
+
+            @include mix.respond(phone) {
+                margin-top: 0;
+                padding: 8px 10px;
+                background-color: var(--card-bg);
+            }
+
+            h3 {
+                margin: 0;
+                font-weight: 600;
+                font-size: 16px;
+                color: var(--text-primary);
+                flex: 1;
+                min-width: 0;
+                @include mix.respond(phone) {
+                    font-size: 14px;
+                }
+            }
+        }
+
+        .mobile-title-toggle {
+            display: none;
+            align-items: center;
+            justify-content: center;
+            width: 28px;
+            height: 28px;
+            flex-shrink: 0;
+            border: none;
+            border-radius: 50%;
+            background: rgba(255, 255, 255, 0.1);
+            color: var(--text-primary);
+            cursor: pointer;
+            transition: background 0.2s ease;
+
+            &:hover {
+                background: rgba(255, 255, 255, 0.2);
+            }
+
+            @include mix.respond(phone) {
+                display: flex;
+            }
+        }
+
+        .video-details-collapsible {
+            @include mix.respond(phone) {
+                padding: 0 10px 10px;
+                background-color: var(--card-bg);
+
+                &.collapsed {
+                    display: none;
+                }
+            }
+        }
+
         h3{
             margin-top: 10px;
             font-weight: 600;
@@ -279,6 +343,13 @@
   padding-top: 56.25%; // 16:9 ratio
   overflow: hidden; // stops scrollbars
   background: #000;
+
+  @include mix.respond(phone) {
+    position: sticky;
+    top: 50px; // below nav bar
+    z-index: 9;
+    border-radius: 0;
+  }
 }
 
 .video-iframe-wrapper iframe {
@@ -330,13 +401,37 @@
 
     .description-wrap{
         margin-top: 10px;
-        // padding: 20px;
         border-radius: 10px;
         background-color: var(--card-bg);
-        border-radius: 10px;
         box-shadow: var(--card-shadow);
         color: var(--text-primary);
         transition: background-color 0.3s ease;
+        overflow: hidden;
+
+        .description-collapsible {
+            &.collapsed {
+                max-height: 0;
+                overflow: hidden;
+            }
+        }
+
+        .description-toggle-btn {
+            display: block;
+            width: 100%;
+            padding: 8px;
+            border: none;
+            background: transparent;
+            color: var(--text-secondary);
+            font-size: 13px;
+            font-weight: 500;
+            cursor: pointer;
+            text-align: center;
+            transition: color 0.2s ease;
+
+            &:hover {
+                color: var(--text-primary);
+            }
+        }
     }
 
     // .blog-content {
@@ -431,7 +526,14 @@
         from { transform: rotate(0deg); }
         to { transform: rotate(360deg); }
       }
-    
 
+    // Mobile reactions slot — hidden on desktop, shown on mobile
+    .mobile-reactions-slot {
+        display: none;
+        margin-top: 10px;
 
+        @include mix.respond(phone) {
+            display: block;
+        }
+    }
 }

--- a/src/components/playVideo/PlayVideo.scss
+++ b/src/components/playVideo/PlayVideo.scss
@@ -165,7 +165,7 @@
             align-items: center;
             gap: 6px;
             width: fit-content;
-            padding: 3px 10px 3px 3px;
+            padding: 1px 10px 1px 1px;
             background: var(--bg-tertiary);
             border: 1px solid var(--border-light);
             border-radius: 20px;
@@ -178,8 +178,8 @@
             }
 
             img {
-                width: 26px;
-                height: 26px;
+                width: 30px;
+                height: 30px;
                 border-radius: 50%;
                 object-fit: cover;
             }

--- a/src/components/playVideo/PlayVideo.scss
+++ b/src/components/playVideo/PlayVideo.scss
@@ -370,22 +370,27 @@
             // color: #fff;
             &.sub{
                 border-radius: 12px;
+
+                > span {
+                    display: block;
+                    font-size: 14px;
+                    font-weight: 600;
+                    padding: 3px 20px;
+                    border-radius: 12px 12px 0 0;
+                    background-color: var(--bg-tertiary);
+                    color: var(--text-primary);
+                }
             }
-        span{
-            display: block;
+        .comment-header-row {
             margin-top: 10px;
-            // margin-bottom: 14px;
             font-size: 14px;
             font-weight: 600;
-            padding-left: 20px;
-            padding-top: 3px;
-            padding-bottom: 3px;
+            padding: 3px 20px;
             border-radius: 10px 10px 0px 0px;
             box-sizing: border-box;
             background-color: var(--bg-tertiary);
             color: var(--text-primary);
-
-            width: 100% ;
+            width: 100%;
         }
         .textarea-box{
             width: 100%;

--- a/src/components/recommended/Recommended.scss
+++ b/src/components/recommended/Recommended.scss
@@ -1,10 +1,7 @@
 @use "../../mixins.scss" as mix;
 
 .recommended {
-  flex-basis: 30%;
-  @include mix.respond(phone) {
-    display: none;
-  }
+  width: 100%;
 
   .side-video-link {
     text-decoration: none;

--- a/src/components/tooltip/CommentVoteTooltip.jsx
+++ b/src/components/tooltip/CommentVoteTooltip.jsx
@@ -1,113 +1,217 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
 import './UpvoteTooltip.scss';
 import { useAppStore } from '../../lib/store';
-import { IoChevronUpCircleOutline } from 'react-icons/io5';
+import { X, ChevronUp } from 'lucide-react';
 import { toast } from 'sonner';
-import { estimate, getUersContent, getVotePower } from '../../utils/hiveUtils';
+import { getUersContent, getVotePower, getDynamicProps, votingPower, accountVestingShares, calculateVoteRshares } from '../../utils/hiveUtils';
 import { TailChase } from 'ldrs/react';
 import 'ldrs/react/TailChase.css';
 import { Orbit } from 'ldrs/react';
 import 'ldrs/react/Orbit.css';
 import { voteWithAioha, isLoggedIn } from '../../hive-api/aioha';
 
+// Pure-math vote estimation — no API calls
+function estimateLocal(account, dynamicProps, percent) {
+  if (!account || !dynamicProps) return '0.000';
+  const { fundRecentClaims, fundRewardBalance, base, quote } = dynamicProps;
+  if (!fundRecentClaims || !fundRewardBalance || !base || !quote) return '0.000';
+
+  const sign = percent < 0 ? -1 : 1;
+  const userEffectiveVests = accountVestingShares(account);
+  const userVotingPower = votingPower(account) * 100;
+  const voteWeight = Math.abs(percent) * 100;
+  const voteEffectiveShares = calculateVoteRshares(userEffectiveVests, userVotingPower * (voteWeight / 10000));
+  const voteValue = (voteEffectiveShares / fundRecentClaims) * fundRewardBalance * (base / quote);
+  return (Math.max(voteValue, 0) * sign).toFixed(3);
+}
+
 const CommentVoteTooltip = ({
   author,
   permlink,
   showTooltip,
   setShowTooltip,
-  weight,
-  setWeight,
+  weight: parentWeight,
+  setWeight: setParentWeight,
   setCommentList,
-  voteValue,
-  setVoteValue,
+  voteValue: parentVoteValue,
+  setVoteValue: setParentVoteValue,
   accountData,
   setAccountData,
   setActiveTooltipPermlink,
-  onVoteSuccess // Optional callback for when vote succeeds (used by Short.jsx for main post)
+  onVoteSuccess,
+  compact
 }) => {
   const { user, authenticated } = useAppStore();
   const [isLoading, setIsLoading] = useState(false);
-  const [isCalculating, setIsCalculating] = useState(false);
+  const [initializing, setInitializing] = useState(false);
+  const isLoadingRef = useRef(false);
   const tooltipRef = useRef(null);
-  const isLoadingRef = useRef(false); // Track loading state for click outside handler
 
-  // Keep isLoadingRef in sync with isLoading state
+  // DOM refs for custom slider
+  const sliderContainerRef = useRef(null);
+  const fillRef = useRef(null);
+  const thumbRef = useRef(null);
+  const labelRef = useRef(null);
+  const valueRef = useRef(null);
+
+  // Current weight lives in a ref — no React state during drag
+  const weightRef = useRef(parentWeight);
+
+  // Cached data for local estimation (fetched once on open)
+  const cachedAccountRef = useRef(null);
+  const cachedDynamicPropsRef = useRef(null);
+
+  // Update all DOM elements for a given weight (no React re-render)
+  const updateSliderDOM = useCallback((w) => {
+    weightRef.current = w;
+    if (labelRef.current) labelRef.current.textContent = `Vote Weight: ${w}%`;
+    if (fillRef.current) fillRef.current.style.width = `${w}%`;
+    if (thumbRef.current) thumbRef.current.style.left = `${w}%`;
+    if (valueRef.current && cachedAccountRef.current && cachedDynamicPropsRef.current) {
+      valueRef.current.textContent = `$${estimateLocal(cachedAccountRef.current, cachedDynamicPropsRef.current, w)}`;
+    }
+  }, []);
+
+  // Build the custom div-based slider when popup opens
+  useEffect(() => {
+    if (!showTooltip) return;
+    const container = sliderContainerRef.current;
+    if (!container) return;
+
+    weightRef.current = parentWeight;
+    if (labelRef.current) labelRef.current.textContent = `Vote Weight: ${parentWeight}%`;
+
+    // Build track → fill + thumb
+    const track = document.createElement('div');
+    track.className = 'vote-slider-track';
+
+    const fill = document.createElement('div');
+    fill.className = 'vote-slider-fill';
+    fill.style.width = `${parentWeight}%`;
+
+    const thumb = document.createElement('div');
+    thumb.className = 'vote-slider-thumb';
+    thumb.style.left = `${parentWeight}%`;
+
+    track.appendChild(fill);
+    track.appendChild(thumb);
+
+    fillRef.current = fill;
+    thumbRef.current = thumb;
+
+    // Convert mouse/touch clientX → 1–100 percent
+    const getPct = (clientX) => {
+      const rect = track.getBoundingClientRect();
+      const raw = ((clientX - rect.left) / rect.width) * 100;
+      return Math.round(Math.max(1, Math.min(100, raw)));
+    };
+
+    let dragging = false;
+
+    const onPointerDown = (clientX) => {
+      if (isLoadingRef.current) return;
+      dragging = true;
+      const pct = getPct(clientX);
+      updateSliderDOM(pct);
+    };
+
+    const onPointerMove = (clientX) => {
+      if (!dragging) return;
+      const pct = getPct(clientX);
+      updateSliderDOM(pct);
+    };
+
+    const onPointerUp = () => { dragging = false; };
+
+    // Mouse events
+    const onMouseDown = (e) => { e.preventDefault(); onPointerDown(e.clientX); };
+    const onMouseMove = (e) => { onPointerMove(e.clientX); };
+    const onMouseUp = () => { onPointerUp(); };
+
+    // Touch events
+    const onTouchStart = (e) => { onPointerDown(e.touches[0].clientX); };
+    const onTouchMove = (e) => { if (dragging) { e.preventDefault(); onPointerMove(e.touches[0].clientX); } };
+    const onTouchEnd = () => { onPointerUp(); };
+
+    track.addEventListener('mousedown', onMouseDown);
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+
+    track.addEventListener('touchstart', onTouchStart, { passive: true });
+    document.addEventListener('touchmove', onTouchMove, { passive: false });
+    document.addEventListener('touchend', onTouchEnd);
+
+    container.appendChild(track);
+
+    return () => {
+      track.removeEventListener('mousedown', onMouseDown);
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      track.removeEventListener('touchstart', onTouchStart);
+      document.removeEventListener('touchmove', onTouchMove);
+      document.removeEventListener('touchend', onTouchEnd);
+      if (container.contains(track)) container.removeChild(track);
+      fillRef.current = null;
+      thumbRef.current = null;
+    };
+  }, [showTooltip]); // eslint-disable-line react-hooks/exhaustive-deps
+
   useEffect(() => {
     isLoadingRef.current = isLoading;
   }, [isLoading]);
 
-  // Close tooltip on outside click (but not while voting is in progress)
+  // Close on Escape key
   useEffect(() => {
-    const handleClickOutside = (e) => {
-      // Don't close if voting is in progress
-      if (isLoadingRef.current) return;
-
-      if (tooltipRef.current && !tooltipRef.current.contains(e.target)) {
+    if (!showTooltip) return;
+    const handleKey = (e) => {
+      if (e.key === 'Escape' && !isLoadingRef.current) {
         setShowTooltip(false);
         setActiveTooltipPermlink?.(null);
       }
     };
-
-    if (showTooltip) {
-      document.addEventListener('mousedown', handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
   }, [showTooltip, setShowTooltip, setActiveTooltipPermlink]);
 
-  // Fetch account data when tooltip opens
+  // Fetch account + dynamic props ONCE when popup opens
   useEffect(() => {
     if (!user || !showTooltip) return;
 
-    const fetchAccountData = async () => {
+    let cancelled = false;
+    const init = async () => {
+      setInitializing(true);
       try {
-        setIsCalculating(true);
-        const result = await getVotePower(user);
+        const [acctResult, dynProps] = await Promise.all([
+          getVotePower(user),
+          getDynamicProps(),
+        ]);
 
-        if (result && result.account) {
-          setAccountData(result.account);
-          // Calculate initial vote value with the fetched account data
-          await calculateVoteValue(result.account, weight);
-        } else {
-          console.error('No account data returned');
-          setVoteValue('0.000');
+        if (cancelled) return;
+
+        const acct = acctResult?.account;
+        if (acct) {
+          setAccountData(acct);
+          cachedAccountRef.current = acct;
+        }
+        if (dynProps) {
+          cachedDynamicPropsRef.current = dynProps;
+        }
+
+        // Initial estimate — update DOM directly
+        if (acct && dynProps && valueRef.current) {
+          valueRef.current.textContent = `$${estimateLocal(acct, dynProps, weightRef.current)}`;
         }
       } catch (err) {
-        console.error('Error fetching account:', err);
-        setVoteValue('0.000');
+        console.error('Error fetching vote data:', err);
+        if (!cancelled && valueRef.current) valueRef.current.textContent = '$0.000';
       } finally {
-        setIsCalculating(false);
+        if (!cancelled) setInitializing(false);
       }
     };
 
-    fetchAccountData();
-  }, [user, showTooltip]);
-
-  // Recalculate vote value when weight changes
-  useEffect(() => {
-    if (!accountData) return;
-
-    const debounceTimer = setTimeout(() => {
-      calculateVoteValue(accountData, weight);
-    }, 100); // Small debounce to avoid too many calculations
-
-    return () => clearTimeout(debounceTimer);
-  }, [weight, accountData]);
-
-  const calculateVoteValue = async (account, percent) => {
-    try {
-      setIsCalculating(true);
-      const estimatedValue = await estimate(account, percent);
-      setVoteValue(estimatedValue || '0.000');
-    } catch (err) {
-      console.error('Error calculating vote value:', err);
-      setVoteValue('0.000');
-    } finally {
-      setIsCalculating(false);
-    }
-  };
+    init();
+    return () => { cancelled = true; };
+  }, [user, showTooltip]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleVote = async () => {
     if (!authenticated || !isLoggedIn()) {
@@ -116,7 +220,8 @@ const CommentVoteTooltip = ({
     }
 
     setIsLoading(true);
-    const voteWeight = Math.round(weight * 100); // Convert 1-100 to 100-10000
+    const currentWeight = weightRef.current;
+    const voteWeight = Math.round(currentWeight * 100);
 
     try {
       const data = await getUersContent(author, permlink);
@@ -135,21 +240,27 @@ const CommentVoteTooltip = ({
         return;
       }
 
-      // Use aioha for client-side voting
       await voteWithAioha(author, permlink, voteWeight);
 
-      toast.success(`Vote successful! Value: $${voteValue}`);
+      const finalValue = cachedAccountRef.current && cachedDynamicPropsRef.current
+        ? estimateLocal(cachedAccountRef.current, cachedDynamicPropsRef.current, currentWeight)
+        : '0.000';
 
-      // Update comment list optimistically
+      toast.success(`Vote successful! Value: $${finalValue}`);
+
+      // Sync back to parent
+      setParentWeight(currentWeight);
+      setParentVoteValue(finalValue);
+
       const isNewVote = !existingVote;
-      setCommentList(prev => updateCommentsRecursively(prev, permlink, false, isNewVote));
+      if (setCommentList) {
+        setCommentList(prev => updateCommentsRecursively(prev, permlink, false, isNewVote));
+      }
 
-      // Call onVoteSuccess callback if provided (for main post votes in Short.jsx)
       if (onVoteSuccess) {
         onVoteSuccess(author, permlink, isNewVote, voteWeight);
       }
 
-      // Close tooltip only after successful vote
       setShowTooltip(false);
       setActiveTooltipPermlink?.(null);
     } catch (err) {
@@ -160,20 +271,19 @@ const CommentVoteTooltip = ({
     }
   };
 
-  // Helper function to recursively update comments
   const updateCommentsRecursively = (comments, targetPermlink, isRollback = false, isNewVote = true) => {
     return comments.map(comment => {
       if (comment.permlink === targetPermlink) {
         return {
           ...comment,
-          has_voted: !isRollback, // true for vote, false for rollback
+          has_voted: !isRollback,
           stats: {
             ...comment.stats,
             num_likes: isRollback
               ? Math.max(0, (comment.stats.num_likes || 0) - 1)
               : isNewVote
                 ? (comment.stats.num_likes || 0) + 1
-                : comment.stats.num_likes || 0, // Re-vote: don't increment
+                : comment.stats.num_likes || 0,
           },
         };
       }
@@ -190,50 +300,65 @@ const CommentVoteTooltip = ({
   };
 
   return (
-    <div
-      className="upvote-tooltip-wrap"
-      ref={tooltipRef}
-      onClick={(e) => e.preventDefault()}
-    >
+    <>
       {showTooltip && (
-        <div className="tooltip-box comment">
-          <p>Vote Weight: {weight}%</p>
-          <div className="wrap">
-            {isLoading ? (
-              <div className='wrap-circle'>
-                <TailChase
-                  className="loader-circle"
-                  size="15"
-                  speed="1.5"
-                  color="red"
-                />
-              </div>
-            ) : (
-              <IoChevronUpCircleOutline
-                size={30}
-                onClick={handleVote}
-                style={{ cursor: 'pointer' }}
-              />
-            )}
-            <input
-              type="range"
-              min="1"
-              max="100"
-              value={weight}
-              onChange={(e) => setWeight(Number(e.target.value))}
+        <div className="vote-popup-overlay" onMouseDown={(e) => {
+          if (!isLoadingRef.current) {
+            setShowTooltip(false);
+            setActiveTooltipPermlink?.(null);
+          }
+        }}>
+          <div
+            className={`vote-popup${compact ? ' vote-popup--compact' : ''}`}
+            ref={tooltipRef}
+            onClick={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            <button
+              className="vote-popup-close"
+              onClick={() => {
+                if (!isLoading) {
+                  setShowTooltip(false);
+                  setActiveTooltipPermlink?.(null);
+                }
+              }}
               disabled={isLoading}
-            />
-            <p>
-              {isCalculating ? (
-                <Orbit size="30" speed="1.5" color="red" />
-              ) : (
-                `$${voteValue}`
-              )}
+            >
+              <X size={18} />
+            </button>
+
+            <p className="vote-popup-label" ref={labelRef}>Vote Weight: {parentWeight}%</p>
+
+            {/* Container for custom div-based slider — no <input> at all */}
+            <div ref={sliderContainerRef} />
+
+            <p className="vote-popup-value" ref={valueRef}>
+              {initializing ? '' : `$${parentVoteValue}`}
             </p>
+            {initializing && (
+              <div style={{ display: 'flex', justifyContent: 'center' }}>
+                <Orbit size="24" speed="1.5" color="red" />
+              </div>
+            )}
+
+            <button
+              className="vote-popup-submit"
+              onClick={handleVote}
+              disabled={isLoading || initializing}
+            >
+              {isLoading ? (
+                <TailChase size="18" speed="1.5" color="white" />
+              ) : (
+                <>
+                  <ChevronUp size={20} />
+                  Vote
+                </>
+              )}
+            </button>
           </div>
         </div>
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/components/tooltip/UpvoteTooltip.scss
+++ b/src/components/tooltip/UpvoteTooltip.scss
@@ -18,6 +18,35 @@
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
     display: flex;
     flex-direction: column;
+
+    .tooltip-close-btn {
+      position: absolute;
+      top: 4px;
+      right: 4px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 20px;
+      height: 20px;
+      padding: 0;
+      margin: 0;
+      border: none;
+      border-radius: 50%;
+      background: rgba(0, 0, 0, 0.1);
+      color: #666;
+      cursor: pointer;
+      z-index: 1;
+
+      &:hover { background: rgba(0, 0, 0, 0.2); }
+      &:disabled { opacity: 0.4; cursor: not-allowed; }
+
+      [data-theme="dark"] & {
+        background: rgba(255, 255, 255, 0.15);
+        color: #ccc;
+        &:hover { background: rgba(255, 255, 255, 0.25); }
+      }
+    }
+
     [data-theme="dark"] & {
       background-color: #333;
       border: solid 1px rgba(128, 128, 128, 0.144);
@@ -102,7 +131,7 @@
       position: relative;
     }
 
-    button {
+    button:not(.tooltip-close-btn) {
       margin-top: 8px;
       padding: 6px 12px;
       background: #1fae51;
@@ -118,5 +147,166 @@
     border: none;
     cursor: pointer;
     font-size: 16px;
+  }
+}
+
+/* ============= Centered vote popup (used by CommentVoteTooltip) ============= */
+.vote-popup-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+.vote-popup {
+  position: relative;
+  width: 320px;
+  max-width: 90vw;
+  background: #fff;
+  border-radius: 16px;
+  padding: 28px 24px 24px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  [data-theme="dark"] & {
+    background: #1e1e1e;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.6);
+  }
+
+  .vote-popup-close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.08);
+    color: #555;
+    cursor: pointer;
+    transition: background 0.15s;
+
+    &:hover { background: rgba(0, 0, 0, 0.15); }
+    &:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    [data-theme="dark"] & {
+      background: rgba(255, 255, 255, 0.12);
+      color: #ccc;
+      &:hover { background: rgba(255, 255, 255, 0.2); }
+    }
+  }
+
+  .vote-popup-label {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+    text-align: center;
+    color: #222;
+
+    [data-theme="dark"] & { color: #eee; }
+  }
+
+  --range-track: #ddd;
+  [data-theme="dark"] & { --range-track: #444; }
+
+  .vote-slider-track {
+    position: relative;
+    width: 100%;
+    height: 6px;
+    border-radius: 3px;
+    background: var(--range-track);
+    cursor: pointer;
+    touch-action: none;
+    user-select: none;
+  }
+
+  .vote-slider-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    border-radius: 3px;
+    background: var(--accent-primary, #e53935);
+    pointer-events: none;
+  }
+
+  .vote-slider-thumb {
+    position: absolute;
+    top: 50%;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: var(--accent-primary, #e53935);
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+  }
+
+  .vote-popup-value {
+    margin: 0;
+    font-size: 22px;
+    font-weight: 700;
+    text-align: center;
+    color: #111;
+    min-height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    [data-theme="dark"] & { color: #fff; }
+  }
+
+  .vote-popup-submit {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    width: 100%;
+    padding: 12px 0;
+    border: none;
+    border-radius: 10px;
+    background: var(--accent-primary, #e53935);
+    color: #fff;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s, transform 0.1s;
+    min-height: 48px;
+
+    &:hover { background: var(--accent-hover, #c62828); }
+    &:active { transform: scale(0.98); }
+    &:disabled { opacity: 0.6; cursor: not-allowed; }
+  }
+
+  // Compact variant — smaller popup on desktop (watch page)
+  &.vote-popup--compact {
+    @media screen and (min-width: 768px) {
+      width: 260px;
+      padding: 20px 18px 18px;
+      gap: 12px;
+      border-radius: 12px;
+
+      .vote-popup-close { width: 26px; height: 26px; top: 8px; right: 8px; }
+      .vote-popup-label { font-size: 14px; }
+      .vote-popup-value { font-size: 18px; min-height: 24px; }
+      .vote-slider-thumb { width: 16px; height: 16px; }
+
+      .vote-popup-submit {
+        padding: 8px 0;
+        font-size: 14px;
+        min-height: 38px;
+        border-radius: 8px;
+      }
+    }
   }
 }

--- a/src/hive-api/hiveApi.js
+++ b/src/hive-api/hiveApi.js
@@ -12,6 +12,7 @@ import { HIVE_API_URL } from "../utils/config";
    Hive RPC setup
 ------------------------------ */
 const SHORTS_API = import.meta.env.VITE_SHORTS_API_URL || "https://3speak-checker.okinoko.io/shortssorted";
+const USER_SHORTS_API = import.meta.env.VITE_USER_SHORTS_API_URL || "https://3speak-checker.okinoko.io/shorts";
 
 // Random seed for shorts ordering — regenerated each time shorts are opened
 let SHORTS_SEED = Math.floor(Math.random() * 1_000_000);
@@ -48,45 +49,25 @@ async function hiveRpc(method, params) {
    Shorts list
 ------------------------------ */
 
+// In-memory index of shorts we've already fetched — avoids redundant API lookups
+const _shortsByEmbedUrl = new Map(); // embed_url → short object
+const _shortsByPermlink = new Map(); // permlink → short object
+
 export async function fetchShortsList(page = 1, limit = 20) {
   const url = `${SHORTS_API}?page=${page}&limit=${limit}&seed=${SHORTS_SEED}`;
   const response = await axios.get(url);
   console.log('Fetching shorts list data:', response.data);
-  return response.data;
-}
 
-/* -----------------------------
-   Cached shorts list (avoids repeated pagination)
------------------------------- */
-let _cachedShorts = null;
-let _cachedShortsTime = 0;
-let _cachePromise = null;
-const SHORTS_CACHE_TTL = 60000; // 1 minute
-
-async function getAllShortsCached() {
-  if (_cachedShorts && Date.now() - _cachedShortsTime < SHORTS_CACHE_TTL) return _cachedShorts;
-  // Deduplicate: if a fetch is already in progress, share the same promise
-  if (_cachePromise) return _cachePromise;
-  _cachePromise = (async () => {
-    try {
-      const all = [];
-      let page = 1;
-      const limit = 50;
-      while (page <= 20) {
-        const data = await fetchShortsList(page, limit);
-        if (!data?.shorts) break;
-        all.push(...data.shorts);
-        if (page >= (data.totalPages || 1)) break;
-        page++;
-      }
-      _cachedShorts = all;
-      _cachedShortsTime = Date.now();
-      return all;
-    } finally {
-      _cachePromise = null;
+  // Index every short we receive so findShortByEmbedUrl/findShortByPermlink
+  // can resolve instantly without extra API calls
+  if (response.data?.shorts) {
+    for (const s of response.data.shorts) {
+      if (s.embed_url) _shortsByEmbedUrl.set(s.embed_url, s);
+      if (s.permlink) _shortsByPermlink.set(s.permlink, s);
     }
-  })();
-  return _cachePromise;
+  }
+
+  return response.data;
 }
 
 /* -----------------------------
@@ -292,6 +273,14 @@ export async function fetchCompleteShortData(shortItem, loggedInUser = null) {
       }
 
       if (post) {
+        // Populate stats from Hive post data
+        base.stats.likes = post.stats?.total_votes || post.active_votes?.filter(v => v.percent > 0).length || 0;
+        base.stats.comments = post.children || 0;
+        const payout = parseFloat(post.payout) || parseFloat(post.pending_payout_value) || 0;
+        base.stats.payout = payout.toFixed(2);
+        base.caption = bodyToPlaintext(post.body) || base.caption;
+        base.title = post.title || base.title;
+
         // Check if this short is a reaction with a parentTimestamp
         const jm = typeof post.json_metadata === 'string'
           ? JSON.parse(post.json_metadata || '{}')
@@ -345,6 +334,7 @@ export async function fetchCompleteShortData(shortItem, loggedInUser = null) {
                   duration: parentDur,
                   type: parentJm.video ? 'video' : 'comment',
                   thumbnail: parentJm?.image?.[0] || null,
+                  children: immediateParent.children || 0,
                 }];
                 let current = immediateParent;
                 let depth = 0;
@@ -365,6 +355,7 @@ export async function fetchCompleteShortData(shortItem, loggedInUser = null) {
                       duration: dur,
                       type: cJm.video ? 'video' : 'comment',
                       thumbnail: cJm?.image?.[0] || null,
+                      children: current.children || 0,
                     });
                   }
                   depth++;
@@ -404,22 +395,23 @@ export async function fetchCompleteShortData(shortItem, loggedInUser = null) {
                   type: 'video',
                   thumbnail: rootJm?.image?.[0] || null,
                   isRoot: true,
+                  children: rootPost.children || 0,
                 };
                 base.reactionChain = [rootEntry, ...intermediateChain];
 
                 // Resolve internal player permlinks for video-type chain steps
                 try {
-                  const allShorts = await getAllShortsCached();
-                  for (const step of base.reactionChain) {
-                    if (step.type === 'video' && !step.isRoot) {
-                      const target = `@${step.author}/${step.permlink}`;
-                      const found = allShorts.find(s => s.embed_url === target);
-                      if (found) {
-                        step.shortAuthor = found.owner;
-                        step.shortPermlink = found.permlink;
-                      }
-                    }
-                  }
+                  await Promise.all(
+                    base.reactionChain
+                      .filter(step => step.type === 'video' && !step.isRoot)
+                      .map(async (step) => {
+                        const found = await findShortByEmbedUrl(step.author, step.permlink);
+                        if (found) {
+                          step.shortAuthor = found.owner;
+                          step.shortPermlink = found.permlink;
+                        }
+                      })
+                  );
                 } catch (e) {
                   console.warn('Failed to resolve chain step permlinks:', e.message);
                 }
@@ -434,16 +426,18 @@ export async function fetchCompleteShortData(shortItem, loggedInUser = null) {
         try {
           const replies = await hiveRpc("condenser_api.get_content_replies", [post.author, post.permlink]);
           if (replies?.length > 0) {
-            const allShorts = await getAllShortsCached();
-            const childReactions = [];
-            for (const reply of replies) {
+            const videoReplies = replies.filter(reply => {
               const rJm = typeof reply.json_metadata === 'string'
                 ? JSON.parse(reply.json_metadata || '{}') : (reply.json_metadata || {});
-              if (rJm.video?.url || rJm.video?.platform === '3speak') {
-                const target = `@${reply.author}/${reply.permlink}`;
-                const found = allShorts.find(s => s.embed_url === target);
+              return rJm.video?.url || rJm.video?.platform === '3speak';
+            });
+            const childReactions = (await Promise.all(
+              videoReplies.map(async (reply) => {
+                const rJm = typeof reply.json_metadata === 'string'
+                  ? JSON.parse(reply.json_metadata || '{}') : (reply.json_metadata || {});
+                const found = await findShortByEmbedUrl(reply.author, reply.permlink);
                 if (found) {
-                  childReactions.push({
+                  return {
                     author: reply.author,
                     permlink: reply.permlink,
                     shortAuthor: found.owner,
@@ -452,10 +446,12 @@ export async function fetchCompleteShortData(shortItem, loggedInUser = null) {
                     type: 'video',
                     thumbnail: rJm?.image?.[0] || null,
                     duration: rJm.video?.info?.duration || rJm.video?.duration || 0,
-                  });
+                    children: reply.children || 0,
+                  };
                 }
-              }
-            }
+                return null;
+              })
+            )).filter(Boolean);
             if (childReactions.length > 0) base.childReactions = childReactions;
           }
         } catch (err) {
@@ -545,6 +541,12 @@ async function loadNestedComments(comments, loggedInUser = null) {
 
 export async function findShortByEmbedUrl(author, hivePermlink) {
   const target = `@${author}/${hivePermlink}`;
+
+  // Fast path: check in-memory index first (populated by every fetchShortsList call)
+  const cached = _shortsByEmbedUrl.get(target);
+  if (cached) return cached;
+
+  // Slow fallback: paginate the API (only hits shorts not yet in our index)
   let page = 1;
   const limit = 50;
   const maxPages = 10;
@@ -553,7 +555,8 @@ export async function findShortByEmbedUrl(author, hivePermlink) {
     const data = await fetchShortsList(page, limit);
     if (!data?.shorts) break;
 
-    const found = data.shorts.find(s => s.embed_url === target);
+    // fetchShortsList already indexes results, so just re-check the map
+    const found = _shortsByEmbedUrl.get(target);
     if (found) return found;
 
     if (page >= (data.totalPages || 1)) break;
@@ -568,6 +571,11 @@ export async function findShortByEmbedUrl(author, hivePermlink) {
 ------------------------------ */
 
 export async function findShortByPermlink(permlink) {
+  // Fast path: check in-memory index first
+  const cached = _shortsByPermlink.get(permlink);
+  if (cached) return cached;
+
+  // Slow fallback: paginate the API
   let page = 1;
   const limit = 50;
   const maxPages = 10;
@@ -576,7 +584,7 @@ export async function findShortByPermlink(permlink) {
     const data = await fetchShortsList(page, limit);
     if (!data?.shorts) break;
 
-    const found = data.shorts.find(s => s.permlink === permlink);
+    const found = _shortsByPermlink.get(permlink);
     if (found) return found;
 
     if (page >= (data.totalPages || 1)) break;
@@ -635,6 +643,81 @@ export async function fetchShortsWithDetails(page = 1, limit = 10, loggedInUser 
       isLiked: false,
       isDisliked: false,
       // Mark as not yet enriched — reaction chain & vote status loaded lazily
+      _enriched: false,
+    };
+  });
+
+  return {
+    success: true,
+    page: shortsList.page,
+    total: shortsList.total,
+    totalPages: shortsList.totalPages,
+    shorts
+  };
+}
+
+/* -----------------------------
+   User-specific shorts feed
+------------------------------ */
+
+export async function fetchUserShortsList(username, page = 1, limit = 20) {
+  const url = `${USER_SHORTS_API}/${username}?page=${page}&limit=${limit}`;
+  const response = await axios.get(url);
+
+  // Index results in the same maps so findShortByPermlink works
+  if (response.data?.shorts) {
+    for (const s of response.data.shorts) {
+      if (s.embed_url) _shortsByEmbedUrl.set(s.embed_url, s);
+      if (s.permlink) _shortsByPermlink.set(s.permlink, s);
+    }
+  }
+
+  return response.data;
+}
+
+export async function fetchUserShortsWithDetails(username, page = 1, limit = 20) {
+  const shortsList = await fetchUserShortsList(username, page, limit);
+
+  if (!shortsList?.shorts) {
+    throw new Error("Failed to fetch user shorts list");
+  }
+
+  const shorts = shortsList.shorts.map((s) => {
+    const { author, permlink: hivePermlink } = parseEmbedUrl(s.embed_url);
+    const finalAuthor = author || s.owner;
+
+    return {
+      id: `${finalAuthor}-${s.permlink}`,
+      author: finalAuthor,
+      permlink: s.permlink,
+      hivePermlink: hivePermlink,
+      embedUrl: s.embed_url,
+      thumbnailUrl: s.thumbnail_url,
+      views: s.views || 0,
+      createdAt: s.createdAt,
+      timeAgo: timeAgo(s.createdAt),
+      title: s.hive_title || s.embed_title || "",
+      caption: bodyToPlaintext(s.hive_body) || s.hive_title || s.embed_title || "",
+      tags: Array.isArray(s.hive_tags) ? s.hive_tags : [],
+      user: {
+        username: `@${finalAuthor}`,
+        avatar: `https://images.hive.blog/u/${finalAuthor}/avatar`,
+        isSubscribed: false,
+        followersCount: s.hive_followers ?? null,
+        reputation: s.hive_author_reputation ?? null,
+      },
+      stats: {
+        likes: s.hive_votes || 0,
+        dislikes: 0,
+        comments: s.hive_comments || 0,
+        shares: 0,
+        remixes: 0,
+        payout: s.hive_reward != null ? String(s.hive_reward) : "0.00"
+      },
+      comments: [],
+      commentsLoaded: false,
+      isLiked: false,
+      isDisliked: false,
       _enriched: false,
     };
   });

--- a/src/hive-api/hiveApi.js
+++ b/src/hive-api/hiveApi.js
@@ -5,12 +5,20 @@
  */
 
 import axios from "axios";
+import { convert } from "html-to-text";
 import { HIVE_API_URL } from "../utils/config";
 
 /* -----------------------------
    Hive RPC setup
 ------------------------------ */
-const SHORTS_API = "https://tags.3speak.tv/shorts";
+const SHORTS_API = import.meta.env.VITE_SHORTS_API_URL || "https://3speak-checker.okinoko.io/shortssorted";
+
+// Random seed for shorts ordering — regenerated each time shorts are opened
+let SHORTS_SEED = Math.floor(Math.random() * 1_000_000);
+
+export function regenerateShortsSeed() {
+  SHORTS_SEED = Math.floor(Math.random() * 1_000_000);
+}
 
 /* -----------------------------
    Hive RPC helper
@@ -41,7 +49,7 @@ async function hiveRpc(method, params) {
 ------------------------------ */
 
 export async function fetchShortsList(page = 1, limit = 20) {
-  const url = `${SHORTS_API}?page=${page}&limit=${limit}`;
+  const url = `${SHORTS_API}?page=${page}&limit=${limit}&seed=${SHORTS_SEED}`;
   const response = await axios.get(url);
   console.log('Fetching shorts list data:', response.data);
   return response.data;
@@ -89,6 +97,10 @@ export async function getPostDetails(author, permlink) {
   return await hiveRpc("bridge.get_post", { author, permlink });
 }
 
+export async function getActiveVotes(author, permlink) {
+  return await hiveRpc("condenser_api.get_active_votes", [author, permlink]);
+}
+
 export async function getComments(author, permlink) {
   return await hiveRpc("bridge.get_discussion", { author, permlink });
 }
@@ -100,6 +112,29 @@ export async function getAccounts(accounts) {
 /* -----------------------------
    Utils
 ------------------------------ */
+
+/**
+ * Convert hive_body (markdown/HTML) to clean plaintext for display as caption.
+ * Strips URLs, HTML tags, markdown syntax, and collapses whitespace.
+ */
+function bodyToPlaintext(body) {
+  if (!body) return "";
+  // Convert any HTML to text
+  let text = convert(body, { wordwrap: false, selectors: [{ selector: 'a', options: { ignoreHref: true } }, { selector: 'img', format: 'skip' }] });
+  // Remove URLs
+  text = text.replace(/https?:\/\/\S+/gi, '');
+  // Remove markdown image/link syntax leftovers: ![alt](url) or [text](url)
+  text = text.replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1');
+  // Remove markdown bold/italic markers
+  text = text.replace(/[*_]{1,3}/g, '');
+  // Remove markdown headers
+  text = text.replace(/^#{1,6}\s+/gm, '');
+  // Remove <sup>...</sup> and similar stray HTML
+  text = text.replace(/<[^>]+>/g, '');
+  // Collapse whitespace and trim
+  text = text.replace(/\n{3,}/g, '\n\n').replace(/[ \t]+/g, ' ').trim();
+  return text;
+}
 
 /**
  * Parse embed_url to extract author and permlink
@@ -241,34 +276,22 @@ export async function fetchCompleteShortData(shortItem, loggedInUser = null) {
 
   try {
     if (hivePermlink) {
-      const post = await getPostDetails(author, hivePermlink);
-      console.log('Fetching post details data:', post);
+      // Run vote check and post details in parallel
+      const [votes, post] = await Promise.all([
+        loggedInUser ? getActiveVotes(author, hivePermlink).catch(() => null) : Promise.resolve(null),
+        getPostDetails(author, hivePermlink),
+      ]);
+
+      // Lightweight vote status from get_active_votes
+      if (votes && loggedInUser) {
+        const userVote = votes.find(v => v.voter === loggedInUser);
+        if (userVote) {
+          base.isLiked = userVote.percent >= 0;
+          base.isDisliked = userVote.percent < 0;
+        }
+      }
 
       if (post) {
-        base.title = post.title || base.title;
-        base.caption = post.title || base.caption;
-        base.stats.comments = post.children || 0;
-        base.stats.likes = post.stats?.total_votes || post.active_votes?.length || 0;
-        base.stats.payout = post.payout || post.pending_payout_value || "0.00";
-
-        // Determine if the logged-in user has voted on the post
-        if (loggedInUser) {
-          try {
-            const userVoted = post.active_votes?.some(v => v.voter === loggedInUser) ?? false;
-            base.isLiked = userVoted;
-            // Check for negative percent to mark as disliked
-            const userVote = post.active_votes?.find(v => v.voter === loggedInUser);
-            base.isDisliked = userVote ? (userVote.percent < 0) : false;
-          } catch (_) {
-            base.isLiked = false;
-            base.isDisliked = false;
-          }
-        }
-
-        if (post.author_reputation) {
-          base.user.reputation = post.author_reputation;
-        }
-
         // Check if this short is a reaction with a parentTimestamp
         const jm = typeof post.json_metadata === 'string'
           ? JSON.parse(post.json_metadata || '{}')
@@ -574,40 +597,47 @@ export async function fetchShortsWithDetails(page = 1, limit = 10, loggedInUser 
     throw new Error("Failed to fetch shorts list");
   }
 
-  const shorts = await Promise.all(
-    shortsList.shorts.map((s) =>
-      fetchCompleteShortData(s, loggedInUser).catch((err) => {
-        console.warn(`Error fetching short data for ${s.embed_url}:`, err);
+  // Fast path: format directly from the list API data (no per-short RPC)
+  const shorts = shortsList.shorts.map((s) => {
+    const { author, permlink: hivePermlink } = parseEmbedUrl(s.embed_url);
+    const finalAuthor = author || s.owner;
 
-        const { author, permlink: hivePermlink } = parseEmbedUrl(s.embed_url);
-        const finalAuthor = author || s.owner;
-
-        return {
-          id: `${finalAuthor}-${s.permlink}`,
-          author: finalAuthor,
-          permlink: s.permlink,
-          hivePermlink: hivePermlink,
-          embedUrl: s.embed_url,
-          thumbnailUrl: s.thumbnail_url,
-          views: s.views || 0,
-          createdAt: s.createdAt,
-          timeAgo: timeAgo(s.createdAt),
-          title: s.embed_title || "",
-          caption: s.embed_title || "",
-          user: {
-            username: `@${finalAuthor}`,
-            avatar: `https://images.hive.blog/u/${finalAuthor}/avatar`,
-            isSubscribed: false
-          },
-          stats: { likes: 0, dislikes: 0, comments: 0, shares: 0, remixes: 0, payout: "0.00" },
-          comments: [],
-          commentsLoaded: false,
-          isLiked: false,
-          isDisliked: false
-        };
-      })
-    )
-  );
+    return {
+      id: `${finalAuthor}-${s.permlink}`,
+      author: finalAuthor,
+      permlink: s.permlink,
+      hivePermlink: hivePermlink,
+      embedUrl: s.embed_url,
+      thumbnailUrl: s.thumbnail_url,
+      views: s.views || 0,
+      createdAt: s.createdAt,
+      timeAgo: timeAgo(s.createdAt),
+      title: s.hive_title || s.embed_title || "",
+      caption: bodyToPlaintext(s.hive_body) || s.hive_title || s.embed_title || "",
+      tags: Array.isArray(s.hive_tags) ? s.hive_tags : [],
+      user: {
+        username: `@${finalAuthor}`,
+        avatar: `https://images.hive.blog/u/${finalAuthor}/avatar`,
+        isSubscribed: false,
+        followersCount: s.hive_followers ?? null,
+        reputation: s.hive_author_reputation ?? null,
+      },
+      stats: {
+        likes: s.hive_votes || 0,
+        dislikes: 0,
+        comments: s.hive_comments || 0,
+        shares: 0,
+        remixes: 0,
+        payout: s.hive_reward != null ? String(s.hive_reward) : "0.00"
+      },
+      comments: [],
+      commentsLoaded: false,
+      isLiked: false,
+      isDisliked: false,
+      // Mark as not yet enriched — reaction chain & vote status loaded lazily
+      _enriched: false,
+    };
+  });
 
   return {
     success: true,
@@ -638,6 +668,51 @@ export function build3SpeakEmbedUrl(author, permlink, layout = "mobile", control
 }
 
 /* -----------------------------
+   Shorts preload cache
+------------------------------ */
+
+let _preloadedShorts = null;
+let _preloadPromise = null;
+
+/**
+ * Preloads the first page of shorts in the background.
+ * Safe to call multiple times — only runs once until consumed.
+ */
+export function preloadShorts(limit = 5) {
+  if (_preloadedShorts || _preloadPromise) return; // already preloading or done
+  regenerateShortsSeed();
+  _preloadPromise = fetchShortsWithDetails(1, limit)
+    .then((data) => {
+      _preloadedShorts = data;
+      _preloadPromise = null;
+    })
+    .catch((err) => {
+      console.warn('Shorts preload failed:', err.message);
+      _preloadPromise = null;
+    });
+}
+
+/**
+ * Synchronous check: returns true if preloaded data is already available
+ * (finished loading, not just in-flight).
+ */
+export function hasShortsPreloaded() {
+  return _preloadedShorts != null;
+}
+
+/**
+ * Returns preloaded shorts data and clears the cache (one-time consumption).
+ * If preload is still in flight, waits for it.
+ * Returns null if nothing was preloaded.
+ */
+export async function consumePreloadedShorts() {
+  if (_preloadPromise) await _preloadPromise;
+  const data = _preloadedShorts;
+  _preloadedShorts = null;
+  return data;
+}
+
+/* -----------------------------
    Default export
 ------------------------------ */
 
@@ -657,6 +732,9 @@ export default {
   fetchPostComments,
   get3SpeakEmbedUrl,
   build3SpeakEmbedUrl,
+  preloadShorts,
+  hasShortsPreloaded,
+  consumePreloadedShorts,
   HIVE_API_URL,
   SHORTS_API
 };

--- a/src/hive-api/hiveApi.js
+++ b/src/hive-api/hiveApi.js
@@ -48,6 +48,40 @@ export async function fetchShortsList(page = 1, limit = 20) {
 }
 
 /* -----------------------------
+   Cached shorts list (avoids repeated pagination)
+------------------------------ */
+let _cachedShorts = null;
+let _cachedShortsTime = 0;
+let _cachePromise = null;
+const SHORTS_CACHE_TTL = 60000; // 1 minute
+
+async function getAllShortsCached() {
+  if (_cachedShorts && Date.now() - _cachedShortsTime < SHORTS_CACHE_TTL) return _cachedShorts;
+  // Deduplicate: if a fetch is already in progress, share the same promise
+  if (_cachePromise) return _cachePromise;
+  _cachePromise = (async () => {
+    try {
+      const all = [];
+      let page = 1;
+      const limit = 50;
+      while (page <= 20) {
+        const data = await fetchShortsList(page, limit);
+        if (!data?.shorts) break;
+        all.push(...data.shorts);
+        if (page >= (data.totalPages || 1)) break;
+        page++;
+      }
+      _cachedShorts = all;
+      _cachedShortsTime = Date.now();
+      return all;
+    } finally {
+      _cachePromise = null;
+    }
+  })();
+  return _cachePromise;
+}
+
+/* -----------------------------
    Hive data fetchers
 ------------------------------ */
 
@@ -246,6 +280,7 @@ export async function fetchCompleteShortData(shortItem, loggedInUser = null) {
             const immediateParent = await getPostDetails(post.parent_author, post.parent_permlink);
             if (immediateParent) {
               let rootPost = immediateParent;
+              let intermediateChain = [];
 
               // If the immediate parent is a comment (not the root video), capture it
               if (immediateParent.parent_author) {
@@ -257,15 +292,63 @@ export async function fetchCompleteShortData(shortItem, loggedInUser = null) {
                   };
                 }
 
-                // Walk up the chain to find the root video
+                // Check if the immediate parent is itself a short (video reaction)
+                const parentJm = typeof immediateParent.json_metadata === 'string'
+                  ? JSON.parse(immediateParent.json_metadata || '{}')
+                  : (immediateParent.json_metadata || {});
+                if (parentJm.video?.url || parentJm.video?.platform === '3speak') {
+                  try {
+                    const parentShortEntry = await findShortByEmbedUrl(immediateParent.author, immediateParent.permlink);
+                    if (parentShortEntry) {
+                      base.parentShort = {
+                        author: parentShortEntry.owner,
+                        permlink: parentShortEntry.permlink,
+                      };
+                    }
+                  } catch (e) {
+                    console.warn('Failed to look up parent short:', e.message);
+                  }
+                }
+
+                // Walk up the chain to find the root video, collecting the chain
+                const parentDur = parentJm.video?.info?.duration || parentJm.video?.duration || 0;
+                const parentBody = (immediateParent.body || '').split('\n').filter(l => l.trim() && !l.startsWith('<sup>') && !l.startsWith('http')).slice(0, 3).join('\n');
+
+                const reactionChain = [{
+                  author: immediateParent.author,
+                  permlink: immediateParent.permlink,
+                  title: immediateParent.title || '',
+                  body: parentBody,
+                  duration: parentDur,
+                  type: parentJm.video ? 'video' : 'comment',
+                  thumbnail: parentJm?.image?.[0] || null,
+                }];
                 let current = immediateParent;
                 let depth = 0;
                 while (current.parent_author && depth < 10) {
                   current = await getPostDetails(current.parent_author, current.parent_permlink);
                   if (!current) break;
+                  if (current.parent_author) {
+                    const cJm = typeof current.json_metadata === 'string'
+                      ? JSON.parse(current.json_metadata || '{}') : (current.json_metadata || {});
+                    const dur = cJm.video?.info?.duration || cJm.video?.duration || 0;
+                    const cBody = (current.body || '').split('\n').filter(l => l.trim() && !l.startsWith('<sup>') && !l.startsWith('http')).slice(0, 3).join('\n');
+
+                    reactionChain.unshift({
+                      author: current.author,
+                      permlink: current.permlink,
+                      title: current.title || '',
+                      body: cBody,
+                      duration: dur,
+                      type: cJm.video ? 'video' : 'comment',
+                      thumbnail: cJm?.image?.[0] || null,
+                    });
+                  }
                   depth++;
                 }
                 if (current) rootPost = current;
+                // Store intermediates for later — root will be prepended below
+                intermediateChain = reactionChain;
               }
 
               // Store the root video
@@ -285,11 +368,75 @@ export async function fetchCompleteShortData(shortItem, loggedInUser = null) {
                     num_votes: rootPost.stats?.total_votes || rootPost.active_votes?.length || 0,
                   }
                 };
+
+                // Build complete chain: [root, ...intermediates]
+                const rootDur = rootJm?.video?.info?.duration || rootJm?.video?.duration || 0;
+                const rootBody = (rootPost.body || '').split('\n').filter(l => l.trim() && !l.startsWith('<sup>') && !l.startsWith('http')).slice(0, 3).join('\n');
+                const rootEntry = {
+                  author: rootPost.author,
+                  permlink: rootPost.permlink,
+                  title: rootPost.title || '',
+                  body: rootBody,
+                  duration: rootDur,
+                  type: 'video',
+                  thumbnail: rootJm?.image?.[0] || null,
+                  isRoot: true,
+                };
+                base.reactionChain = [rootEntry, ...intermediateChain];
+
+                // Resolve internal player permlinks for video-type chain steps
+                try {
+                  const allShorts = await getAllShortsCached();
+                  for (const step of base.reactionChain) {
+                    if (step.type === 'video' && !step.isRoot) {
+                      const target = `@${step.author}/${step.permlink}`;
+                      const found = allShorts.find(s => s.embed_url === target);
+                      if (found) {
+                        step.shortAuthor = found.owner;
+                        step.shortPermlink = found.permlink;
+                      }
+                    }
+                  }
+                } catch (e) {
+                  console.warn('Failed to resolve chain step permlinks:', e.message);
+                }
               }
             }
           } catch (err) {
             console.warn('Failed to fetch parent video:', err.message);
           }
+        }
+
+        // Load direct child reactions (replies to this short that are themselves shorts)
+        try {
+          const replies = await hiveRpc("condenser_api.get_content_replies", [post.author, post.permlink]);
+          if (replies?.length > 0) {
+            const allShorts = await getAllShortsCached();
+            const childReactions = [];
+            for (const reply of replies) {
+              const rJm = typeof reply.json_metadata === 'string'
+                ? JSON.parse(reply.json_metadata || '{}') : (reply.json_metadata || {});
+              if (rJm.video?.url || rJm.video?.platform === '3speak') {
+                const target = `@${reply.author}/${reply.permlink}`;
+                const found = allShorts.find(s => s.embed_url === target);
+                if (found) {
+                  childReactions.push({
+                    author: reply.author,
+                    permlink: reply.permlink,
+                    shortAuthor: found.owner,
+                    shortPermlink: found.permlink,
+                    title: reply.title || '',
+                    type: 'video',
+                    thumbnail: rJm?.image?.[0] || null,
+                    duration: rJm.video?.info?.duration || rJm.video?.duration || 0,
+                  });
+                }
+              }
+            }
+            if (childReactions.length > 0) base.childReactions = childReactions;
+          }
+        } catch (err) {
+          console.warn('Failed to load child reactions:', err.message);
         }
       }
     }
@@ -367,6 +514,30 @@ async function loadNestedComments(comments, loggedInUser = null) {
   );
 
   return result;
+}
+
+/* -----------------------------
+   Find a short by its Hive embed_url (e.g. "@author/permlink")
+------------------------------ */
+
+export async function findShortByEmbedUrl(author, hivePermlink) {
+  const target = `@${author}/${hivePermlink}`;
+  let page = 1;
+  const limit = 50;
+  const maxPages = 10;
+
+  while (page <= maxPages) {
+    const data = await fetchShortsList(page, limit);
+    if (!data?.shorts) break;
+
+    const found = data.shorts.find(s => s.embed_url === target);
+    if (found) return found;
+
+    if (page >= (data.totalPages || 1)) break;
+    page++;
+  }
+
+  return null;
 }
 
 /* -----------------------------
@@ -473,6 +644,7 @@ export function build3SpeakEmbedUrl(author, permlink, layout = "mobile", control
 export default {
   fetchShortsList,
   findShortByPermlink,
+  findShortByEmbedUrl,
   getPostDetails,
   getComments,
   getAccounts,

--- a/src/hive-api/hiveApi.js
+++ b/src/hive-api/hiveApi.js
@@ -40,8 +40,8 @@ async function hiveRpc(method, params) {
    Shorts list
 ------------------------------ */
 
-export async function fetchShortsList(page = 1, limit = 20, app = "snapie") {
-  const url = `${SHORTS_API}?page=${page}&limit=${limit}&app=${app}`;
+export async function fetchShortsList(page = 1, limit = 20) {
+  const url = `${SHORTS_API}?page=${page}&limit=${limit}`;
   const response = await axios.get(url);
   console.log('Fetching shorts list data:', response.data);
   return response.data;
@@ -234,6 +234,63 @@ export async function fetchCompleteShortData(shortItem, loggedInUser = null) {
         if (post.author_reputation) {
           base.user.reputation = post.author_reputation;
         }
+
+        // Check if this short is a reaction with a parentTimestamp
+        const jm = typeof post.json_metadata === 'string'
+          ? JSON.parse(post.json_metadata || '{}')
+          : (post.json_metadata || {});
+
+        if (jm.parentTimestamp != null && post.parent_author) {
+          base.parentTimestamp = jm.parentTimestamp;
+          try {
+            const immediateParent = await getPostDetails(post.parent_author, post.parent_permlink);
+            if (immediateParent) {
+              let rootPost = immediateParent;
+
+              // If the immediate parent is a comment (not the root video), capture it
+              if (immediateParent.parent_author) {
+                const bodyExcerpt = (immediateParent.body || '').split('\n').filter(l => l.trim()).slice(0, 2).join('\n');
+                if (bodyExcerpt) {
+                  base.parentComment = {
+                    author: immediateParent.author,
+                    body: bodyExcerpt,
+                  };
+                }
+
+                // Walk up the chain to find the root video
+                let current = immediateParent;
+                let depth = 0;
+                while (current.parent_author && depth < 10) {
+                  current = await getPostDetails(current.parent_author, current.parent_permlink);
+                  if (!current) break;
+                  depth++;
+                }
+                if (current) rootPost = current;
+              }
+
+              // Store the root video
+              if (rootPost && !rootPost.parent_author) {
+                const rootJm = typeof rootPost.json_metadata === 'string'
+                  ? JSON.parse(rootPost.json_metadata || '{}')
+                  : (rootPost.json_metadata || {});
+                base.parentVideo = {
+                  author: rootPost.author,
+                  permlink: rootPost.permlink,
+                  title: rootPost.title,
+                  created: rootPost.created,
+                  duration: rootJm?.video?.info?.duration || rootJm?.video?.duration || 0,
+                  thumbnail: rootJm?.image?.[0] || null,
+                  stats: {
+                    total_hive_reward: rootPost.payout || rootPost.pending_payout_value || 0,
+                    num_votes: rootPost.stats?.total_votes || rootPost.active_votes?.length || 0,
+                  }
+                };
+              }
+            }
+          } catch (err) {
+            console.warn('Failed to fetch parent video:', err.message);
+          }
+        }
       }
     }
   } catch (err) {
@@ -310,6 +367,29 @@ async function loadNestedComments(comments, loggedInUser = null) {
   );
 
   return result;
+}
+
+/* -----------------------------
+   Find a short by player permlink
+------------------------------ */
+
+export async function findShortByPermlink(permlink) {
+  let page = 1;
+  const limit = 50;
+  const maxPages = 10;
+
+  while (page <= maxPages) {
+    const data = await fetchShortsList(page, limit);
+    if (!data?.shorts) break;
+
+    const found = data.shorts.find(s => s.permlink === permlink);
+    if (found) return found;
+
+    if (page >= (data.totalPages || 1)) break;
+    page++;
+  }
+
+  return null;
 }
 
 /* -----------------------------
@@ -392,6 +472,7 @@ export function build3SpeakEmbedUrl(author, permlink, layout = "mobile", control
 
 export default {
   fetchShortsList,
+  findShortByPermlink,
   getPostDetails,
   getComments,
   getAccounts,

--- a/src/page/Short.jsx
+++ b/src/page/Short.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import "./Short.scss";
 import {
-  ThumbsUp,
+  Heart,
   MessageSquare,
   Share2,
   RefreshCw,
@@ -21,7 +21,9 @@ import {
   ExternalLink,
   Video,
   MessageSquareText,
-  Camera
+  Camera,
+  Volume2,
+  VolumeX
 } from 'lucide-react';
 import { GiTwoCoins } from 'react-icons/gi';
 
@@ -39,7 +41,7 @@ const HiveIcon = ({ size = 24, className = '' }) => (
     <path d="M6.076 1.637a.103.103 0 00-.09.05L.014 11.95a.102.102 0 000 .104l6.039 10.26c.04.068.14.068.18 0l5.972-10.262a.102.102 0 00-.002-.104L6.166 1.687a.103.103 0 00-.09-.05zm2.863 0c-.079 0-.13.085-.09.154l5.186 8.967a.105.105 0 00.09.053h3.117c.08 0 .13-.088.09-.157l-5.186-8.966a.104.104 0 00-.09-.051H8.94zm5.891 0a.102.102 0 00-.088.154L20.656 12l-5.914 10.209a.102.102 0 00.088.154h3.123a.1.1 0 00.088-.05l5.945-10.262a.1.1 0 000-.102L18.041 1.688a.1.1 0 00-.088-.051H14.83zm-.79 11.7a.1.1 0 00-.089.052l-5.101 8.82c-.04.069.01.154.09.154h3.117a.104.104 0 00.09-.05l5.1-8.82a.103.103 0 00-.09-.155h-3.118z" />
   </svg>
 );
-import hiveApi, { regenerateShortsSeed, consumePreloadedShorts, hasShortsPreloaded, preloadShorts } from '../hive-api/hiveApi';
+import hiveApi, { regenerateShortsSeed, consumePreloadedShorts, hasShortsPreloaded, preloadShorts, fetchUserShortsWithDetails } from '../hive-api/hiveApi';
 import { useAppStore } from '../lib/store';
 import axios from 'axios';
 import { toast } from 'sonner';
@@ -49,6 +51,21 @@ import { useNavigate, useLocation, Link } from 'react-router-dom';
 import { fixVideoThumbnail } from '../utils/fixThumbnails';
 import AuthorBadge from '../components/AuthorBadge/AuthorBadge';
 
+// Lazy-loaded Hive markdown renderer (same as CommentSection)
+let rendererPromise = null;
+const getRenderer = async () => {
+  if (!rendererPromise) {
+    rendererPromise = import('@snapie/renderer').then(({ createHiveRenderer }) => {
+      return createHiveRenderer({
+        ipfsGateway: 'https://ipfs-3speak.b-cdn.net',
+        convertHiveUrls: true,
+        usertagUrlFn: (account) => `/p/${account}`,
+        hashtagUrlFn: (tag) => `/t/${tag}`,
+      });
+    });
+  }
+  return rendererPromise;
+};
 
 /* ================= COMPONENT ================= */
 const VideoShort = () => {
@@ -64,13 +81,30 @@ const VideoShort = () => {
   const [parentCardVisible, setParentCardVisible] = useState(true);
   const [expandedChainCard, setExpandedChainCard] = useState(null);
   const [shortNavLoading, setShortNavLoading] = useState(false);
+  const [firstPlayerReady, setFirstPlayerReady] = useState(false);
   const shortHistoryRef = useRef([]); // Stack of {author, permlink} for back navigation
+  const isNavigatingBackRef = useRef(false); // Prevents URL-change effect from pushing to history on back
 
   // Player state
   const [isPlaying, setIsPlaying] = useState(false);
-  const [currentTime, setCurrentTime] = useState(0);
-  const [duration, setDuration] = useState(0);
+  const [isMuted, setIsMuted] = useState(() => {
+    const cookie = document.cookie.split('; ').find(c => c.startsWith('shorts_muted='));
+    return cookie ? cookie.split('=')[1] !== '0' : false;
+  });
+  // currentTime/duration as refs instead of state to avoid re-renders on every timeupdate (~4x/sec)
+  // Progress bar is updated directly via DOM refs
+  const currentTimeRef = useRef(0);
+  const durationRef = useRef(0);
+  const progressFillRef = useRef(null);
+  const progressHandleRef = useRef(null);
+  const updateProgressBar = useCallback(() => {
+    const pct = durationRef.current > 0 ? (currentTimeRef.current / durationRef.current) * 100 : 0;
+    if (progressFillRef.current) progressFillRef.current.style.width = `${pct}%`;
+    if (progressHandleRef.current) progressHandleRef.current.style.left = `${pct}%`;
+  }, []);
   const [showPlayPauseIcon, setShowPlayPauseIcon] = useState(false);
+  const [showMuteIcon, setShowMuteIcon] = useState(false);
+  const [showHeartAnimation, setShowHeartAnimation] = useState(false);
   const [isScrubbing, setIsScrubbing] = useState(false);
   const [commentsLoading, setCommentsLoading] = useState(false);
   const [postingComment, setPostingComment] = useState(false);
@@ -82,6 +116,9 @@ const VideoShort = () => {
   const [weight, setWeight] = useState(100);
   const [voteValue, setVoteValue] = useState(0.0);
   const [accountData, setAccountData] = useState(null);
+
+  // Rendered comment bodies (permlink -> HTML string)
+  const [renderedBodies, setRenderedBodies] = useState({});
 
   // Reply state
   const [activeReply, setActiveReply] = useState(null);
@@ -95,6 +132,7 @@ const VideoShort = () => {
   const [swipeDirection, setSwipeDirection] = useState(null); // 'up' | 'down' | null
   const [swipeDragY, setSwipeDragY] = useState(0); // live drag offset in px
   const swipeAnimRef = useRef(null);
+  const touchStartYRef = useRef(null); // Synchronous mirror of touchStart for gesture detection
 
   const progressBarRef = useRef(null);
   const playPauseTimeoutRef = useRef(null);
@@ -103,14 +141,40 @@ const VideoShort = () => {
   const iframeRefs = useRef({}); // Store refs to all iframes by video id
   const keyboardRef = useRef(null); // capture keyboard events on mobile when focused
   const prevIndexRef = useRef(0); // Track previous index
+  const prevVideoIdRef = useRef(null); // Track previous video id to avoid re-running play on enrichment
   const readyPlayers = useRef(new Set()); // Track which players have sent 3speak-player-ready
   const [readyPlayerIds, setReadyPlayerIds] = useState(new Set()); // State mirror for render gating
   const pendingPlayRef = useRef(null); // Track video waiting to be played
   const chainPreloadDataRef = useRef(new Map()); // Chain short metadata for instant navigation
+  const loadingMoreRef = useRef(false); // Prevent concurrent loadMore calls
+
+  // Gesture detection refs
+  const tapCountRef = useRef(0);
+  const tapTimerRef = useRef(null);
+  const longPressTimerRef = useRef(null);
+  const gestureHandledRef = useRef(false); // Prevent touch + click double-fire
+  const muteIconTimeoutRef = useRef(null);
+  const heartAnimTimeoutRef = useRef(null);
+  const isMutedRef = useRef(isMuted); // Mirror of isMuted for use inside message handler closure
+  const mouseLongPressRef = useRef(null); // Timer for desktop mouse long-press
+  const mouseLongPressHandledRef = useRef(false); // Tracks whether mouse long-press fired
+  const recentTouchRef = useRef(false); // Guards click handler from firing after touch events
+  const wasPlayingBeforePopupRef = useRef(false); // Tracks play state before vote popup opens
+
+  const commentsDragStartY = useRef(null); // Drag handle touch start Y
+  const commentsPanelRef = useRef(null); // Ref for comments panel element
 
   const accessToken = localStorage.getItem("access_token");
   const navigate = useNavigate();
   const location = useLocation();
+
+  // User-specific feed mode: when ?user=username is in the URL, load from the per-user endpoint
+  const feedUser = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('user') || null;
+  }, [location.search]);
+  const feedUserRef = useRef(feedUser);
+  feedUserRef.current = feedUser;
 
   // Minimum swipe distance to trigger navigation (in pixels)
   const minSwipeDistance = 50;
@@ -158,34 +222,124 @@ const VideoShort = () => {
     sendCommandToVideo(currentVid, command, data);
   }, [videos, currentIndex, sendCommandToVideo]);
 
-  const togglePlayPause = useCallback((e) => {
-    e.stopPropagation();
-    sendCommand('toggle-play');
+  // Play an iframe with correct mute state.
+  // mute=1 in URL doesn't survive player.load() after user activation,
+  // so we always explicitly sync mute state via postMessage before playing.
+  // Play an iframe with correct mute state.
+  // Sends mute/unmute before play so the player's intendedMuted flag is set correctly.
+  const playIframeWithMuteSync = useCallback((iframe) => {
+    if (!iframe?.contentWindow) return;
+    const muteCmd = isMutedRef.current ? 'mute' : 'unmute';
+    iframe.contentWindow.postMessage({ type: muteCmd }, '*');
+    iframe.contentWindow.postMessage({ type: 'play' }, '*');
+  }, []);
 
+  const togglePlayPause = useCallback(() => {
+    sendCommand('toggle-play');
     setShowPlayPauseIcon(true);
-    if (playPauseTimeoutRef.current) {
-      clearTimeout(playPauseTimeoutRef.current);
-    }
-    playPauseTimeoutRef.current = setTimeout(() => {
-      setShowPlayPauseIcon(false);
-    }, 500);
+    if (playPauseTimeoutRef.current) clearTimeout(playPauseTimeoutRef.current);
+    playPauseTimeoutRef.current = setTimeout(() => setShowPlayPauseIcon(false), 500);
   }, [sendCommand]);
+
+  // Toggle mute: only send to current (active) iframe — background iframes ignore postMessage.
+  // Other iframes get mute synced when they become current via playIframeWithMuteSync.
+  const toggleMute = useCallback(() => {
+    const newMuted = !isMuted;
+    const command = newMuted ? 'mute' : 'unmute';
+    // Only the current iframe is active and will receive this
+    sendCommand(command);
+    setIsMuted(newMuted);
+    isMutedRef.current = newMuted;
+    document.cookie = `shorts_muted=${newMuted ? '1' : '0'}; path=/; max-age=${365 * 24 * 3600}`;
+    // Show mute/unmute icon feedback
+    setShowMuteIcon(true);
+    if (muteIconTimeoutRef.current) clearTimeout(muteIconTimeoutRef.current);
+    muteIconTimeoutRef.current = setTimeout(() => setShowMuteIcon(false), 600);
+  }, [isMuted, sendCommand]);
+
+  // Pause video while vote popup is open, resume when it closes (only if was playing)
+  useEffect(() => {
+    if (showTooltip) {
+      wasPlayingBeforePopupRef.current = isPlaying;
+      if (isPlaying) sendCommand('pause');
+    } else {
+      if (wasPlayingBeforePopupRef.current) {
+        sendCommand('play');
+        wasPlayingBeforePopupRef.current = false;
+      }
+    }
+  }, [showTooltip]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Quick upvote via double-tap — opens vote popup (same as sidebar heart button)
+  const quickUpvote = useCallback(() => {
+    const video = videos[currentIndex];
+    if (!video) return;
+    // Open the vote tooltip (same as clicking the heart in the sidebar)
+    if (!authenticated) {
+      toast.error('Login to vote');
+      return;
+    }
+    setSelectedComment({ author: video.author, permlink: video.hivePermlink });
+    setShowTooltip(true);
+    setActiveTooltipPermlink(video.hivePermlink);
+  }, [videos, currentIndex, authenticated]);
+
+  // Desktop mouse handlers: mouseDown starts a long-press timer (mute/unmute), mouseUp cancels it,
+  // click fires the single/double-click gesture (play/pause or upvote).
+  // Touch devices suppress click via e.preventDefault() in onTouchEnd, so no double-fire.
+  const handleOverlayMouseDown = useCallback((e) => {
+    if (showComments) return;
+    mouseLongPressHandledRef.current = false;
+    mouseLongPressRef.current = setTimeout(() => {
+      mouseLongPressHandledRef.current = true;
+      toggleMute();
+    }, 700); // Longer threshold for mouse (700ms vs 500ms touch)
+  }, [showComments, toggleMute]);
+
+  const handleOverlayMouseUp = useCallback(() => {
+    if (mouseLongPressRef.current) {
+      clearTimeout(mouseLongPressRef.current);
+      mouseLongPressRef.current = null;
+    }
+  }, []);
+
+  const handleOverlayClick = useCallback((e) => {
+    e.stopPropagation();
+    // Skip click if it was synthesized from a recent touch (touch handler already processed it)
+    if (recentTouchRef.current) return;
+    if (showComments || mouseLongPressHandledRef.current) return;
+
+    tapCountRef.current += 1;
+    if (tapCountRef.current === 1) {
+      tapTimerRef.current = setTimeout(() => {
+        if (tapCountRef.current === 1) {
+          togglePlayPause();
+        }
+        tapCountRef.current = 0;
+      }, 300);
+    } else if (tapCountRef.current >= 2) {
+      if (tapTimerRef.current) clearTimeout(tapTimerRef.current);
+      tapCountRef.current = 0;
+      quickUpvote();
+    }
+  }, [showComments, togglePlayPause, quickUpvote]);
 
   const seekTo = useCallback((time) => {
     sendCommand('seek', { time });
   }, [sendCommand]);
 
   const handleProgressBarInteraction = useCallback((e) => {
-    if (!progressBarRef.current || duration === 0) return;
+    if (!progressBarRef.current || durationRef.current === 0) return;
 
     const rect = progressBarRef.current.getBoundingClientRect();
     const x = e.clientX - rect.left;
     const percentage = Math.max(0, Math.min(1, x / rect.width));
-    const newTime = percentage * duration;
+    const newTime = percentage * durationRef.current;
 
     seekTo(newTime);
-    setCurrentTime(newTime);
-  }, [duration, seekTo]);
+    currentTimeRef.current = newTime;
+    updateProgressBar();
+  }, [seekTo, updateProgressBar]);
 
   const handleProgressMouseDown = useCallback((e) => {
     e.stopPropagation();
@@ -245,6 +399,8 @@ const VideoShort = () => {
               next.add(sourceVideoId);
               return next;
             });
+            // Dismiss the initial "Loading shorts..." overlay once any player is ready
+            setFirstPlayerReady(true);
           }
           
           // Apply orientation styles to the source iframe
@@ -269,38 +425,33 @@ const VideoShort = () => {
             }
           }
 
-          // If this video is waiting to be played (is current and was pending), play it now
+          // If this is the current video (or pending), sync mute + play.
+          // Background iframes ignore postMessage, so we only sync when becoming current.
           if (isFromCurrentVideo || pendingPlayRef.current === sourceVideoId) {
             console.log(`[VideoShort] Player ready - now playing: ${sourceVideoId}`);
             pendingPlayRef.current = null;
-            setTimeout(() => {
-              sourceIframe?.contentWindow?.postMessage({ type: 'play' }, '*');
-            }, 50);
+            setTimeout(() => playIframeWithMuteSync(sourceIframe), 50);
           }
           break;
 
         case '3speak-timeupdate':
-          // Only update state if from current video
+          // Only update if from current video — use refs (not state) to avoid re-renders
           if (isFromCurrentVideo && !isScrubbing && data.duration > 0) {
-            setCurrentTime(data.currentTime || 0);
-            setDuration(data.duration);
+            currentTimeRef.current = data.currentTime || 0;
+            durationRef.current = data.duration;
+            updateProgressBar(); // Direct DOM update, no React re-render
             if (data.paused !== undefined) {
               setIsPlaying(!data.paused);
             }
-            // Loop before the player reaches the end (avoids replay button flash)
-            if (data.currentTime > 0 && data.duration - data.currentTime <= 0.15) {
-              const loopIframe = sourceVideoId ? iframeRefs.current[sourceVideoId] : null;
-              if (loopIframe?.contentWindow) {
-                loopIframe.contentWindow.postMessage({ type: 'seek', time: 0 }, '*');
-                loopIframe.contentWindow.postMessage({ type: 'play' }, '*');
-              }
-            }
+            // NOTE: We intentionally do NOT sync muted state from the player.
+            // Our React state (isMuted / isMutedRef) is the source of truth.
+            // Looping is handled natively by the player via loop=1 param.
           }
           break;
 
         case '3speak-durationchange':
           if (isFromCurrentVideo) {
-            setDuration(data.duration || 0);
+            durationRef.current = data.duration || 0;
           }
           break;
 
@@ -317,16 +468,17 @@ const VideoShort = () => {
           break;
 
         case '3speak-ended':
-          if (isFromCurrentVideo) {
-            // Auto-replay: seek to start and play again
-            const endedIframe = sourceVideoId ? iframeRefs.current[sourceVideoId] : null;
-            if (endedIframe?.contentWindow) {
-              endedIframe.contentWindow.postMessage({ type: 'seek', time: 0 }, '*');
-              setTimeout(() => {
-                endedIframe.contentWindow?.postMessage({ type: 'play' }, '*');
-              }, 50);
-            }
-          }
+          // Looping is handled natively by the player via loop=1 param.
+          // The player should not fire this event when loop=1 is set,
+          // but if it does, no action needed.
+          break;
+
+        case '3speak-state':
+          console.log(`[MuteSync] STATE from ${sourceVideoId}: muted=${data.muted}, intendedMuted=${data.intendedMuted}, paused=${data.paused}, volume=${data.volume}`);
+          break;
+
+        case '3speak-volumechange':
+          console.log(`[MuteSync] VOLUMECHANGE from ${sourceVideoId}: muted=${data.muted}, volume=${data.volume}`);
           break;
       }
     };
@@ -336,47 +488,62 @@ const VideoShort = () => {
   }, [isScrubbing, videos, currentIndex]);
 
   // Handle video change - pause previous, play current
+  // Only react to actual index changes (not videos enrichment re-renders)
   useEffect(() => {
     const currentVid = videos[currentIndex];
+    if (!currentVid) return;
+
+    // Skip if index hasn't actually changed (e.g. videos array updated by enrichment)
+    if (prevIndexRef.current === currentIndex && currentVid.id === prevVideoIdRef.current) return;
+
     const prevIndex = prevIndexRef.current;
     const prevVid = videos[prevIndex];
 
-    if (!currentVid) return;
-
     console.log(`[VideoShort] Index changed: ${prevIndex} -> ${currentIndex}, video: ${currentVid.id}`);
+
+    // Always clear pending play from previous navigation
+    pendingPlayRef.current = null;
 
     // Update URL with current video (without page reload)
     updateUrlWithCurrentVideo(currentVid);
 
     // Reset player state
     setIsPlaying(false);
-    setCurrentTime(0);
-    setDuration(0);
+    currentTimeRef.current = 0;
+    durationRef.current = 0;
+    updateProgressBar();
     setParentCardVisible(true);
     setCaptionExpanded(false);
 
-    // Pause the previous video if different
-    if (prevVid && prevVid.id !== currentVid.id) {
-      console.log(`[VideoShort] Pausing previous video: ${prevVid.id}`);
-      sendCommandToVideo(prevVid, 'pause');
-    }
+    // Pause ALL other players (not just previous) to free up connections on mobile
+    Object.entries(iframeRefs.current).forEach(([id, iframe]) => {
+      if (id !== currentVid.id && iframe?.contentWindow) {
+        try {
+          iframe.contentWindow.postMessage({ type: 'pause' }, '*');
+        } catch (e) { /* ignore */ }
+      }
+    });
+
+    // Update tracking refs
+    prevIndexRef.current = currentIndex;
+    prevVideoIdRef.current = currentVid.id;
 
     // Check if the player is already ready
     const isPlayerReady = readyPlayers.current.has(currentVid.id);
     console.log(`[VideoShort] Player ready status for ${currentVid.id}: ${isPlayerReady}`);
 
     if (isPlayerReady) {
-      // Player is ready, play immediately
+      // Player is ready, play immediately (small delay for DOM to settle)
       const iframe = iframeRefs.current[currentVid.id];
       if (iframe?.contentWindow) {
         console.log(`[VideoShort] Playing immediately (player ready): ${currentVid.id}`);
-        iframe.contentWindow.postMessage({ type: 'play' }, '*');
+        setTimeout(() => playIframeWithMuteSync(iframe), 50);
       }
     } else {
       // Player not ready yet, set as pending and wait for 3speak-player-ready
       console.log(`[VideoShort] Player not ready, setting pending play: ${currentVid.id}`);
       pendingPlayRef.current = currentVid.id;
-      
+
       // Also set up a fallback with retries in case the ready event was missed
       const timeouts = [];
       const playIfReady = (attempt) => {
@@ -385,38 +552,56 @@ const VideoShort = () => {
           console.log(`[VideoShort] Skipping retry - no longer pending: ${currentVid.id}`);
           return;
         }
-        
+
         // Check if player became ready
         if (readyPlayers.current.has(currentVid.id)) {
           const iframe = iframeRefs.current[currentVid.id];
           if (iframe?.contentWindow) {
             console.log(`[VideoShort] Playing on retry ${attempt} (player now ready): ${currentVid.id}`);
             pendingPlayRef.current = null;
-            iframe.contentWindow.postMessage({ type: 'play' }, '*');
+            playIframeWithMuteSync(iframe);
           }
         } else {
           console.log(`[VideoShort] Retry ${attempt}: Player still not ready: ${currentVid.id}`);
         }
       };
-      
+
       // Retry at longer intervals to catch late ready events
       [500, 1000, 1500, 2000, 3000, 4000, 5000].forEach((delay, idx) => {
         const timeout = setTimeout(() => playIfReady(idx + 1), delay);
         timeouts.push(timeout);
       });
 
-      // Update previous index
-      prevIndexRef.current = currentIndex;
-
       // Cleanup
       return () => {
         timeouts.forEach(t => clearTimeout(t));
       };
     }
-
-    // Update previous index
-    prevIndexRef.current = currentIndex;
   }, [currentIndex, videos, sendCommandToVideo]);
+
+  // Force-show fallback: if the player hasn't sent ready after 6s, show it anyway and try playing
+  useEffect(() => {
+    const currentVid = videos[currentIndex];
+    if (!currentVid || readyPlayers.current.has(currentVid.id)) return;
+
+    const timer = setTimeout(() => {
+      if (!readyPlayers.current.has(currentVid.id)) {
+        console.log(`[VideoShort] Force-showing player after timeout: ${currentVid.id}`);
+        readyPlayers.current.add(currentVid.id);
+        setReadyPlayerIds(prev => {
+          const next = new Set(prev);
+          next.add(currentVid.id);
+          return next;
+        });
+        setFirstPlayerReady(true);
+        // Try playing — the iframe may be functional, just didn't fire the ready event
+        const iframe = iframeRefs.current[currentVid.id];
+        playIframeWithMuteSync(iframe);
+      }
+    }, 6000);
+
+    return () => clearTimeout(timer);
+  }, [currentIndex, videos]);
 
   // Lazy enrichment: when a short becomes visible and hasn't been enriched yet,
   // fetch full Hive data (vote status, reaction chain, child reactions) in background
@@ -590,29 +775,38 @@ const VideoShort = () => {
       try {
         setError(null);
 
-        // Try preloaded data first (already fetched when the app loaded)
-        // Only show the loading spinner if we actually need to fetch
-        if (!hasShortsPreloaded()) {
+        // User-specific feed mode: skip preloading, fetch directly from user endpoint
+        if (feedUser) {
           setLoading(true);
-        }
+          const data = await fetchUserShortsWithDetails(feedUser, 1, 20);
+          if (data.success) {
+            const formattedVideos = formatShorts(data.shorts);
+            await applySharedVideoLogic(formattedVideos, data);
+          }
+        } else {
+          // Default global feed
+          // Try preloaded data first (already fetched when the app loaded)
+          if (!hasShortsPreloaded()) {
+            setLoading(true);
+          }
 
-        const preloaded = await consumePreloadedShorts();
-        if (preloaded?.success) {
-          const formattedVideos = formatShorts(preloaded.shorts);
-          await applySharedVideoLogic(formattedVideos, preloaded);
+          const preloaded = await consumePreloadedShorts();
+          if (preloaded?.success) {
+            const formattedVideos = formatShorts(preloaded.shorts);
+            await applySharedVideoLogic(formattedVideos, preloaded);
+            setLoading(false);
+            return;
+          }
 
-          setLoading(false);
-          return;
-        }
+          // No preload available — generate a fresh seed and fetch
+          setLoading(true);
+          regenerateShortsSeed();
+          const data = await hiveApi.fetchShortsWithDetails(1, 10, user);
 
-        // No preload available — generate a fresh seed and fetch
-        setLoading(true);
-        regenerateShortsSeed();
-        const data = await hiveApi.fetchShortsWithDetails(1, 10, user);
-
-        if (data.success) {
-          const formattedVideos = formatShorts(data.shorts);
-          await applySharedVideoLogic(formattedVideos, data);
+          if (data.success) {
+            const formattedVideos = formatShorts(data.shorts);
+            await applySharedVideoLogic(formattedVideos, data);
+          }
         }
       } catch (err) {
         console.error('Error fetching shorts:', err);
@@ -623,7 +817,7 @@ const VideoShort = () => {
     };
 
     fetchShorts();
-  }, [user, getSharedVideoFromUrl, updateUrlWithCurrentVideo]);
+  }, [user, feedUser, getSharedVideoFromUrl, updateUrlWithCurrentVideo]);
 
   /* ---------- HANDLE IN-PAGE NAVIGATION TO A SHORT ---------- */
   // When location.search changes (e.g. clicking "View parent reaction"),
@@ -643,10 +837,14 @@ const VideoShort = () => {
     const [targetAuthor, targetPermlink] = videoParam.split('/');
     if (!targetAuthor || !targetPermlink) return;
 
-    // Save current short to history stack for back navigation
-    const currentVid = videos[currentIndex];
-    if (currentVid) {
-      shortHistoryRef.current = [...shortHistoryRef.current, { author: currentVid.author, permlink: currentVid.permlink }];
+    // Save current short to history stack for back navigation (skip when navigating back)
+    if (isNavigatingBackRef.current) {
+      isNavigatingBackRef.current = false;
+    } else {
+      const currentVid = videos[currentIndex];
+      if (currentVid) {
+        shortHistoryRef.current = [...shortHistoryRef.current, { author: currentVid.author, permlink: currentVid.permlink }];
+      }
     }
 
     // Check if it's already in the feed
@@ -795,14 +993,16 @@ const VideoShort = () => {
 
   /* ---------- LOAD MORE VIDEOS ---------- */
   const loadMoreVideos = useCallback(async () => {
-    if (!hasMore || loading) return;
+    if (!hasMore || loadingMoreRef.current) return;
+    loadingMoreRef.current = true;
 
     const nextPage = page + 1;
     setPage(nextPage);
 
     try {
-
-      const data = await hiveApi.fetchShortsWithDetails(nextPage, 20, user);
+      const data = feedUserRef.current
+        ? await fetchUserShortsWithDetails(feedUserRef.current, nextPage, 20)
+        : await hiveApi.fetchShortsWithDetails(nextPage, 20, user);
 
       if (data.success) {
         const formattedVideos = data.shorts.map(short => ({
@@ -852,8 +1052,10 @@ const VideoShort = () => {
       }
     } catch (err) {
       console.error('Error loading more shorts:', err);
+    } finally {
+      loadingMoreRef.current = false;
     }
-  }, [hasMore, loading, page]);
+  }, [hasMore, page]);
 
   /* ---------- FETCH COMMENTS ---------- */
   const fetchComments = useCallback(async () => {
@@ -867,6 +1069,20 @@ const VideoShort = () => {
 
     try {
       const comments = await hiveApi.fetchPostComments(video.author, video.hivePermlink, user);
+
+      // Pre-render comment bodies as HTML
+      try {
+        const render = await getRenderer();
+        const rendered = {};
+        const renderComment = (c) => {
+          if (c?.body) {
+            try { rendered[c.permlink] = render(c.body); } catch (_) {}
+          }
+          if (c.children) c.children.forEach(renderComment);
+        };
+        comments.forEach(renderComment);
+        setRenderedBodies(prev => ({ ...prev, ...rendered }));
+      } catch (_) {}
 
       setVideos(prev =>
         prev.map((v, idx) =>
@@ -1030,15 +1246,19 @@ const VideoShort = () => {
 
   // Update post (video) state after a vote on the main post
   const handlePostVoteSuccess = (author, permlink, isNewVote, voteWeight) => {
+    // Show heart animation on confirmed vote
+    setShowHeartAnimation(true);
+    if (heartAnimTimeoutRef.current) clearTimeout(heartAnimTimeoutRef.current);
+    heartAnimTimeoutRef.current = setTimeout(() => setShowHeartAnimation(false), 800);
+
     setVideos(prev => prev.map(v => {
       if (v.author === author && v.hivePermlink === permlink) {
-        // Only increment likes count if it's a new vote (not a re-vote with different weight)
-        const newLikes = isNewVote 
-          ? (v.stats?.likes || 0) + 1 
+        const newLikes = isNewVote
+          ? (v.stats?.likes || 0) + 1
           : v.stats?.likes || 0;
         return {
           ...v,
-          isLiked: true, // Always set to true on successful vote
+          isLiked: true,
           stats: { ...v.stats, likes: newLikes }
         };
       }
@@ -1052,6 +1272,7 @@ const VideoShort = () => {
     if (history.length === 0) return;
     const prev = history[history.length - 1];
     shortHistoryRef.current = history.slice(0, -1);
+    isNavigatingBackRef.current = true;
     navigate(`/shorts?v=${prev.author}/${prev.permlink}`, { replace: true });
   }, [navigate]);
 
@@ -1106,6 +1327,37 @@ const VideoShort = () => {
 
   const handleToggleComments = () => setShowComments(prev => !prev);
 
+  // Mobile comments panel drag-to-close
+  const handleCommentsDragStart = useCallback((e) => {
+    commentsDragStartY.current = e.touches[0].clientY;
+    const panel = commentsPanelRef.current;
+    if (panel) panel.style.transition = 'none';
+  }, []);
+
+  const handleCommentsDragMove = useCallback((e) => {
+    if (commentsDragStartY.current == null) return;
+    const dy = e.touches[0].clientY - commentsDragStartY.current;
+    const offset = Math.max(0, dy); // only allow dragging down
+    const panel = commentsPanelRef.current;
+    if (panel) panel.style.transform = `translateY(${offset}px)`;
+  }, []);
+
+  const handleCommentsDragEnd = useCallback((e) => {
+    if (commentsDragStartY.current == null) return;
+    const dy = e.changedTouches[0].clientY - commentsDragStartY.current;
+    commentsDragStartY.current = null;
+    const panel = commentsPanelRef.current;
+    if (panel) panel.style.transition = '';
+    if (dy > 80) {
+      // Dragged down far enough — close
+      setShowComments(false);
+      if (panel) panel.style.transform = '';
+    } else {
+      // Snap back
+      if (panel) panel.style.transform = '';
+    }
+  }, []);
+
   /* ---------- NAVIGATION ---------- */
 
   const triggerSwipeAnimation = (direction) => {
@@ -1118,26 +1370,42 @@ const VideoShort = () => {
     }, 350);
   };
 
+  // Find the nearest ready player index in a given direction, skipping up to `maxSkip` non-ready videos
+  const findNextReady = (fromIdx, direction = 1, maxSkip = 2) => {
+    let target = fromIdx + direction;
+    if (readyPlayers.current.has(videos[target]?.id)) return target;
+    for (let i = 1; i <= maxSkip; i++) {
+      const candidate = target + i * direction;
+      if (candidate < 0 || candidate >= videos.length) break;
+      if (readyPlayers.current.has(videos[candidate]?.id)) return candidate;
+    }
+    return target; // fallback to immediate next (will show thumbnail)
+  };
+
   const handlePrevious = () => {
     if (currentIndex === 0) return;
     shortHistoryRef.current = [];
     triggerSwipeAnimation('down');
-    setCurrentIndex(prev => prev - 1);
+    const prevIdx = findNextReady(currentIndex, -1);
+    setCurrentIndex(Math.max(0, prevIdx));
   };
 
   const handleNext = async () => {
-    if (currentIndex === videos.length - 1) {
-      if (hasMore) {
+    if (currentIndex >= videos.length - 1) {
+      if (hasMore && !loadingMoreRef.current) {
         await loadMoreVideos();
+        triggerSwipeAnimation('up');
+        setCurrentIndex(prev => prev + 1);
       }
       return;
     }
     shortHistoryRef.current = [];
     triggerSwipeAnimation('up');
-    setCurrentIndex(prev => prev + 1);
+    const nextIdx = findNextReady(currentIndex, 1);
+    setCurrentIndex(Math.min(videos.length - 1, nextIdx));
 
     // Prefetch 7 items before the end of the current page
-    if (currentIndex >= videos.length - 7 && hasMore) {
+    if (nextIdx >= videos.length - 7 && hasMore) {
       loadMoreVideos();
     }
   };
@@ -1158,12 +1426,23 @@ const VideoShort = () => {
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
         handlePrevious();
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        seekTo(Math.max(0, currentTimeRef.current - 5));
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        seekTo(Math.min(durationRef.current, currentTimeRef.current + 5));
+      } else if (e.key === ' ') {
+        e.preventDefault();
+        togglePlayPause();
+      } else if (e.key === 'm' || e.key === 'M') {
+        toggleMute();
       }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [handleNext, handlePrevious, showComments, isTransitioning]);
+  }, [handleNext, handlePrevious, seekTo, togglePlayPause, toggleMute, showComments, isTransitioning]);
 
   // Local handler for the hidden focusable element (helps capture on mobile)
   const handleKeyDownCapture = (e) => {
@@ -1179,6 +1458,17 @@ const VideoShort = () => {
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
       handlePrevious();
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      seekTo(Math.max(0, currentTimeRef.current - 5));
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      seekTo(Math.min(durationRef.current, currentTimeRef.current + 5));
+    } else if (e.key === ' ') {
+      e.preventDefault();
+      togglePlayPause();
+    } else if (e.key === 'm' || e.key === 'M') {
+      toggleMute();
     }
   };
 
@@ -1188,7 +1478,15 @@ const VideoShort = () => {
     // Don't handle swipe if comments panel is open
     if (showComments) return;
     setTouchEnd(null);
-    setTouchStart(e.targetTouches[0].clientY);
+    const startY = e.targetTouches[0].clientY;
+    setTouchStart(startY);
+    touchStartYRef.current = startY; // Synchronous mirror for reliable gesture detection
+    gestureHandledRef.current = false;
+    // Start long-press timer (500ms)
+    longPressTimerRef.current = setTimeout(() => {
+      gestureHandledRef.current = true;
+      toggleMute();
+    }, 500);
     // attempt to focus the hidden keyboard capture so mobile hardware keyboards send events
     try {
       keyboardRef.current?.focus?.();
@@ -1206,31 +1504,65 @@ const VideoShort = () => {
       const delta = y - touchStart;
       setSwipeDragY(Math.max(-120, Math.min(120, delta)));
     }
+    // Cancel long press if finger is moving
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
   };
 
-  const onTouchEnd = async () => {
+  const onTouchEnd = async (e) => {
+    // Prevent browser from synthesizing a click event after touch
+    if (e?.preventDefault) e.preventDefault();
+    // Guard: mark recent touch so handleOverlayClick skips any synthetic click
+    recentTouchRef.current = true;
+    setTimeout(() => { recentTouchRef.current = false; }, 400);
     setSwipeDragY(0);
-    if (!touchStart || !touchEnd || showComments || isTransitioning) return;
+    // Cancel long-press timer
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
 
-    const distance = touchStart - touchEnd;
-    const isSwipeUp = distance > minSwipeDistance;
-    const isSwipeDown = distance < -minSwipeDistance;
+    // Compute swipe distance from refs/event (not state, which may be stale on fast swipes)
+    const startY = touchStartYRef.current;
+    const endY = e.changedTouches?.[0]?.clientY;
+    const distance = startY != null && endY != null ? startY - endY : 0;
+    const wasSwipe = Math.abs(distance) > minSwipeDistance;
 
-    if (isSwipeUp && (currentIndex < videos.length - 1 || hasMore)) {
-      // Swipe up = next video
-      setIsTransitioning(true);
-      await handleNext();
-      setTimeout(() => setIsTransitioning(false), 350);
-    } else if (isSwipeDown && currentIndex > 0) {
-      // Swipe down = previous video
-      setIsTransitioning(true);
-      handlePrevious();
-      setTimeout(() => setIsTransitioning(false), 350);
+    if (startY != null && endY != null && !showComments && !isTransitioning) {
+      if (distance > minSwipeDistance && (currentIndex < videos.length - 1 || hasMore)) {
+        setIsTransitioning(true);
+        await handleNext();
+        setTimeout(() => setIsTransitioning(false), 350);
+      } else if (distance < -minSwipeDistance && currentIndex > 0) {
+        setIsTransitioning(true);
+        handlePrevious();
+        setTimeout(() => setIsTransitioning(false), 350);
+      }
     }
 
     // Reset touch state
     setTouchStart(null);
     setTouchEnd(null);
+    touchStartYRef.current = null;
+
+    // Gesture tap detection — only if it wasn't a swipe or long press
+    if (wasSwipe || gestureHandledRef.current || showComments) return;
+
+    tapCountRef.current += 1;
+    if (tapCountRef.current === 1) {
+      tapTimerRef.current = setTimeout(() => {
+        if (tapCountRef.current === 1) {
+          togglePlayPause();
+        }
+        tapCountRef.current = 0;
+      }, 300);
+    } else if (tapCountRef.current >= 2) {
+      if (tapTimerRef.current) clearTimeout(tapTimerRef.current);
+      tapCountRef.current = 0;
+      quickUpvote();
+    }
   };
 
   const formatNumber = (num) =>
@@ -1244,15 +1576,16 @@ const VideoShort = () => {
     return `$${num.toFixed(2)}`;
   };
 
-  const progressPercentage = duration > 0 ? (currentTime / duration) * 100 : 0;
-
-  // Calculate which videos to preload — on mobile iframes load slower so keep more ahead
-  const isMobile = typeof window !== 'undefined' && window.innerWidth <= 768;
-  const preloadRange = { before: 3, after: isMobile ? 10 : 6 };
-  const preloadedIndices = [];
-  for (let i = Math.max(0, currentIndex - preloadRange.before); i <= Math.min(videos.length - 1, currentIndex + preloadRange.after); i++) {
-    preloadedIndices.push(i);
-  }
+  // Calculate which videos to preload — memoized to prevent cleanup effect from running on every render
+  const preloadedIndices = useMemo(() => {
+    const isMobile = typeof window !== 'undefined' && window.innerWidth <= 768;
+    const preloadRange = { before: 1, after: isMobile ? 4 : 4 };
+    const indices = [];
+    for (let i = Math.max(0, currentIndex - preloadRange.before); i <= Math.min(videos.length - 1, currentIndex + preloadRange.after); i++) {
+      indices.push(i);
+    }
+    return indices;
+  }, [currentIndex, videos.length]);
 
   // Store iframe ref
   const setIframeRef = useCallback((videoId, element) => {
@@ -1325,12 +1658,20 @@ const VideoShort = () => {
   }, [videos, currentIndex]);
 
   // Clean up old iframe refs that are no longer in preload range
+  // IMPORTANT: pause players before removing them so HLS streams stop downloading
   useEffect(() => {
     const preloadedIds = new Set(preloadedIndices.map(idx => videos[idx]?.id).filter(Boolean));
     chainPreloadEntries.forEach(e => preloadedIds.add(e.id));
     const removedIds = [];
     Object.keys(iframeRefs.current).forEach(id => {
       if (!preloadedIds.has(id)) {
+        // Pause the player to stop HLS stream download before removing
+        const iframe = iframeRefs.current[id];
+        if (iframe?.contentWindow) {
+          try {
+            iframe.contentWindow.postMessage({ type: 'pause' }, '*');
+          } catch (e) { /* iframe may already be gone */ }
+        }
         delete iframeRefs.current[id];
         readyPlayers.current.delete(id);
         removedIds.push(id);
@@ -1362,6 +1703,10 @@ const VideoShort = () => {
       </main>
     );
   }
+
+  // Show "Loading shorts..." overlay until the first player is ready
+  // (iframes render underneath so they can load in the background)
+  const showInitialLoadingOverlay = !firstPlayerReady && videos.length > 0;
 
   if (error && videos.length === 0) {
     return (
@@ -1399,9 +1744,6 @@ const VideoShort = () => {
         <div
           className={`videoContainer${swipeDirection ? ` swipe-${swipeDirection}` : ''}`}
           ref={videoContainerRef}
-          onTouchStart={onTouchStart}
-          onTouchMove={onTouchMove}
-          onTouchEnd={onTouchEnd}
           style={swipeDragY && !swipeDirection ? { transform: `translateY(${swipeDragY * 0.3}px)`, transition: 'none' } : undefined}
         >
           {/* Preloaded iframes for smooth playback */}
@@ -1416,14 +1758,14 @@ const VideoShort = () => {
                 key={video.id}
                 id={getPlayerId(video)}
                 ref={(el) => setIframeRef(video.id, el)}
-                src={`${PLAYER_URL}/embed?v=${video.author}/${video.permlink}&mode=iframe&controls=0`}
+                src={`${PLAYER_URL}/embed?v=${video.author}/${video.permlink}&mode=iframe&controls=0&loop=1&mute=1`}
                 width="100%"
                 height="100%"
                 frameBorder="0"
                 allow="autoplay; fullscreen"
                 allowFullScreen
                 onLoad={(e) => {
-                  // Store ref again on load in case it wasn't set
+
                   iframeRefs.current[video.id] = e.target;
                 }}
                 style={{
@@ -1438,7 +1780,7 @@ const VideoShort = () => {
             );
           })}
 
-          {/* Loading overlay while player initializes */}
+          {/* Thumbnail placeholder while player initializes */}
           {currentVideo && !readyPlayerIds.has(currentVideo.id) && (
             <div
               style={{
@@ -1449,15 +1791,48 @@ const VideoShort = () => {
                 height: '100%',
                 zIndex: 1,
                 display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                background: '#000',
+              }}
+            >
+              {currentVideo.thumbnailUrl && (
+                <img
+                  src={currentVideo.thumbnailUrl}
+                  alt=""
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: '100%',
+                    height: '100%',
+                    objectFit: 'contain',
+                  }}
+                />
+              )}
+              <Loader2 className="spinner" size={36} style={{ position: 'relative', zIndex: 2 }} />
+            </div>
+          )}
+
+          {/* Full "Loading shorts..." overlay for the very first video until its player is ready */}
+          {showInitialLoadingOverlay && (
+            <div
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: '100%',
+                zIndex: 10,
+                display: 'flex',
                 flexDirection: 'column',
                 alignItems: 'center',
                 justifyContent: 'center',
                 background: '#000',
-                gap: '1rem',
               }}
             >
               <Loader2 className="spinner" size={48} />
-              <p style={{ fontSize: '0.8rem', color: 'var(--text-secondary)', animation: 'pulseText 2s ease-in-out infinite' }}>Loading shorts...</p>
+              <p style={{ color: '#fff', marginTop: 12 }}>Loading shorts...</p>
             </div>
           )}
 
@@ -1466,13 +1841,14 @@ const VideoShort = () => {
             <iframe
               key={entry.id}
               ref={(el) => setIframeRef(entry.id, el)}
-              src={`${PLAYER_URL}/embed?v=${entry.author}/${entry.permlink}&mode=iframe&controls=0`}
+              src={`${PLAYER_URL}/embed?v=${entry.author}/${entry.permlink}&mode=iframe&controls=0&loop=1&mute=1`}
               width="100%"
               height="100%"
               frameBorder="0"
               allow="autoplay; fullscreen"
               allowFullScreen
               onLoad={(e) => {
+                // chain iframe loaded
                 iframeRefs.current[entry.id] = e.target;
               }}
               style={{
@@ -1486,16 +1862,35 @@ const VideoShort = () => {
             />
           ))}
 
-          {/* Transparent overlay for play/pause */}
+          {/* Transparent overlay for gestures */}
           <div
             className="videoOverlay"
-            onClick={togglePlayPause}
+            onClick={handleOverlayClick}
+            onMouseDown={handleOverlayMouseDown}
+            onMouseUp={handleOverlayMouseUp}
             onTouchStart={onTouchStart}
             onTouchMove={onTouchMove}
             onTouchEnd={onTouchEnd}
           >
+            {/* Play/Pause icon (long press feedback) */}
             <div className={`playPauseIcon ${showPlayPauseIcon ? 'visible' : ''}`}>
               {isPlaying ? <Pause size={48} /> : <Play size={48} />}
+            </div>
+            {/* Mute/Unmute icon (single tap feedback) */}
+            <div className={`playPauseIcon ${showMuteIcon ? 'visible' : ''}`}>
+              {isMuted ? <VolumeX size={48} /> : <Volume2 size={48} />}
+            </div>
+            {/* Heart animation (double tap feedback) */}
+            <div className={`heartAnimation ${showHeartAnimation ? 'visible' : ''}`}>
+              <Heart size={80} fill="#ff2d55" color="#ff2d55" />
+            </div>
+            {/* Mute/unmute toggle button */}
+            <div className="muteIndicator"
+              onClick={(e) => { e.stopPropagation(); toggleMute(); }}
+              onTouchStart={(e) => e.stopPropagation()}
+              onTouchEnd={(e) => { e.stopPropagation(); e.preventDefault(); toggleMute(); }}
+            >
+              {isMuted ? <VolumeX size={18} /> : <Volume2 size={18} />}
             </div>
           </div>
 
@@ -1506,8 +1901,8 @@ const VideoShort = () => {
             onMouseDown={handleProgressMouseDown}
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="videoProgressFill" style={{ width: `${progressPercentage}%` }} />
-            <div className="videoProgressHandle" style={{ left: `${progressPercentage}%` }} />
+            <div className="videoProgressFill" ref={progressFillRef} style={{ width: '0%' }} />
+            <div className="videoProgressHandle" ref={progressHandleRef} style={{ left: '0%' }} />
           </div>
 
           {/* Loading overlay for short navigation */}
@@ -1687,7 +2082,7 @@ const VideoShort = () => {
         <div className="actionSidebar" onClick={(e) => e.stopPropagation()}>
           <div className="actionItem" onClick={(e) => { e.stopPropagation(); toggleVoteTooltip(currentVideo.author, currentVideo.hivePermlink); }}>
             <div className={`actionButton ${currentVideo.isLiked ? 'liked' : ''}`}>
-              <ThumbsUp size={24} />
+              <Heart size={24} fill={currentVideo.isLiked ? '#ff2d55' : 'none'} />
             </div>
             <span className="actionLabel">{formatNumber(currentVideo.stats.likes)}</span>
             <CommentVoteTooltip
@@ -1736,6 +2131,13 @@ const VideoShort = () => {
             <span className="actionLabel">{currentVideo.stats.remixes || 0}</span>
           </div>
 
+          <div className="actionItem" onClick={(e) => { e.stopPropagation(); toggleMute(); }}>
+            <div className={`actionButton ${isMuted ? '' : 'active'}`}>
+              {isMuted ? <VolumeX size={24} /> : <Volume2 size={24} />}
+            </div>
+            <span className="actionLabel">{isMuted ? 'Unmute' : 'Mute'}</span>
+          </div>
+
           <div className="albumArt"  onClick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
@@ -1767,9 +2169,14 @@ const VideoShort = () => {
       />
 
       {/* COMMENTS PANEL */}
-      <div className={`commentsPanel ${showComments ? 'open' : ''}`}>
+      <div className={`commentsPanel ${showComments ? 'open' : ''}`} ref={commentsPanelRef}>
         {/* Mobile drag handle */}
-        <div className="commentsPanelHandle" />
+        <div
+          className="commentsPanelHandle"
+          onTouchStart={handleCommentsDragStart}
+          onTouchMove={handleCommentsDragMove}
+          onTouchEnd={handleCommentsDragEnd}
+        />
 
         <div className="commentsHeader">
           <span className="commentsTitle">Comments</span>
@@ -1821,6 +2228,7 @@ const VideoShort = () => {
                 handlePostComment={handlePostComment}
                 postingComment={postingComment}
                 user={user}
+                renderedBodies={renderedBodies}
               />
             ))
           )}
@@ -1879,12 +2287,22 @@ const CommentItem = ({
   setReplyText,
   handlePostComment,
   postingComment,
-  user
+  user,
+  renderedBodies
 }) => {
   const [showReplies, setShowReplies] = useState(false);
   const maxDepth = 3;
 
   const isReplying = activeReply === comment.permlink;
+
+  // Use pre-rendered HTML if available, strip "replied to" metadata
+  const getCommentHtml = () => {
+    let html = renderedBodies?.[comment.permlink] || comment.body || '';
+    return html
+      .replace(/<p>\s*<sup>\s*replied to\s*<a[^>]*>.*?<\/a>\s*<\/sup>\s*<\/p>/gi, '')
+      .replace(/<sup>\s*replied to\s*<a[^>]*>.*?<\/a>\s*<\/sup>/gi, '')
+      .replace(/\n?<sup>replied to \[.*?\]\([^)]*\)<\/sup>/g, '');
+  };
 
   return (
     <div className={`commentItem ${depth > 0 ? 'nested' : ''}`} style={{ marginLeft: depth > 0 ? '12px' : '0' }}>
@@ -1896,13 +2314,13 @@ const CommentItem = ({
           <span className="commentUsername">{comment.user?.username}</span>
           <span className="commentTime">{comment.timeAgo}</span>
         </div>
-        <p className="commentText">{comment.body}</p>
+        <div className="commentText markdown-view" dangerouslySetInnerHTML={{ __html: getCommentHtml() }} />
         <div className="commentActions">
           <button
             className={`commentActionBtn ${comment.has_voted ? 'liked' : ''}`}
             onClick={() => toggleVoteTooltip(comment.author, comment.permlink)}
           >
-            <ThumbsUp size={14} />
+            <Heart size={14} fill={comment.has_voted ? '#ff2d55' : 'none'} />
             <span>{comment.stats?.num_likes ?? 0}</span>
           </button>
           <div className="commentReward">
@@ -2001,6 +2419,7 @@ const CommentItem = ({
                 handlePostComment={handlePostComment}
                 postingComment={postingComment}
                 user={user}
+                renderedBodies={renderedBodies}
               />
             ))}
           </div>

--- a/src/page/Short.jsx
+++ b/src/page/Short.jsx
@@ -16,7 +16,12 @@ import {
   Pause,
   Send,
   ChevronUp,
-  ChevronDown
+  ChevronDown,
+  ArrowLeft,
+  ExternalLink,
+  Video,
+  MessageSquareText,
+  Camera
 } from 'lucide-react';
 import { GiTwoCoins } from 'react-icons/gi';
 
@@ -40,8 +45,9 @@ import axios from 'axios';
 import { toast } from 'sonner';
 import CommentVoteTooltip from '../components/tooltip/CommentVoteTooltip';
 import { PLAYER_URL } from '../utils/config';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate, useLocation, Link } from 'react-router-dom';
 import { fixVideoThumbnail } from '../utils/fixThumbnails';
+import AuthorBadge from '../components/AuthorBadge/AuthorBadge';
 
 
 /* ================= COMPONENT ================= */
@@ -56,6 +62,9 @@ const VideoShort = () => {
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
   const [parentCardVisible, setParentCardVisible] = useState(true);
+  const [expandedChainCard, setExpandedChainCard] = useState(null);
+  const [shortNavLoading, setShortNavLoading] = useState(false);
+  const shortHistoryRef = useRef([]); // Stack of {author, permlink} for back navigation
 
   // Player state
   const [isPlaying, setIsPlaying] = useState(false);
@@ -95,6 +104,7 @@ const VideoShort = () => {
 
   const accessToken = localStorage.getItem("access_token");
   const navigate = useNavigate();
+  const location = useLocation();
 
   // Minimum swipe distance to trigger navigation (in pixels)
   const minSwipeDistance = 50;
@@ -431,6 +441,9 @@ const VideoShort = () => {
             parentVideo: short.parentVideo || null,
             parentTimestamp: short.parentTimestamp || null,
             parentComment: short.parentComment || null,
+            parentShort: short.parentShort || null,
+            reactionChain: short.reactionChain || null,
+            childReactions: short.childReactions || null,
           }));
 
           // Check if there's a shared video in the URL
@@ -483,6 +496,9 @@ const VideoShort = () => {
                   parentVideo: sharedVideoData.parentVideo || null,
                   parentTimestamp: sharedVideoData.parentTimestamp || null,
                   parentComment: sharedVideoData.parentComment || null,
+                  parentShort: sharedVideoData.parentShort || null,
+                  reactionChain: sharedVideoData.reactionChain || null,
+                  childReactions: sharedVideoData.childReactions || null,
                 };
 
                 // Prepend shared video to the feed
@@ -517,6 +533,91 @@ const VideoShort = () => {
 
     fetchShorts();
   }, [user, getSharedVideoFromUrl, updateUrlWithCurrentVideo]);
+
+  /* ---------- HANDLE IN-PAGE NAVIGATION TO A SHORT ---------- */
+  // When location.search changes (e.g. clicking "View parent reaction"),
+  // jump to or load the target short without re-fetching the entire feed.
+  const prevSearchRef = useRef(location.search);
+  useEffect(() => {
+    if (location.search === prevSearchRef.current) return;
+    prevSearchRef.current = location.search;
+
+    // Only act if we already have videos loaded
+    if (videos.length === 0) return;
+
+    const params = new URLSearchParams(location.search);
+    const videoParam = params.get('v');
+    if (!videoParam) return;
+
+    const [targetAuthor, targetPermlink] = videoParam.split('/');
+    if (!targetAuthor || !targetPermlink) return;
+
+    // Save current short to history stack for back navigation
+    const currentVid = videos[currentIndex];
+    if (currentVid) {
+      shortHistoryRef.current = [...shortHistoryRef.current, { author: currentVid.author, permlink: currentVid.permlink }];
+    }
+
+    // Check if it's already in the feed
+    const existingIdx = videos.findIndex(
+      v => v.author === targetAuthor && v.permlink === targetPermlink
+    );
+
+    if (existingIdx !== -1) {
+      setCurrentIndex(existingIdx);
+      return;
+    }
+
+    // Not in feed — fetch and prepend it
+    setShortNavLoading(true);
+    (async () => {
+      try {
+        const shortEntry = await hiveApi.findShortByPermlink(targetPermlink);
+        const shortItem = shortEntry || {
+          owner: targetAuthor,
+          permlink: targetPermlink,
+          embed_url: `@${targetAuthor}/${targetPermlink}`,
+          thumbnail_url: '',
+          views: 0,
+          createdAt: new Date().toISOString(),
+          embed_title: '',
+        };
+
+        const shortData = await hiveApi.fetchCompleteShortData(shortItem, user);
+
+        const formatted = {
+          id: shortData.id,
+          author: shortData.author,
+          permlink: shortData.permlink,
+          hivePermlink: shortData.hivePermlink,
+          user: shortData.user,
+          caption: shortData.caption || shortData.title || '',
+          audio: `${shortData.user.username} - Original Audio`,
+          albumArt: shortData.user.avatar,
+          stats: shortData.stats,
+          isLiked: shortData.isLiked || false,
+          isDisliked: shortData.isDisliked || false,
+          comments: [],
+          commentsLoaded: false,
+          timeAgo: shortData.timeAgo,
+          createdAt: shortData.createdAt,
+          parentVideo: shortData.parentVideo || null,
+          parentTimestamp: shortData.parentTimestamp || null,
+          parentComment: shortData.parentComment || null,
+          parentShort: shortData.parentShort || null,
+          reactionChain: shortData.reactionChain || null,
+          childReactions: shortData.childReactions || null,
+        };
+
+        setVideos(prev => [formatted, ...prev]);
+        setCurrentIndex(0);
+      } catch (err) {
+        console.warn('Could not navigate to parent short:', err);
+      } finally {
+        setShortNavLoading(false);
+      }
+    })();
+  }, [location.search, videos, user]);
 
   /* ---------- LOAD MORE VIDEOS ---------- */
   const loadMoreVideos = useCallback(async () => {
@@ -561,6 +662,8 @@ const VideoShort = () => {
           parentVideo: short.parentVideo || null,
           parentTimestamp: short.parentTimestamp || null,
           parentComment: short.parentComment || null,
+          parentShort: short.parentShort || null,
+          reactionChain: short.reactionChain || null,
         }));
 
         setVideos(prev => [...prev, ...formattedVideos]);
@@ -760,6 +863,15 @@ const VideoShort = () => {
       return v;
     }));
   };
+
+  /* ---------- BACK NAVIGATION ---------- */
+  const handleShortBack = useCallback(() => {
+    const history = shortHistoryRef.current;
+    if (history.length === 0) return;
+    const prev = history[history.length - 1];
+    shortHistoryRef.current = history.slice(0, -1);
+    navigate(`/shorts?v=${prev.author}/${prev.permlink}`, { replace: true });
+  }, [navigate]);
 
   /* ---------- SHARE FUNCTIONALITY ---------- */
   const handleShare = async () => {
@@ -1073,40 +1185,145 @@ const VideoShort = () => {
             <div className="videoProgressHandle" style={{ left: `${progressPercentage}%` }} />
           </div>
 
-          {/* Bottom overlay */}
-          {/* Parent video overlay card (for reactions) */}
-          {currentVideo.parentVideo && (
-            <div className={`parentVideoOverlay${parentCardVisible ? '' : ' collapsed'}`} onClick={(e) => e.stopPropagation()}>
-              {parentCardVisible && (
-                <Link to={`/watch?v=${currentVideo.parentVideo.author}/${currentVideo.parentVideo.permlink}${currentVideo.parentTimestamp != null ? `&t=${currentVideo.parentTimestamp}` : ''}`} className="parentVideoCard">
-                  <img
-                    src={fixVideoThumbnail(currentVideo.parentVideo)}
-                    alt=""
-                    className="parentVideoThumb"
-                  />
-                  <div className="parentVideoInfo">
-                    <span className="parentVideoTitle">{currentVideo.parentVideo.title}</span>
-                    <span className="parentVideoAuthor">@{currentVideo.parentVideo.author}</span>
-                    {currentVideo.parentComment && (
-                      <div className="parentCommentExcerpt">
-                        <span className="parentCommentLabel">Replying to @{currentVideo.parentComment.author}:</span>
-                        <p className="parentCommentBody">{currentVideo.parentComment.body}</p>
+          {/* Loading overlay for short navigation */}
+          {shortNavLoading && (
+            <div className="shortNavLoadingOverlay" onClick={(e) => e.stopPropagation()}>
+              <Loader2 size={28} className="spinner" />
+            </div>
+          )}
+
+          {/* Back button (visible after navigating to a parent short) */}
+          {shortHistoryRef.current.length > 0 && (
+            <button className="shortBackBtn" onClick={(e) => { e.stopPropagation(); handleShortBack(); }}>
+              <ArrowLeft size={18} />
+              <span>Back</span>
+            </button>
+          )}
+
+          {/* Reaction chain overlay (for reactions) */}
+          {currentVideo.reactionChain && currentVideo.reactionChain.length > 0 && (() => {
+            const rootStep = currentVideo.reactionChain.find(s => s.isRoot);
+            const childSteps = currentVideo.reactionChain.filter(s => !s.isRoot);
+            const rootUrl = rootStep ? `/watch?v=${rootStep.author}/${rootStep.permlink}${currentVideo.parentTimestamp != null ? `&t=${currentVideo.parentTimestamp}` : ''}` : null;
+            return (
+              <div className={`reactionChainOverlay${parentCardVisible ? '' : ' collapsed'}${shortHistoryRef.current.length > 0 ? ' has-back' : ''}`} onClick={(e) => e.stopPropagation()}>
+                {parentCardVisible && (
+                  <div className="reactionChainBreadcrumb">
+                    {/* Root / origin card — 50% wide, thumb left + info right */}
+                    {rootStep && (
+                      <div className="chainRoot">
+                        {rootStep.thumbnail && (
+                          <img className="chainRootThumb" src={fixVideoThumbnail({ thumbnail: rootStep.thumbnail })} alt="" />
+                        )}
+                        <div className="chainRootInfo">
+                          <span className="chainRootTitle">{rootStep.title || 'Original video'}</span>
+                          <div className="chainRootMeta">
+                            <AuthorBadge author={rootStep.author} compact noLink />
+                            {currentVideo.parentTimestamp != null && (
+                              <span className="chainRootTimestamp">
+                                {Math.floor(currentVideo.parentTimestamp / 60)}:{(currentVideo.parentTimestamp % 60).toString().padStart(2, '0')}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                        <Link to={rootUrl} className="chainActionBtn" onClick={(e) => e.stopPropagation()} title="Watch">
+                          <Video size={14} />
+                        </Link>
+                      </div>
+                    )}
+
+                    {/* Child steps — horizontal scroll row */}
+                    {childSteps.length > 0 && (
+                      <div className="chainChildRow">
+                        {childSteps.map((step, i) => {
+                          const isExpanded = expandedChainCard === i;
+                          return (
+                            <React.Fragment key={i}>
+                              {i > 0 && <span className="chainDash">&mdash;</span>}
+                              <div
+                                className={`chainChild${isExpanded ? ' chainChild--expanded' : ''}${step.type === 'video' ? ' chainChild--video' : ' chainChild--comment'}`}
+                                onClick={() => setExpandedChainCard(isExpanded ? null : i)}
+                              >
+                                <div className="chainChildHeader">
+                                  <AuthorBadge author={step.author} compact noLink />
+                                  {step.type === 'video' && (
+                                    step.shortPermlink ? (
+                                      <Link to={`/shorts?v=${step.shortAuthor}/${step.shortPermlink}`} className="chainActionBtn chainActionBtn--sm" onClick={(e) => e.stopPropagation()} title="Open short">
+                                        <Camera size={11} />
+                                      </Link>
+                                    ) : (
+                                      <Link to={`/watch?v=${step.author}/${step.permlink}`} className="chainActionBtn chainActionBtn--sm" onClick={(e) => e.stopPropagation()} title="Watch">
+                                        <Video size={11} />
+                                      </Link>
+                                    )
+                                  )}
+                                </div>
+                                <span className={`chainChildTitle${isExpanded ? ' chainChildTitle--full' : ''}`}>
+                                  {step.title || (step.type === 'comment' ? 'Comment' : 'Reaction')}
+                                </span>
+                                {isExpanded && step.body && (
+                                  <p className="chainChildText">{step.body}</p>
+                                )}
+                                {step.duration > 0 && (
+                                  <span className="chainChildDuration">
+                                    {Math.floor(step.duration / 60)}:{Math.floor(step.duration % 60).toString().padStart(2, '0')}
+                                  </span>
+                                )}
+                              </div>
+                            </React.Fragment>
+                          );
+                        })}
+                        <span className="chainDash">&mdash;</span>
+                        {(() => {
+                          const currentIdx = childSteps.length;
+                          const isCurExpanded = expandedChainCard === currentIdx;
+                          return (
+                            <div
+                              className={`chainChild chainChild--current${isCurExpanded ? ' chainChild--expanded' : ''}`}
+                              onClick={() => setExpandedChainCard(isCurExpanded ? null : currentIdx)}
+                            >
+                              <div className="chainChildHeader">
+                                <AuthorBadge author={currentVideo.author} compact noLink />
+                              </div>
+                              <span className={`chainChildTitle${isCurExpanded ? ' chainChildTitle--full' : ''}`}>
+                                {currentVideo.caption || 'This video'}
+                              </span>
+                            </div>
+                          );
+                        })()}
+                        {/* Child reactions (downstream from current short) */}
+                        {currentVideo.childReactions?.map((child, ci) => (
+                          <React.Fragment key={`child-${ci}`}>
+                            <span className="chainDash">&mdash;</span>
+                            <div className="chainChild chainChild--video chainChild--downstream">
+                              <div className="chainChildHeader">
+                                <AuthorBadge author={child.author} compact noLink />
+                                <Link to={`/shorts?v=${child.shortAuthor}/${child.shortPermlink}`} className="chainActionBtn chainActionBtn--sm" onClick={(e) => e.stopPropagation()} title="Open short">
+                                  <Camera size={11} />
+                                </Link>
+                              </div>
+                              <span className="chainChildTitle">
+                                {child.title || 'Reaction'}
+                              </span>
+                              {child.duration > 0 && (
+                                <span className="chainChildDuration">
+                                  {Math.floor(child.duration / 60)}:{Math.floor(child.duration % 60).toString().padStart(2, '0')}
+                                </span>
+                              )}
+                            </div>
+                          </React.Fragment>
+                        ))}
                       </div>
                     )}
                   </div>
-                  {currentVideo.parentTimestamp != null && (
-                    <span className="parentVideoTimestamp">
-                      at {Math.floor(currentVideo.parentTimestamp / 60)}:{(currentVideo.parentTimestamp % 60).toString().padStart(2, '0')}
-                    </span>
-                  )}
-                </Link>
-              )}
-              <button className="parentVideoClose" onClick={(e) => { e.stopPropagation(); setParentCardVisible(prev => !prev); }}>
-                {!parentCardVisible && <span className="parentVideoCloseLabel">show origin</span>}
-                {parentCardVisible ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
-              </button>
-            </div>
-          )}
+                )}
+                <button className="chainToggleBtn" onClick={(e) => { e.stopPropagation(); setParentCardVisible(prev => !prev); }}>
+                  {!parentCardVisible && <span className="chainToggleLabel">show reaction chain</span>}
+                  {parentCardVisible ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+                </button>
+              </div>
+            );
+          })()}
 
           <div className="bottomOverlay">
             <div className="userRow">

--- a/src/page/Short.jsx
+++ b/src/page/Short.jsx
@@ -14,7 +14,9 @@ import {
   Loader2,
   Play,
   Pause,
-  Send
+  Send,
+  ChevronUp,
+  ChevronDown
 } from 'lucide-react';
 import { GiTwoCoins } from 'react-icons/gi';
 
@@ -38,7 +40,8 @@ import axios from 'axios';
 import { toast } from 'sonner';
 import CommentVoteTooltip from '../components/tooltip/CommentVoteTooltip';
 import { PLAYER_URL } from '../utils/config';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
+import { fixVideoThumbnail } from '../utils/fixThumbnails';
 
 
 /* ================= COMPONENT ================= */
@@ -52,6 +55,7 @@ const VideoShort = () => {
   const [error, setError] = useState(null);
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
+  const [parentCardVisible, setParentCardVisible] = useState(true);
 
   // Player state
   const [isPlaying, setIsPlaying] = useState(false);
@@ -311,6 +315,7 @@ const VideoShort = () => {
     setIsPlaying(false);
     setCurrentTime(0);
     setDuration(0);
+    setParentCardVisible(true);
 
     // Pause the previous video if different
     if (prevVid && prevVid.id !== currentVid.id) {
@@ -422,7 +427,10 @@ const VideoShort = () => {
             comments: [],
             commentsLoaded: false,
             timeAgo: short.timeAgo,
-            createdAt: short.createdAt
+            createdAt: short.createdAt,
+            parentVideo: short.parentVideo || null,
+            parentTimestamp: short.parentTimestamp || null,
+            parentComment: short.parentComment || null,
           }));
 
           // Check if there's a shared video in the URL
@@ -439,20 +447,22 @@ const VideoShort = () => {
               setVideos(formattedVideos);
               setCurrentIndex(sharedIndex);
             } else {
-              // Video not in current feed, fetch it separately and prepend
+              // Video not in current feed, search the API for the actual short data
               try {
-                const sharedVideoData = await hiveApi.fetchCompleteShortData(
-                  { 
-                    owner: sharedVideo.author, 
-                    permlink: sharedVideo.permlink,
-                    embed_url: `@${sharedVideo.author}/${sharedVideo.permlink}`,
-                    thumbnail_url: '',
-                    views: 0,
-                    createdAt: new Date().toISOString(),
-                    embed_title: ''
-                  }, 
-                  user
-                );
+                // Find the short in the API to get the correct embed_url (Hive permlink)
+                const actualShort = await hiveApi.findShortByPermlink(sharedVideo.permlink);
+
+                const shortItem = actualShort || {
+                  owner: sharedVideo.author,
+                  permlink: sharedVideo.permlink,
+                  embed_url: `@${sharedVideo.author}/${sharedVideo.permlink}`,
+                  thumbnail_url: '',
+                  views: 0,
+                  createdAt: new Date().toISOString(),
+                  embed_title: ''
+                };
+
+                const sharedVideoData = await hiveApi.fetchCompleteShortData(shortItem, user);
                 
                 const formattedSharedVideo = {
                   id: sharedVideoData.id,
@@ -469,7 +479,10 @@ const VideoShort = () => {
                   comments: [],
                   commentsLoaded: false,
                   timeAgo: sharedVideoData.timeAgo,
-                  createdAt: sharedVideoData.createdAt
+                  createdAt: sharedVideoData.createdAt,
+                  parentVideo: sharedVideoData.parentVideo || null,
+                  parentTimestamp: sharedVideoData.parentTimestamp || null,
+                  parentComment: sharedVideoData.parentComment || null,
                 };
 
                 // Prepend shared video to the feed
@@ -544,7 +557,10 @@ const VideoShort = () => {
           comments: [],
           commentsLoaded: false,
           timeAgo: short.timeAgo,
-          createdAt: short.createdAt
+          createdAt: short.createdAt,
+          parentVideo: short.parentVideo || null,
+          parentTimestamp: short.parentTimestamp || null,
+          parentComment: short.parentComment || null,
         }));
 
         setVideos(prev => [...prev, ...formattedVideos]);
@@ -1058,6 +1074,40 @@ const VideoShort = () => {
           </div>
 
           {/* Bottom overlay */}
+          {/* Parent video overlay card (for reactions) */}
+          {currentVideo.parentVideo && (
+            <div className={`parentVideoOverlay${parentCardVisible ? '' : ' collapsed'}`} onClick={(e) => e.stopPropagation()}>
+              {parentCardVisible && (
+                <Link to={`/watch?v=${currentVideo.parentVideo.author}/${currentVideo.parentVideo.permlink}${currentVideo.parentTimestamp != null ? `&t=${currentVideo.parentTimestamp}` : ''}`} className="parentVideoCard">
+                  <img
+                    src={fixVideoThumbnail(currentVideo.parentVideo)}
+                    alt=""
+                    className="parentVideoThumb"
+                  />
+                  <div className="parentVideoInfo">
+                    <span className="parentVideoTitle">{currentVideo.parentVideo.title}</span>
+                    <span className="parentVideoAuthor">@{currentVideo.parentVideo.author}</span>
+                    {currentVideo.parentComment && (
+                      <div className="parentCommentExcerpt">
+                        <span className="parentCommentLabel">Replying to @{currentVideo.parentComment.author}:</span>
+                        <p className="parentCommentBody">{currentVideo.parentComment.body}</p>
+                      </div>
+                    )}
+                  </div>
+                  {currentVideo.parentTimestamp != null && (
+                    <span className="parentVideoTimestamp">
+                      at {Math.floor(currentVideo.parentTimestamp / 60)}:{(currentVideo.parentTimestamp % 60).toString().padStart(2, '0')}
+                    </span>
+                  )}
+                </Link>
+              )}
+              <button className="parentVideoClose" onClick={(e) => { e.stopPropagation(); setParentCardVisible(prev => !prev); }}>
+                {!parentCardVisible && <span className="parentVideoCloseLabel">show origin</span>}
+                {parentCardVisible ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+              </button>
+            </div>
+          )}
+
           <div className="bottomOverlay">
             <div className="userRow">
               <div className="avatar" onClick={(e) => {

--- a/src/page/Short.jsx
+++ b/src/page/Short.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import "./Short.scss";
 import {
   ThumbsUp,
@@ -39,7 +39,7 @@ const HiveIcon = ({ size = 24, className = '' }) => (
     <path d="M6.076 1.637a.103.103 0 00-.09.05L.014 11.95a.102.102 0 000 .104l6.039 10.26c.04.068.14.068.18 0l5.972-10.262a.102.102 0 00-.002-.104L6.166 1.687a.103.103 0 00-.09-.05zm2.863 0c-.079 0-.13.085-.09.154l5.186 8.967a.105.105 0 00.09.053h3.117c.08 0 .13-.088.09-.157l-5.186-8.966a.104.104 0 00-.09-.051H8.94zm5.891 0a.102.102 0 00-.088.154L20.656 12l-5.914 10.209a.102.102 0 00.088.154h3.123a.1.1 0 00.088-.05l5.945-10.262a.1.1 0 000-.102L18.041 1.688a.1.1 0 00-.088-.051H14.83zm-.79 11.7a.1.1 0 00-.089.052l-5.101 8.82c-.04.069.01.154.09.154h3.117a.104.104 0 00.09-.05l5.1-8.82a.103.103 0 00-.09-.155h-3.118z" />
   </svg>
 );
-import hiveApi from '../hive-api/hiveApi';
+import hiveApi, { regenerateShortsSeed, consumePreloadedShorts, hasShortsPreloaded, preloadShorts } from '../hive-api/hiveApi';
 import { useAppStore } from '../lib/store';
 import axios from 'axios';
 import { toast } from 'sonner';
@@ -86,11 +86,15 @@ const VideoShort = () => {
   // Reply state
   const [activeReply, setActiveReply] = useState(null);
   const [replyText, setReplyText] = useState('');
+  const [captionExpanded, setCaptionExpanded] = useState(false);
 
   // Touch/swipe state for mobile navigation
   const [touchStart, setTouchStart] = useState(null);
   const [touchEnd, setTouchEnd] = useState(null);
   const [isTransitioning, setIsTransitioning] = useState(false);
+  const [swipeDirection, setSwipeDirection] = useState(null); // 'up' | 'down' | null
+  const [swipeDragY, setSwipeDragY] = useState(0); // live drag offset in px
+  const swipeAnimRef = useRef(null);
 
   const progressBarRef = useRef(null);
   const playPauseTimeoutRef = useRef(null);
@@ -100,7 +104,9 @@ const VideoShort = () => {
   const keyboardRef = useRef(null); // capture keyboard events on mobile when focused
   const prevIndexRef = useRef(0); // Track previous index
   const readyPlayers = useRef(new Set()); // Track which players have sent 3speak-player-ready
+  const [readyPlayerIds, setReadyPlayerIds] = useState(new Set()); // State mirror for render gating
   const pendingPlayRef = useRef(null); // Track video waiting to be played
+  const chainPreloadDataRef = useRef(new Map()); // Chain short metadata for instant navigation
 
   const accessToken = localStorage.getItem("access_token");
   const navigate = useNavigate();
@@ -233,6 +239,12 @@ const VideoShort = () => {
           // Mark this player as ready
           if (sourceVideoId) {
             readyPlayers.current.add(sourceVideoId);
+            setReadyPlayerIds(prev => {
+              if (prev.has(sourceVideoId)) return prev;
+              const next = new Set(prev);
+              next.add(sourceVideoId);
+              return next;
+            });
           }
           
           // Apply orientation styles to the source iframe
@@ -275,6 +287,14 @@ const VideoShort = () => {
             if (data.paused !== undefined) {
               setIsPlaying(!data.paused);
             }
+            // Loop before the player reaches the end (avoids replay button flash)
+            if (data.currentTime > 0 && data.duration - data.currentTime <= 0.15) {
+              const loopIframe = sourceVideoId ? iframeRefs.current[sourceVideoId] : null;
+              if (loopIframe?.contentWindow) {
+                loopIframe.contentWindow.postMessage({ type: 'seek', time: 0 }, '*');
+                loopIframe.contentWindow.postMessage({ type: 'play' }, '*');
+              }
+            }
           }
           break;
 
@@ -298,7 +318,14 @@ const VideoShort = () => {
 
         case '3speak-ended':
           if (isFromCurrentVideo) {
-            setIsPlaying(false);
+            // Auto-replay: seek to start and play again
+            const endedIframe = sourceVideoId ? iframeRefs.current[sourceVideoId] : null;
+            if (endedIframe?.contentWindow) {
+              endedIframe.contentWindow.postMessage({ type: 'seek', time: 0 }, '*');
+              setTimeout(() => {
+                endedIframe.contentWindow?.postMessage({ type: 'play' }, '*');
+              }, 50);
+            }
           }
           break;
       }
@@ -326,6 +353,7 @@ const VideoShort = () => {
     setCurrentTime(0);
     setDuration(0);
     setParentCardVisible(true);
+    setCaptionExpanded(false);
 
     // Pause the previous video if different
     if (prevVid && prevVid.id !== currentVid.id) {
@@ -390,138 +418,201 @@ const VideoShort = () => {
     prevIndexRef.current = currentIndex;
   }, [currentIndex, videos, sendCommandToVideo]);
 
-  // Cleanup on unmount
+  // Lazy enrichment: when a short becomes visible and hasn't been enriched yet,
+  // fetch full Hive data (vote status, reaction chain, child reactions) in background
+  useEffect(() => {
+    const currentVid = videos[currentIndex];
+    if (!currentVid || currentVid._enriched !== false) return;
+
+    // Mark as enriching to prevent duplicate calls
+    setVideos(prev => prev.map((v, i) => i === currentIndex ? { ...v, _enriched: 'loading' } : v));
+
+    const videoId = currentVid.id;
+    (async () => {
+      try {
+        const shortItem = {
+          owner: currentVid.author,
+          permlink: currentVid.permlink,
+          embed_url: currentVid.embedUrl || `@${currentVid.author}/${currentVid.hivePermlink}`,
+          thumbnail_url: currentVid.thumbnailUrl || '',
+          views: currentVid.stats?.views || currentVid.views || 0,
+          createdAt: currentVid.createdAt || '',
+          embed_title: currentVid.caption || '',
+        };
+        const enriched = await hiveApi.fetchCompleteShortData(shortItem, user);
+
+        setVideos(prev => prev.map(v => {
+          if (v.id !== videoId) return v;
+          return {
+            ...v,
+            isLiked: enriched.isLiked || false,
+            isDisliked: enriched.isDisliked || false,
+            parentVideo: enriched.parentVideo || null,
+            parentTimestamp: enriched.parentTimestamp || null,
+            parentComment: enriched.parentComment || null,
+            parentShort: enriched.parentShort || null,
+            reactionChain: enriched.reactionChain || null,
+            childReactions: enriched.childReactions || null,
+            _enriched: true,
+          };
+        }));
+      } catch (err) {
+        console.warn('Failed to enrich short:', err);
+        setVideos(prev => prev.map(v => v.id === videoId ? { ...v, _enriched: true } : v));
+      }
+    })();
+  }, [currentIndex, videos, user]);
+
+  // Cleanup on unmount — preload fresh shorts for the next visit
   useEffect(() => {
     return () => {
       if (playPauseTimeoutRef.current) {
         clearTimeout(playPauseTimeoutRef.current);
       }
+      preloadShorts(10);
     };
   }, []);
 
   /* ---------- FETCH SHORTS DATA ---------- */
   useEffect(() => {
-    const fetchShorts = async () => {
-      try {
-        setLoading(true);
-        setError(null);
+    const formatShorts = (shorts) => shorts.map(short => ({
+      id: short.id,
+      author: short.author,
+      permlink: short.permlink,
+      hivePermlink: short.hivePermlink,
+      embedUrl: short.embedUrl || null,
+      thumbnailUrl: short.thumbnailUrl || null,
+      user: {
+        username: short.user.username,
+        avatar: short.user.avatar,
+        isSubscribed: false,
+        followersCount: short.user.followersCount ?? null,
+        reputation: short.user.reputation ?? null,
+      },
+      caption: short.caption || short.title || '',
+      tags: short.tags || [],
+      audio: `${short.user.username} - Original Audio`,
+      albumArt: short.user.avatar,
+      stats: {
+        likes: short.stats.likes,
+        dislikes: short.stats.dislikes,
+        comments: short.stats.comments,
+        shares: short.stats.shares,
+        remixes: short.stats.remixes,
+        views: short.views || short.stats.views || 0,
+        payout: short.stats.payout
+      },
+      isLiked: short.isLiked || false,
+      isDisliked: short.isDisliked || false,
+      comments: [],
+      commentsLoaded: false,
+      timeAgo: short.timeAgo,
+      createdAt: short.createdAt,
+      parentVideo: short.parentVideo || null,
+      parentTimestamp: short.parentTimestamp || null,
+      parentComment: short.parentComment || null,
+      parentShort: short.parentShort || null,
+      reactionChain: short.reactionChain || null,
+      childReactions: short.childReactions || null,
+      _enriched: short._enriched != null ? short._enriched : true,
+    }));
 
-        const data = await hiveApi.fetchShortsWithDetails(1, 10, user);
+    const applySharedVideoLogic = async (formattedVideos, data) => {
+      const sharedVideo = getSharedVideoFromUrl();
 
-        if (data.success) {
-          console.log(data.shorts);
-          const formattedVideos = data.shorts.map(short => ({
-            id: short.id,
-            author: short.author,
-            permlink: short.permlink,
-            hivePermlink: short.hivePermlink,
-            user: {
-              username: short.user.username,
-              avatar: short.user.avatar,
-              isSubscribed: false
-            },
-            caption: short.caption || short.title || '',
-            audio: `${short.user.username} - Original Audio`,
-            albumArt: short.user.avatar,
-            stats: {
-              likes: short.stats.likes,
-              dislikes: short.stats.dislikes,
-              comments: short.stats.comments,
-              shares: short.stats.shares,
-              remixes: short.stats.remixes,
-              views: short.views,
-              payout: short.stats.payout
-            },
-            isLiked: short.isLiked || false,
-            isDisliked: short.isDisliked || false,
-            comments: [],
-            commentsLoaded: false,
-            timeAgo: short.timeAgo,
-            createdAt: short.createdAt,
-            parentVideo: short.parentVideo || null,
-            parentTimestamp: short.parentTimestamp || null,
-            parentComment: short.parentComment || null,
-            parentShort: short.parentShort || null,
-            reactionChain: short.reactionChain || null,
-            childReactions: short.childReactions || null,
-          }));
+      if (sharedVideo) {
+        const sharedIndex = formattedVideos.findIndex(
+          v => v.author === sharedVideo.author && v.permlink === sharedVideo.permlink
+        );
 
-          // Check if there's a shared video in the URL
-          const sharedVideo = getSharedVideoFromUrl();
-          
-          if (sharedVideo) {
-            // Find the index of the shared video in the feed
-            const sharedIndex = formattedVideos.findIndex(
-              v => v.author === sharedVideo.author && v.permlink === sharedVideo.permlink
-            );
+        if (sharedIndex !== -1) {
+          setVideos(formattedVideos);
+          setCurrentIndex(sharedIndex);
+        } else {
+          try {
+            const actualShort = await hiveApi.findShortByPermlink(sharedVideo.permlink);
+            const shortItem = actualShort || {
+              owner: sharedVideo.author,
+              permlink: sharedVideo.permlink,
+              embed_url: `@${sharedVideo.author}/${sharedVideo.permlink}`,
+              thumbnail_url: '',
+              views: 0,
+              createdAt: new Date().toISOString(),
+              embed_title: ''
+            };
 
-            if (sharedIndex !== -1) {
-              // Video found in feed, start from that index
-              setVideos(formattedVideos);
-              setCurrentIndex(sharedIndex);
-            } else {
-              // Video not in current feed, search the API for the actual short data
-              try {
-                // Find the short in the API to get the correct embed_url (Hive permlink)
-                const actualShort = await hiveApi.findShortByPermlink(sharedVideo.permlink);
+            const sharedVideoData = await hiveApi.fetchCompleteShortData(shortItem, user);
+            const formattedSharedVideo = {
+              id: sharedVideoData.id,
+              author: sharedVideoData.author,
+              permlink: sharedVideoData.permlink,
+              hivePermlink: sharedVideoData.hivePermlink,
+              user: sharedVideoData.user,
+              caption: sharedVideoData.caption || sharedVideoData.title || '',
+              audio: `${sharedVideoData.user.username} - Original Audio`,
+              albumArt: sharedVideoData.user.avatar,
+              stats: sharedVideoData.stats,
+              isLiked: sharedVideoData.isLiked || false,
+              isDisliked: sharedVideoData.isDisliked || false,
+              comments: [],
+              commentsLoaded: false,
+              timeAgo: sharedVideoData.timeAgo,
+              createdAt: sharedVideoData.createdAt,
+              parentVideo: sharedVideoData.parentVideo || null,
+              parentTimestamp: sharedVideoData.parentTimestamp || null,
+              parentComment: sharedVideoData.parentComment || null,
+              parentShort: sharedVideoData.parentShort || null,
+              reactionChain: sharedVideoData.reactionChain || null,
+              childReactions: sharedVideoData.childReactions || null,
+            };
 
-                const shortItem = actualShort || {
-                  owner: sharedVideo.author,
-                  permlink: sharedVideo.permlink,
-                  embed_url: `@${sharedVideo.author}/${sharedVideo.permlink}`,
-                  thumbnail_url: '',
-                  views: 0,
-                  createdAt: new Date().toISOString(),
-                  embed_title: ''
-                };
-
-                const sharedVideoData = await hiveApi.fetchCompleteShortData(shortItem, user);
-                
-                const formattedSharedVideo = {
-                  id: sharedVideoData.id,
-                  author: sharedVideoData.author,
-                  permlink: sharedVideoData.permlink,
-                  hivePermlink: sharedVideoData.hivePermlink,
-                  user: sharedVideoData.user,
-                  caption: sharedVideoData.caption || sharedVideoData.title || '',
-                  audio: `${sharedVideoData.user.username} - Original Audio`,
-                  albumArt: sharedVideoData.user.avatar,
-                  stats: sharedVideoData.stats,
-                  isLiked: sharedVideoData.isLiked || false,
-                  isDisliked: sharedVideoData.isDisliked || false,
-                  comments: [],
-                  commentsLoaded: false,
-                  timeAgo: sharedVideoData.timeAgo,
-                  createdAt: sharedVideoData.createdAt,
-                  parentVideo: sharedVideoData.parentVideo || null,
-                  parentTimestamp: sharedVideoData.parentTimestamp || null,
-                  parentComment: sharedVideoData.parentComment || null,
-                  parentShort: sharedVideoData.parentShort || null,
-                  reactionChain: sharedVideoData.reactionChain || null,
-                  childReactions: sharedVideoData.childReactions || null,
-                };
-
-                // Prepend shared video to the feed
-                setVideos([formattedSharedVideo, ...formattedVideos]);
-                setCurrentIndex(0);
-              } catch (err) {
-                console.warn('Could not fetch shared video, showing feed from start:', err);
-                setVideos(formattedVideos);
-                // Update URL to first video since shared video couldn't be loaded
-                if (formattedVideos.length > 0) {
-                  updateUrlWithCurrentVideo(formattedVideos[0]);
-                }
-              }
-            }
-          } else {
+            setVideos([formattedSharedVideo, ...formattedVideos]);
+            setCurrentIndex(0);
+          } catch (err) {
+            console.warn('Could not fetch shared video, showing feed from start:', err);
             setVideos(formattedVideos);
-            // Update URL with first video
             if (formattedVideos.length > 0) {
               updateUrlWithCurrentVideo(formattedVideos[0]);
             }
           }
+        }
+      } else {
+        setVideos(formattedVideos);
+        if (formattedVideos.length > 0) {
+          updateUrlWithCurrentVideo(formattedVideos[0]);
+        }
+      }
 
-          setHasMore(1 < data.totalPages);
+      setHasMore(1 < data.totalPages);
+    };
+
+    const fetchShorts = async () => {
+      try {
+        setError(null);
+
+        // Try preloaded data first (already fetched when the app loaded)
+        // Only show the loading spinner if we actually need to fetch
+        if (!hasShortsPreloaded()) {
+          setLoading(true);
+        }
+
+        const preloaded = await consumePreloadedShorts();
+        if (preloaded?.success) {
+          const formattedVideos = formatShorts(preloaded.shorts);
+          await applySharedVideoLogic(formattedVideos, preloaded);
+
+          setLoading(false);
+          return;
+        }
+
+        // No preload available — generate a fresh seed and fetch
+        setLoading(true);
+        regenerateShortsSeed();
+        const data = await hiveApi.fetchShortsWithDetails(1, 10, user);
+
+        if (data.success) {
+          const formattedVideos = formatShorts(data.shorts);
+          await applySharedVideoLogic(formattedVideos, data);
         }
       } catch (err) {
         console.error('Error fetching shorts:', err);
@@ -565,6 +656,89 @@ const VideoShort = () => {
 
     if (existingIdx !== -1) {
       setCurrentIndex(existingIdx);
+      return;
+    }
+
+    // Check chain preload data for instant switch (iframe already warm)
+    const preloadKey = `${targetAuthor}-${targetPermlink}`;
+    const chainData = chainPreloadDataRef.current.get(preloadKey);
+
+    if (chainData) {
+      // Instant switch — create minimal entry, iframe is already loaded
+      const formatted = {
+        id: preloadKey,
+        author: chainData.author,
+        permlink: chainData.permlink,
+        hivePermlink: chainData.hivePermlink,
+        user: {
+          username: `@${chainData.author}`,
+          avatar: `https://images.hive.blog/u/${chainData.author}/avatar`,
+          isSubscribed: false,
+        },
+        caption: chainData.title || '',
+        audio: `@${chainData.author} - Original Audio`,
+        albumArt: `https://images.hive.blog/u/${chainData.author}/avatar`,
+        stats: { likes: 0, dislikes: 0, comments: 0, shares: 0, remixes: 0, views: 0, payout: '0.00' },
+        isLiked: false,
+        isDisliked: false,
+        comments: [],
+        commentsLoaded: false,
+        timeAgo: '',
+        createdAt: '',
+        parentVideo: null,
+        parentTimestamp: null,
+        parentComment: null,
+        parentShort: null,
+        reactionChain: null,
+        childReactions: null,
+      };
+
+      setVideos(prev => [formatted, ...prev]);
+      setCurrentIndex(0);
+
+      // Enrich with full data in background
+      (async () => {
+        try {
+          const shortItem = {
+            owner: chainData.author,
+            permlink: chainData.permlink,
+            embed_url: `@${chainData.author}/${chainData.hivePermlink}`,
+            thumbnail_url: chainData.thumbnail || '',
+            views: 0,
+            createdAt: '',
+            embed_title: chainData.title || '',
+          };
+          const shortData = await hiveApi.fetchCompleteShortData(shortItem, user);
+          setVideos(prev => prev.map(v => {
+            if (v.id !== preloadKey) return v;
+            return {
+              id: shortData.id,
+              author: shortData.author,
+              permlink: shortData.permlink,
+              hivePermlink: shortData.hivePermlink,
+              user: shortData.user,
+              caption: shortData.caption || shortData.title || '',
+              audio: `${shortData.user.username} - Original Audio`,
+              albumArt: shortData.user.avatar,
+              stats: shortData.stats,
+              isLiked: shortData.isLiked || false,
+              isDisliked: shortData.isDisliked || false,
+              comments: v.comments,
+              commentsLoaded: v.commentsLoaded,
+              timeAgo: shortData.timeAgo,
+              createdAt: shortData.createdAt,
+              parentVideo: shortData.parentVideo || null,
+              parentTimestamp: shortData.parentTimestamp || null,
+              parentComment: shortData.parentComment || null,
+              parentShort: shortData.parentShort || null,
+              reactionChain: shortData.reactionChain || null,
+              childReactions: shortData.childReactions || null,
+            };
+          }));
+        } catch (err) {
+          console.warn('Failed to enrich chain preload:', err);
+        }
+      })();
       return;
     }
 
@@ -628,7 +802,7 @@ const VideoShort = () => {
 
     try {
 
-      const data = await hiveApi.fetchShortsWithDetails(nextPage, 10, user);
+      const data = await hiveApi.fetchShortsWithDetails(nextPage, 20, user);
 
       if (data.success) {
         const formattedVideos = data.shorts.map(short => ({
@@ -636,12 +810,17 @@ const VideoShort = () => {
           author: short.author,
           permlink: short.permlink,
           hivePermlink: short.hivePermlink,
+          embedUrl: short.embedUrl || null,
+          thumbnailUrl: short.thumbnailUrl || null,
           user: {
             username: short.user.username,
             avatar: short.user.avatar,
-            isSubscribed: false
+            isSubscribed: false,
+            followersCount: short.user.followersCount ?? null,
+            reputation: short.user.reputation ?? null,
           },
           caption: short.caption || short.title || '',
+          tags: short.tags || [],
           audio: `${short.user.username} - Original Audio`,
           albumArt: short.user.avatar,
           stats: {
@@ -650,7 +829,7 @@ const VideoShort = () => {
             comments: short.stats.comments,
             shares: short.stats.shares,
             remixes: short.stats.remixes,
-            views: short.views,
+            views: short.views || short.stats.views || 0,
             payout: short.stats.payout
           },
           isLiked: short.isLiked || false,
@@ -664,6 +843,8 @@ const VideoShort = () => {
           parentComment: short.parentComment || null,
           parentShort: short.parentShort || null,
           reactionChain: short.reactionChain || null,
+          childReactions: short.childReactions || null,
+          _enriched: short._enriched != null ? short._enriched : true,
         }));
 
         setVideos(prev => [...prev, ...formattedVideos]);
@@ -777,13 +958,14 @@ const VideoShort = () => {
         };
 
         if (isReply) {
-          // Add reply to the parent comment
+          // Add reply to the parent comment and increment comment count
           setVideos(prev =>
             prev.map((v, idx) => {
               if (idx !== currentIndex) return v;
               return {
                 ...v,
-                comments: addReplyToComment(v.comments, parentPermlink, newCommentObj)
+                comments: addReplyToComment(v.comments, parentPermlink, newCommentObj),
+                stats: { ...v.stats, comments: (v.stats.comments || 0) + 1 }
               };
             })
           );
@@ -926,8 +1108,20 @@ const VideoShort = () => {
 
   /* ---------- NAVIGATION ---------- */
 
+  const triggerSwipeAnimation = (direction) => {
+    if (swipeAnimRef.current) clearTimeout(swipeAnimRef.current);
+    setSwipeDragY(0);
+    setSwipeDirection(direction);
+    swipeAnimRef.current = setTimeout(() => {
+      setSwipeDirection(null);
+      swipeAnimRef.current = null;
+    }, 350);
+  };
+
   const handlePrevious = () => {
     if (currentIndex === 0) return;
+    shortHistoryRef.current = [];
+    triggerSwipeAnimation('down');
     setCurrentIndex(prev => prev - 1);
   };
 
@@ -938,9 +1132,12 @@ const VideoShort = () => {
       }
       return;
     }
+    shortHistoryRef.current = [];
+    triggerSwipeAnimation('up');
     setCurrentIndex(prev => prev + 1);
 
-    if (currentIndex >= videos.length - 3 && hasMore) {
+    // Prefetch 7 items before the end of the current page
+    if (currentIndex >= videos.length - 7 && hasMore) {
       loadMoreVideos();
     }
   };
@@ -1002,10 +1199,17 @@ const VideoShort = () => {
 
   const onTouchMove = (e) => {
     if (showComments) return;
-    setTouchEnd(e.targetTouches[0].clientY);
+    const y = e.targetTouches[0].clientY;
+    setTouchEnd(y);
+    // Live drag: clamp to ±120px for visual feedback
+    if (touchStart != null) {
+      const delta = y - touchStart;
+      setSwipeDragY(Math.max(-120, Math.min(120, delta)));
+    }
   };
 
   const onTouchEnd = async () => {
+    setSwipeDragY(0);
     if (!touchStart || !touchEnd || showComments || isTransitioning) return;
 
     const distance = touchStart - touchEnd;
@@ -1016,12 +1220,12 @@ const VideoShort = () => {
       // Swipe up = next video
       setIsTransitioning(true);
       await handleNext();
-      setTimeout(() => setIsTransitioning(false), 300);
+      setTimeout(() => setIsTransitioning(false), 350);
     } else if (isSwipeDown && currentIndex > 0) {
       // Swipe down = previous video
       setIsTransitioning(true);
       handlePrevious();
-      setTimeout(() => setIsTransitioning(false), 300);
+      setTimeout(() => setIsTransitioning(false), 350);
     }
 
     // Reset touch state
@@ -1042,8 +1246,9 @@ const VideoShort = () => {
 
   const progressPercentage = duration > 0 ? (currentTime / duration) * 100 : 0;
 
-  // Calculate which videos to preload - keep more in memory
-  const preloadRange = { before: 3, after: 6 };
+  // Calculate which videos to preload — on mobile iframes load slower so keep more ahead
+  const isMobile = typeof window !== 'undefined' && window.innerWidth <= 768;
+  const preloadRange = { before: 3, after: isMobile ? 10 : 6 };
   const preloadedIndices = [];
   for (let i = Math.max(0, currentIndex - preloadRange.before); i <= Math.min(videos.length - 1, currentIndex + preloadRange.after); i++) {
     preloadedIndices.push(i);
@@ -1056,17 +1261,90 @@ const VideoShort = () => {
     }
   }, []);
 
+  // Populate chain preload data for instant navigation
+  useEffect(() => {
+    const cv = videos[currentIndex];
+    if (cv?.reactionChain) {
+      for (const step of cv.reactionChain) {
+        if (step.shortPermlink && !step.isRoot) {
+          chainPreloadDataRef.current.set(`${step.author}-${step.shortPermlink}`, {
+            author: step.author,
+            permlink: step.shortPermlink,
+            hivePermlink: step.permlink,
+            title: step.title || '',
+            thumbnail: step.thumbnail || null,
+          });
+        }
+      }
+    }
+    if (cv?.childReactions) {
+      for (const child of cv.childReactions) {
+        if (child.shortPermlink) {
+          chainPreloadDataRef.current.set(`${child.author}-${child.shortPermlink}`, {
+            author: child.author,
+            permlink: child.shortPermlink,
+            hivePermlink: child.permlink,
+            title: child.title || '',
+            thumbnail: child.thumbnail || null,
+          });
+        }
+      }
+    }
+  }, [videos, currentIndex]);
+
+  // Compute chain preload entries for iframe pre-warming
+  const chainPreloadEntries = useMemo(() => {
+    const cv = videos[currentIndex];
+    const entries = [];
+    const seen = new Set(videos.map(v => v.id));
+
+    if (cv?.reactionChain) {
+      for (const step of cv.reactionChain) {
+        if (step.shortPermlink && !step.isRoot) {
+          const id = `${step.author}-${step.shortPermlink}`;
+          if (!seen.has(id)) {
+            seen.add(id);
+            entries.push({ id, author: step.author, permlink: step.shortPermlink });
+          }
+        }
+      }
+    }
+    if (cv?.childReactions) {
+      for (const child of cv.childReactions) {
+        if (child.shortPermlink) {
+          const id = `${child.author}-${child.shortPermlink}`;
+          if (!seen.has(id)) {
+            seen.add(id);
+            entries.push({ id, author: child.author, permlink: child.shortPermlink });
+          }
+        }
+      }
+    }
+
+    return entries;
+  }, [videos, currentIndex]);
+
   // Clean up old iframe refs that are no longer in preload range
   useEffect(() => {
     const preloadedIds = new Set(preloadedIndices.map(idx => videos[idx]?.id).filter(Boolean));
+    chainPreloadEntries.forEach(e => preloadedIds.add(e.id));
+    const removedIds = [];
     Object.keys(iframeRefs.current).forEach(id => {
       if (!preloadedIds.has(id)) {
         delete iframeRefs.current[id];
-        // Also remove from ready players since the iframe is gone
         readyPlayers.current.delete(id);
+        removedIds.push(id);
       }
     });
-  }, [preloadedIndices, videos]);
+    if (removedIds.length > 0) {
+      setReadyPlayerIds(prev => {
+        if (!removedIds.some(id => prev.has(id))) return prev;
+        const next = new Set(prev);
+        removedIds.forEach(id => next.delete(id));
+        return next;
+      });
+    }
+  }, [preloadedIndices, videos, chainPreloadEntries]);
 
   const handleProfileNavigation = (username) => {
     navigate(`/p/${username}`);
@@ -1119,17 +1397,20 @@ const VideoShort = () => {
 
         {/* VIDEO */}
         <div
-          className="videoContainer"
+          className={`videoContainer${swipeDirection ? ` swipe-${swipeDirection}` : ''}`}
           ref={videoContainerRef}
           onTouchStart={onTouchStart}
           onTouchMove={onTouchMove}
           onTouchEnd={onTouchEnd}
+          style={swipeDragY && !swipeDirection ? { transform: `translateY(${swipeDragY * 0.3}px)`, transition: 'none' } : undefined}
         >
           {/* Preloaded iframes for smooth playback */}
           {preloadedIndices.map((idx) => {
             const video = videos[idx];
             if (!video) return null;
             const isCurrent = idx === currentIndex;
+            const isReady = readyPlayerIds.has(video.id);
+
             return (
               <iframe
                 key={video.id}
@@ -1142,24 +1423,68 @@ const VideoShort = () => {
                 allow="autoplay; fullscreen"
                 allowFullScreen
                 onLoad={(e) => {
-                  console.log(`[VideoShort] Iframe loaded for video: ${video.id}, isCurrent: ${isCurrent}`);
                   // Store ref again on load in case it wasn't set
                   iframeRefs.current[video.id] = e.target;
-                  
-                  // Don't send play here - wait for 3speak-player-ready message
-                  // The player inside the iframe needs time to initialize Video.js
                 }}
                 style={{
                   position: 'absolute',
                   top: 0,
                   left: 0,
-                  opacity: isCurrent ? 1 : 0,
+                  opacity: isCurrent && isReady ? 1 : 0,
                   pointerEvents: 'none',
-                  zIndex: isCurrent ? 1 : 0,
+                  zIndex: isCurrent ? 2 : 0,
                 }}
               />
             );
           })}
+
+          {/* Loading overlay while player initializes */}
+          {currentVideo && !readyPlayerIds.has(currentVideo.id) && (
+            <div
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: '100%',
+                zIndex: 1,
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                background: '#000',
+                gap: '1rem',
+              }}
+            >
+              <Loader2 className="spinner" size={48} />
+              <p style={{ fontSize: '0.8rem', color: 'var(--text-secondary)', animation: 'pulseText 2s ease-in-out infinite' }}>Loading shorts...</p>
+            </div>
+          )}
+
+          {/* Chain preload iframes — pre-warm players for instant navigation */}
+          {chainPreloadEntries.map(entry => (
+            <iframe
+              key={entry.id}
+              ref={(el) => setIframeRef(entry.id, el)}
+              src={`${PLAYER_URL}/embed?v=${entry.author}/${entry.permlink}&mode=iframe&controls=0`}
+              width="100%"
+              height="100%"
+              frameBorder="0"
+              allow="autoplay; fullscreen"
+              allowFullScreen
+              onLoad={(e) => {
+                iframeRefs.current[entry.id] = e.target;
+              }}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                opacity: 0,
+                pointerEvents: 'none',
+                zIndex: 0,
+              }}
+            />
+          ))}
 
           {/* Transparent overlay for play/pause */}
           <div
@@ -1248,7 +1573,7 @@ const VideoShort = () => {
                                   <AuthorBadge author={step.author} compact noLink />
                                   {step.type === 'video' && (
                                     step.shortPermlink ? (
-                                      <Link to={`/shorts?v=${step.shortAuthor}/${step.shortPermlink}`} className="chainActionBtn chainActionBtn--sm" onClick={(e) => e.stopPropagation()} title="Open short">
+                                      <Link to={`/shorts?v=${step.author}/${step.shortPermlink}`} className="chainActionBtn chainActionBtn--sm" onClick={(e) => e.stopPropagation()} title="Open short">
                                         <Camera size={11} />
                                       </Link>
                                     ) : (
@@ -1298,7 +1623,7 @@ const VideoShort = () => {
                             <div className="chainChild chainChild--video chainChild--downstream">
                               <div className="chainChildHeader">
                                 <AuthorBadge author={child.author} compact noLink />
-                                <Link to={`/shorts?v=${child.shortAuthor}/${child.shortPermlink}`} className="chainActionBtn chainActionBtn--sm" onClick={(e) => e.stopPropagation()} title="Open short">
+                                <Link to={`/shorts?v=${child.author}/${child.shortPermlink}`} className="chainActionBtn chainActionBtn--sm" onClick={(e) => e.stopPropagation()} title="Open short">
                                   <Camera size={11} />
                                 </Link>
                               </div>
@@ -1326,25 +1651,31 @@ const VideoShort = () => {
           })()}
 
           <div className="bottomOverlay">
-            <div className="userRow">
-              <div className="avatar" onClick={(e) => {
-                    // e.preventDefault();
-                    e.stopPropagation();
-                    handleProfileNavigation(currentVideo.user.username);
-                  }}>
-                <img src={currentVideo.user.avatar} alt="" />
-              </div>
-              <span className="username">{currentVideo.user.username}</span>
-              <button
-                className="subscribeBtn"
-                onClick={(e) => { e.stopPropagation(); handleSubscribe(); }}
-              >
-                {currentVideo.user.isSubscribed ? "Following" : "Follow"}
-              </button>
+            <div className="userRow" onClick={(e) => e.stopPropagation()}>
+              <AuthorBadge
+                author={currentVideo.author}
+                showFollow
+                followersCount={currentVideo.user.followersCount}
+                reputation={currentVideo.user.reputation}
+                isFollowing={currentVideo.user.isSubscribed}
+                onFollow={() => handleSubscribe()}
+              />
             </div>
-            <p className="caption">{currentVideo.caption}</p>
+            <div className={`caption${captionExpanded ? ' caption--expanded' : ''}`} onClick={(e) => { e.stopPropagation(); setCaptionExpanded(prev => !prev); }}>
+              <p className="captionText">{currentVideo.caption}</p>
+              {captionExpanded && currentVideo.tags?.length > 0 && (
+                <div className="captionTags">
+                  {currentVideo.tags.map((tag, i) => (
+                    <Link key={i} to={`/t/${tag}`} className="captionTag" onClick={(e) => e.stopPropagation()}>#{tag}</Link>
+                  ))}
+                </div>
+              )}
+              {!captionExpanded && currentVideo.caption?.length > 60 && (
+                <span className="captionMore">more</span>
+              )}
+            </div>
             <div className="audioMarquee">
-              <Music2 size={16} />
+              <Music2 size={12} />
               <div className="audioText">
                 <p>{currentVideo.audio}</p>
               </div>

--- a/src/page/Short.scss
+++ b/src/page/Short.scss
@@ -78,6 +78,16 @@
     box-shadow: var(--shadow-lg);
     border: 1px solid var(--border-color);
 
+    // Swipe transition animations
+    &.swipe-up {
+      animation: swipeUp 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+    }
+    &.swipe-down {
+      animation: swipeDown 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+    }
+
+
+
     @media (max-width: 768px) {
       position: absolute;
       top: 0;
@@ -549,6 +559,29 @@
         @media (max-width: 768px) {
       margin-bottom: 0.35rem;
     }
+
+    .author-badge {
+      background: transparent;
+      border-color: transparent;
+
+      &:hover {
+        background: transparent;
+        border-color: transparent;
+      }
+
+      img {
+        width: 36px;
+        height: 36px;
+      }
+
+      .author-name {
+        color: #fff;
+      }
+
+      .followers-count {
+        color: rgba(255, 255, 255, 0.7);
+      }
+    }
   }
 
   .avatar {
@@ -594,14 +627,58 @@
   }
 
   .caption {
-    font-size: 1rem;
+    font-size: 0.8rem;
     color: white;
     font-weight: 400;
     margin-bottom: 0.75rem;
     line-height: 1.375;
+    cursor: pointer;
+    pointer-events: auto;
     @media (max-width: 768px) {
       margin-bottom: 0.4rem;
-      font-size: 0.875rem;
+      font-size: 0.75rem;
+    }
+
+    .captionText {
+      display: -webkit-box;
+      -webkit-line-clamp: 1;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      margin: 0;
+    }
+
+    .captionMore {
+      font-weight: 600;
+      opacity: 0.8;
+      font-size: 0.75rem;
+    }
+
+    &--expanded .captionText {
+      display: block;
+      -webkit-line-clamp: unset;
+      overflow: visible;
+    }
+
+    .captionTags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin-top: 6px;
+
+      .captionTag {
+        font-size: 0.7rem;
+        color: rgba(255, 255, 255, 0.85);
+        background: rgba(255, 255, 255, 0.15);
+        padding: 2px 8px;
+        border-radius: 10px;
+        text-decoration: none;
+        pointer-events: auto;
+
+        &:hover {
+          background: rgba(255, 255, 255, 0.25);
+          color: #fff;
+        }
+      }
     }
   }
 
@@ -612,8 +689,8 @@
     opacity: 0.9;
 
     svg {
-      width: 1rem;
-      height: 1rem;
+      width: 0.75rem;
+      height: 0.75rem;
       color: white;
     }
   }
@@ -623,7 +700,7 @@
     width: 10rem;
 
     p {
-      font-size: 0.875rem;
+      font-size: 0.75rem;
       color: white;
       white-space: nowrap;
     }
@@ -835,6 +912,11 @@
     }
   }
 
+  @keyframes pulseText {
+    0%, 100% { opacity: 0.4; }
+    50% { opacity: 1; }
+  }
+
   .loadingState,
   .errorState,
   .emptyState {
@@ -848,8 +930,10 @@
     gap: 1rem;
 
     p {
-      font-size: 1rem;
+      font-size: 0.8rem;
+      font-family: inherit;
       color: var(--text-secondary);
+      animation: pulseText 1.5s ease-in-out infinite;
     }
 
     button {
@@ -1446,5 +1530,28 @@
       color: var(--text-muted);
       cursor: not-allowed;
     }
+  }
+}
+
+// Swipe navigation animations
+@keyframes swipeUp {
+  0% {
+    transform: translateY(30%);
+    opacity: 0.4;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes swipeDown {
+  0% {
+    transform: translateY(-30%);
+    opacity: 0.4;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
   }
 }

--- a/src/page/Short.scss
+++ b/src/page/Short.scss
@@ -139,6 +139,10 @@
   }
 
   .playPauseIcon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    translate: -50% -50%;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -161,6 +165,71 @@
     &.visible {
       opacity: 1;
       transform: scale(1);
+    }
+  }
+
+  .heartAnimation {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    translate: -50% -50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transform: scale(0);
+    pointer-events: none;
+    z-index: 5;
+
+    &.visible {
+      animation: heartPop 0.8s ease forwards;
+    }
+  }
+
+  .muteIndicator {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.2);
+    pointer-events: auto;
+    cursor: pointer;
+    z-index: 6;
+    transition: background 0.2s;
+
+    &:hover {
+      background: rgba(0, 0, 0, 0.4);
+    }
+
+    svg {
+      color: #fff;
+    }
+  }
+
+  @keyframes heartPop {
+    0% {
+      opacity: 1;
+      transform: scale(0);
+    }
+    15% {
+      opacity: 1;
+      transform: scale(1.3);
+    }
+    30% {
+      transform: scale(1);
+    }
+    80% {
+      opacity: 1;
+      transform: scale(1);
+    }
+    100% {
+      opacity: 0;
+      transform: scale(1.4);
     }
   }
 
@@ -793,14 +862,18 @@
     }
 
     @media (max-width: 768px) {
-      width: 2rem;
-      height: 2rem;
-      background-color: transparent;
+      width: 2.75rem;
+      height: 2.75rem;
+      background-color: rgba(0, 0, 0, 0.20);
       pointer-events: auto;
 
+      [data-theme="dark"] & {
+        background-color: rgba(0, 0, 0, 0.20);
+      }
+
       svg {
-        width: 18px;
-        height: 18px;
+        width: 22px;
+        height: 22px;
         color: white;
         filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.8));
       }
@@ -827,8 +900,8 @@
   }
 
   .albumArt {
-    width: 2.5rem;
-    height: 2.5rem;
+    width: 30px;
+    height: 30px;
     background-color: var(--bg-secondary);
     border-radius: 0.375rem;
     overflow: hidden;
@@ -842,10 +915,7 @@
     }
 
     @media (max-width: 768px) {
-      width: 1.81rem;
-      height: 1.81rem;
-      border-radius: 0.25rem;
-      margin-top: 0.25rem;
+      display: none;
     }
   }
 
@@ -1031,7 +1101,9 @@
     @media (max-width: 768px) {
       display: flex;
       justify-content: center;
-      padding: 0.35rem 0 0.5rem;
+      padding: 0.6rem 0;
+      cursor: grab;
+      touch-action: none;
 
       &::before {
         content: "";
@@ -1246,6 +1318,18 @@
     line-height: 1.4;
     margin-bottom: 0.5rem;
     word-wrap: break-word;
+    overflow: hidden;
+
+    // markdown-view overrides for compact comment context
+    &.markdown-view {
+      p { margin: 0 0 0.4em; &:last-child { margin-bottom: 0; } }
+      img { max-width: 100%; height: auto; border-radius: 6px; margin: 4px 0; }
+      a { color: var(--accent-primary, #e53935); word-break: break-all; }
+      blockquote { margin: 4px 0; padding-left: 8px; border-left: 2px solid var(--border-color); color: var(--text-secondary); }
+      pre, code { font-size: 0.8rem; }
+      h1, h2, h3, h4, h5, h6 { font-size: 0.9rem; margin: 0.3em 0; }
+      ul, ol { margin: 0.3em 0; padding-left: 1.2em; }
+    }
   }
 
   .commentActions {

--- a/src/page/Short.scss
+++ b/src/page/Short.scss
@@ -201,6 +201,134 @@
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
   }
 
+  // Parent video overlay card (for reactions)
+  .parentVideoOverlay {
+    position: absolute;
+    top: 12px;
+    left: 12px;
+    right: 60px;
+    z-index: 11;
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+
+    &.collapsed {
+      left: 0;
+      right: 0;
+      justify-content: center;
+    }
+  }
+
+  .parentVideoCard {
+    position: relative;
+    display: flex;
+    gap: 8px;
+    padding: 8px;
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(8px);
+    color: #fff;
+    text-decoration: none;
+    flex: 1;
+    min-width: 0;
+
+    &:hover {
+      background: rgba(0, 0, 0, 0.85);
+    }
+  }
+
+  .parentVideoThumb {
+    width: 60px;
+    height: 34px;
+    border-radius: 4px;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+
+  .parentVideoTimestamp {
+    position: absolute;
+    bottom: 4px;
+    right: 6px;
+    font-size: 10px;
+    font-weight: 600;
+    line-height: 1;
+    color: rgba(255, 255, 255, 0.6);
+  }
+
+  .parentVideoInfo {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .parentVideoTitle {
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .parentVideoAuthor {
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.6);
+  }
+
+  .parentCommentExcerpt {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    margin-top: 2px;
+    padding-top: 3px;
+    border-top: 1px solid rgba(255, 255, 255, 0.15);
+  }
+
+  .parentCommentLabel {
+    font-size: 10px;
+    color: rgba(255, 255, 255, 0.5);
+    font-weight: 500;
+  }
+
+  .parentCommentBody {
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.75);
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    margin: 0;
+    word-break: break-word;
+  }
+
+  .parentVideoClose {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    height: 24px;
+    border: none;
+    border-radius: 12px;
+    background: rgba(0, 0, 0, 0.7);
+    color: #fff;
+    cursor: pointer;
+    flex-shrink: 0;
+    padding: 0 6px;
+
+    &:hover {
+      background: rgba(0, 0, 0, 0.9);
+    }
+  }
+
+  .parentVideoCloseLabel {
+    font-size: 11px;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+
   .bottomOverlay {
     position: absolute;
     bottom: 0;

--- a/src/page/Short.scss
+++ b/src/page/Short.scss
@@ -201,129 +201,311 @@
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
   }
 
-  // Parent video overlay card (for reactions)
-  .parentVideoOverlay {
+  // Loading overlay for short navigation
+  .shortNavLoadingOverlay {
+    position: absolute;
+    inset: 0;
+    z-index: 30;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(4px);
+  }
+
+  // Back button after navigating to parent short
+  .shortBackBtn {
     position: absolute;
     top: 12px;
     left: 12px;
-    right: 60px;
-    z-index: 11;
+    z-index: 12;
     display: flex;
-    align-items: flex-start;
-    gap: 8px;
-
-    &.collapsed {
-      left: 0;
-      right: 0;
-      justify-content: center;
-    }
-  }
-
-  .parentVideoCard {
-    position: relative;
-    display: flex;
-    gap: 8px;
-    padding: 8px;
-    border-radius: 8px;
-    background: rgba(0, 0, 0, 0.7);
-    backdrop-filter: blur(8px);
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px 8px 12px;
+    border: none;
+    border-radius: 20px;
+    background: rgba(0, 0, 0, 0.8);
     color: #fff;
-    text-decoration: none;
-    flex: 1;
-    min-width: 0;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    backdrop-filter: blur(8px);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+    transition: all 0.15s ease;
 
     &:hover {
-      background: rgba(0, 0, 0, 0.85);
+      background: rgba(255, 255, 255, 0.15);
+      transform: scale(1.04);
+    }
+
+    &:active {
+      transform: scale(0.97);
     }
   }
 
-  .parentVideoThumb {
-    width: 60px;
+  // Reaction chain container
+  .reactionChainBreadcrumb {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    width: 100%;
+
+    // Force AuthorBadge colors for overlay context
+    .author-badge {
+      padding: 1px 4px 1px 1px;
+
+      img {
+        width: 16px;
+        height: 16px;
+      }
+
+      .author-name {
+        font-size: 10px;
+        color: rgba(255, 255, 255, 0.85);
+      }
+
+      .followers-count { display: none; }
+
+      &:hover {
+        background: rgba(255, 255, 255, 0.1);
+        border-color: transparent;
+      }
+    }
+  }
+
+  // Root / origin card — 50% wide, thumb left + info right
+  .chainRoot {
+    display: flex;
+    gap: 8px;
+    width: 50%;
+    padding: 6px;
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.75);
+    backdrop-filter: blur(8px);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-left: 3px solid var(--accent-primary, #e53935);
+    position: relative;
+  }
+
+  .chainRootThumb {
+    width: 54px;
     height: 34px;
     border-radius: 4px;
     object-fit: cover;
     flex-shrink: 0;
   }
 
-  .parentVideoTimestamp {
-    position: absolute;
-    bottom: 4px;
-    right: 6px;
-    font-size: 10px;
-    font-weight: 600;
-    line-height: 1;
-    color: rgba(255, 255, 255, 0.6);
-  }
-
-  .parentVideoInfo {
+  .chainRootInfo {
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    gap: 3px;
     min-width: 0;
+    flex: 1;
   }
 
-  .parentVideoTitle {
-    font-size: 12px;
+  .chainRootTitle {
+    font-size: 11px;
     font-weight: 600;
-    line-height: 1.3;
+    color: rgba(255, 255, 255, 0.9);
+    line-height: 1.25;
     display: -webkit-box;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
   }
 
-  .parentVideoAuthor {
-    font-size: 11px;
-    color: rgba(255, 255, 255, 0.6);
+  .chainRootMeta {
+    display: flex;
+    align-items: center;
+    gap: 6px;
   }
 
-  .parentCommentExcerpt {
+  .chainRootTimestamp {
+    font-size: 10px;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+  }
+
+  // Action button (play / open)
+  .chainActionBtn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    flex-shrink: 0;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.15);
+    color: #fff;
+    text-decoration: none;
+    transition: background 0.15s ease;
+    align-self: center;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.3);
+    }
+
+    &--sm {
+      width: 22px;
+      height: 22px;
+    }
+  }
+
+  // Horizontal child row with dashes
+  .chainChildRow {
+    display: flex;
+    align-items: flex-start;
+    gap: 4px;
+    overflow-x: auto;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+    &::-webkit-scrollbar { display: none; }
+  }
+
+  .chainDash {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    font-size: 10px;
+    color: rgba(255, 255, 255, 0.25);
+    padding-top: 10px;
+    user-select: none;
+  }
+
+  // Child cards — ~33% wide, expand on click
+  .chainChild {
     display: flex;
     flex-direction: column;
-    gap: 1px;
-    margin-top: 2px;
-    padding-top: 3px;
-    border-top: 1px solid rgba(255, 255, 255, 0.15);
+    gap: 3px;
+    width: 140px;
+    min-width: 140px;
+    flex-shrink: 0;
+    padding: 5px 6px;
+    border-radius: 6px;
+    background: rgba(0, 0, 0, 0.65);
+    backdrop-filter: blur(6px);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    cursor: pointer;
+    transition: width 0.2s ease, min-width 0.2s ease, background 0.15s ease;
+
+    &--video {
+      border-left: 2px solid var(--accent-primary, #e53935);
+    }
+
+    &--comment {
+      border-left: 2px solid rgba(255, 255, 255, 0.2);
+    }
+
+    &--current {
+      border-left: 2px solid var(--accent-primary, #e53935);
+      background: rgba(229, 57, 53, 0.1);
+    }
+
+    &--downstream {
+      border-left: 2px dashed var(--accent-primary, #e53935);
+      opacity: 0.8;
+    }
+
+    &--expanded {
+      width: 220px;
+      min-width: 220px;
+      background: rgba(0, 0, 0, 0.8);
+    }
+
+    &:hover {
+      background: rgba(0, 0, 0, 0.8);
+    }
   }
 
-  .parentCommentLabel {
+  .chainChildHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 4px;
+  }
+
+  .chainChildTitle {
     font-size: 10px;
-    color: rgba(255, 255, 255, 0.5);
-    font-weight: 500;
+    color: rgba(255, 255, 255, 0.55);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &--full {
+      white-space: normal;
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+      font-size: 12px;
+      color: rgba(255, 255, 255, 0.75);
+    }
   }
 
-  .parentCommentBody {
-    font-size: 11px;
-    color: rgba(255, 255, 255, 0.75);
-    line-height: 1.3;
+  .chainChildText {
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.6);
+    line-height: 1.4;
+    margin: 0;
     display: -webkit-box;
-    -webkit-line-clamp: 2;
+    -webkit-line-clamp: 4;
     -webkit-box-orient: vertical;
     overflow: hidden;
-    margin: 0;
     word-break: break-word;
   }
 
-  .parentVideoClose {
+  .chainChildDuration {
+    font-size: 9px;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.35);
+  }
+
+  // Reaction chain overlay
+  .reactionChainOverlay {
+    position: absolute;
+    top: 12px;
+    left: 8px;
+    right: 8px;
+    z-index: 11;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+
+    &.has-back {
+      top: 52px;
+    }
+
+    &.collapsed {
+      flex-direction: row;
+      left: 0;
+      right: 0;
+      justify-content: center;
+    }
+  }
+
+  .chainToggleBtn {
     display: flex;
     align-items: center;
     justify-content: center;
     gap: 4px;
-    height: 24px;
-    border: none;
-    border-radius: 12px;
+    height: 26px;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 13px;
     background: rgba(0, 0, 0, 0.7);
     color: #fff;
     cursor: pointer;
     flex-shrink: 0;
-    padding: 0 6px;
+    padding: 0 10px;
 
     &:hover {
       background: rgba(0, 0, 0, 0.9);
+      border-color: rgba(255, 255, 255, 0.5);
     }
   }
 
-  .parentVideoCloseLabel {
+  .chainToggleLabel {
     font-size: 11px;
     font-weight: 500;
     white-space: nowrap;

--- a/src/page/Watch.jsx
+++ b/src/page/Watch.jsx
@@ -327,7 +327,17 @@ function Watch() {
 
       switch (event.data.type) {
         case '3speak-player-ready':
-          setTimeout(() => { triggerPlay(); setIsPlaying(true); }, 100);
+          setTimeout(() => {
+            triggerPlay();
+            setIsPlaying(true);
+            // Seek to timestamp if ?t= parameter is present
+            const startTime = parseInt(searchParams.get('t'), 10);
+            if (startTime > 0 && mainIframe?.contentWindow) {
+              setTimeout(() => {
+                mainIframe.contentWindow.postMessage({ type: 'seek', time: startTime }, '*');
+              }, 200);
+            }
+          }, 100);
           if (mainIframe?.contentWindow) {
             mainIframe.contentWindow.postMessage({ type: 'hide-controls' }, '*');
           }
@@ -494,6 +504,29 @@ function Watch() {
       handleSeek(reaction.pct);
     }
   }, [reactions, videoDuration, handleSeek]);
+
+  // When loading with ?t= parameter and reactions are available, select the closest reaction
+  const initialReactionSetRef = useRef(false);
+  useEffect(() => {
+    if (initialReactionSetRef.current) return;
+    if (!reactions || reactions.length === 0) return;
+    const startTime = parseInt(searchParams.get('t'), 10);
+    if (!(startTime > 0)) return;
+
+    let closestIdx = 0;
+    let closestDist = Infinity;
+    for (let i = 0; i < reactions.length; i++) {
+      const dist = Math.abs(reactions[i].pct - startTime);
+      if (dist < closestDist) {
+        closestDist = dist;
+        closestIdx = i;
+      }
+    }
+
+    initialReactionSetRef.current = true;
+    setSelectedReactionIndex(closestIdx);
+    setReactionsVisible(true);
+  }, [reactions, searchParams]);
 
   const isNetworkError = videoError && videoError.networkError;
   const isLoading = videoLoading || (suggestionsLoading && trendingLoading && authorVideosLoading);

--- a/src/page/Watch.jsx
+++ b/src/page/Watch.jsx
@@ -166,6 +166,11 @@ function Watch() {
     hideTimerRef.current = setTimeout(() => setControlsVisible(false), 3000);
   }, []);
 
+  const pauseMainPlayer = useCallback(() => {
+    sendPlayerCommand('pause');
+    setIsPlaying(false);
+  }, [sendPlayerCommand]);
+
   const handleTogglePlay = useCallback(() => {
     sendPlayerCommand('toggle-play');
     setIsPlaying(prev => !prev);
@@ -231,7 +236,7 @@ function Watch() {
 
       switch (event.data.type) {
         case '3speak-player-ready':
-          setTimeout(() => { triggerPlay(); }, 100);
+          setTimeout(() => { triggerPlay(); setIsPlaying(true); }, 100);
           if (mainIframe?.contentWindow) {
             mainIframe.contentWindow.postMessage({ type: 'hide-controls' }, '*');
           }
@@ -430,6 +435,8 @@ function Watch() {
             onCycleSize={cycleReactionSize}
             currentTime={currentTime}
             duration={videoDuration}
+            mainIsPlaying={isPlaying}
+            onReactionPlay={pauseMainPlayer}
           />
         )}
 
@@ -453,6 +460,8 @@ function Watch() {
               onCycleSize={cycleReactionSize}
               currentTime={currentTime}
               duration={videoDuration}
+              mainIsPlaying={isPlaying}
+              onReactionPlay={pauseMainPlayer}
               mobile
             />
           )}

--- a/src/page/Watch.jsx
+++ b/src/page/Watch.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useMemo, useEffect, useCallback, useRef } from 'react';
 import './Watch.scss';
 import PlayVideo from '../components/playVideo/PlayVideo';
-import Recommended from '../components/recommended/Recommended';
 import Card3 from '../components/Cards/Card3';
 import { useSearchParams, useLocation, useNavigate } from 'react-router-dom';
 import { GET_RELATED, GET_VIDEO_DETAILS, TRENDING_FEED, GET_AUTHOR_VIDEOS } from '../graphql/queries';
@@ -9,6 +8,11 @@ import { useQuery } from '@apollo/client';
 import BarLoader from '../components/Loader/BarLoader';
 import { useAppStore } from '../lib/store';
 import { recordWatch } from '../utils/watchHistory';
+import { Client } from '@hiveio/dhive';
+import { HIVE_API_NODES, PLAYER_URL } from '../utils/config';
+import ReactionPlayer from '../components/ReactionPlayer/ReactionPlayer';
+
+const hiveClient = new Client(HIVE_API_NODES);
 
 // Number of author videos to show at the top of recommendations
 const AUTHOR_VIDEOS_COUNT = 4;
@@ -87,6 +91,117 @@ function Watch() {
     sendPlayerCommand('play');
   }, [sendPlayerCommand]);
 
+  // Video playback state for custom controls
+  const [currentTime, setCurrentTime] = useState(0);
+  const [videoDuration, setVideoDuration] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [controlsVisible, setControlsVisible] = useState(false);
+  const hideTimerRef = useRef(null);
+
+  // Comment-based timeline markers
+  const [commentMarkers, setCommentMarkers] = useState(null);
+
+  useEffect(() => {
+    if (!author || !permlink || author === 'unknown') return;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const replies = await hiveClient.call('condenser_api', 'get_content_replies', [author, permlink]);
+        if (cancelled || !replies || replies.length === 0) return;
+
+        // Build markers from top-level comments, placed randomly on the timeline
+        const markers = replies.map((comment) => {
+          const replyCount = comment.children || 0;
+          return {
+            pct: Math.random(),
+            avatar: `https://images.hive.blog/u/${comment.author}/avatar`,
+            label: comment.author,
+            replyCount,
+          };
+        });
+
+        // Sort by position so they render left-to-right
+        markers.sort((a, b) => a.pct - b.pct);
+
+        if (!cancelled) setCommentMarkers(markers);
+      } catch (err) {
+        console.error('Failed to fetch comments for markers:', err);
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [author, permlink]);
+
+  // Resolve markers with actual time values when duration is known
+  const resolvedMarkers = useMemo(() => {
+    if (!commentMarkers || videoDuration <= 0) return undefined;
+    return commentMarkers.map(m => ({
+      time: Math.round(m.pct * videoDuration),
+      avatar: m.avatar,
+      label: m.label,
+      replyCount: m.replyCount,
+    }));
+  }, [commentMarkers, videoDuration]);
+
+  // Reaction player state
+  const [selectedReactionIndex, setSelectedReactionIndex] = useState(0);
+  const [isReactionPlayerVisible, setIsReactionPlayerVisible] = useState(true);
+  const [reactionSize, setReactionSize] = useState(() => {
+    return localStorage.getItem('3speak-reaction-size') || 'small';
+  });
+
+  const cycleReactionSize = useCallback(() => {
+    setReactionSize(prev => {
+      const next = prev === 'small' ? 'medium' : prev === 'medium' ? 'big' : 'small';
+      localStorage.setItem('3speak-reaction-size', next);
+      return next;
+    });
+  }, []);
+
+  const showControlsTemporarily = useCallback(() => {
+    setControlsVisible(true);
+    if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+    hideTimerRef.current = setTimeout(() => setControlsVisible(false), 3000);
+  }, []);
+
+  const handleTogglePlay = useCallback(() => {
+    sendPlayerCommand('toggle-play');
+    setIsPlaying(prev => !prev);
+  }, [sendPlayerCommand]);
+
+  const handleSeekBackward = useCallback(() => {
+    const iframe = document.querySelector('.video-iframe-wrapper iframe');
+    if (iframe?.contentWindow) {
+      iframe.contentWindow.postMessage({ type: 'seekBackward', seconds: 10 }, '*');
+    }
+  }, []);
+
+  const handleSeekForward = useCallback(() => {
+    const iframe = document.querySelector('.video-iframe-wrapper iframe');
+    if (iframe?.contentWindow) {
+      iframe.contentWindow.postMessage({ type: 'seekForward', seconds: 10 }, '*');
+    }
+  }, []);
+
+  const handleSeek = useCallback((time) => {
+    const iframe = document.querySelector('.video-iframe-wrapper iframe');
+    if (iframe?.contentWindow) {
+      iframe.contentWindow.postMessage({ type: 'seek', time }, '*');
+    }
+  }, []);
+
+  const handleToggleFullscreen = useCallback(() => {
+    const wrapper = document.querySelector('.video-iframe-wrapper');
+    if (!wrapper) return;
+    if (!document.fullscreenElement) {
+      wrapper.requestFullscreen?.();
+    } else {
+      document.exitFullscreen?.();
+    }
+  }, []);
+
   // Navigate to next video in playlist
   const navigateToNextVideo = useCallback(() => {
     if (!playlistData || !playlistData.videos || playlistData.videos.length === 0) {
@@ -105,27 +220,51 @@ function Watch() {
     }
   }, [playlistData, navigate]);
 
-  // Listen for player ready message and auto-play, and video ended for playlist auto-advance
+  // Listen for player messages (only from main player iframe, not reaction player)
   useEffect(() => {
     const handleMessage = (event) => {
-      // Handle player-ready for auto-play
-      if (event.data && event.data.type === '3speak-player-ready') {
-        // Small delay to ensure player is fully ready
-        setTimeout(() => {
-          triggerPlay();
-        }, 100);
-      }
+      if (!event.data || !event.data.type) return;
 
-      // Handle video ended - auto-advance to next video in playlist
-      if (event.data && event.data.type === '3speak-ended') {
-        if (playlistData && showPlaylist) {
-          navigateToNextVideo();
-        }
+      // Only handle messages from the main video player, ignore reaction player iframes
+      const mainIframe = document.querySelector('.video-iframe-wrapper iframe');
+      if (event.source && mainIframe && event.source !== mainIframe.contentWindow) return;
+
+      switch (event.data.type) {
+        case '3speak-player-ready':
+          setTimeout(() => { triggerPlay(); }, 100);
+          if (mainIframe?.contentWindow) {
+            mainIframe.contentWindow.postMessage({ type: 'hide-controls' }, '*');
+          }
+          break;
+        case '3speak-timeupdate':
+          setCurrentTime(event.data.currentTime ?? 0);
+          if (event.data.duration) setVideoDuration(event.data.duration);
+          break;
+        case '3speak-playstate':
+          setIsPlaying(event.data.isPlaying ?? false);
+          break;
+        case '3speak-durationchange':
+          setVideoDuration(event.data.duration ?? 0);
+          break;
+        case '3speak-ended':
+          setIsPlaying(false);
+          if (playlistData && showPlaylist) {
+            navigateToNextVideo();
+          }
+          break;
       }
     };
 
+    const handleFullscreenChange = () => {
+      setIsFullscreen(!!document.fullscreenElement);
+    };
+
     window.addEventListener('message', handleMessage);
-    return () => window.removeEventListener('message', handleMessage);
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+    return () => {
+      window.removeEventListener('message', handleMessage);
+      document.removeEventListener('fullscreenchange', handleFullscreenChange);
+    };
   }, [triggerPlay, playlistData, showPlaylist, navigateToNextVideo]);
 
   const { data: videoData, loading: videoLoading, error: videoError } = useQuery(GET_VIDEO_DETAILS, {
@@ -209,7 +348,36 @@ function Watch() {
     // Combine: author videos first, then recommendations
     return [...authorVideos, ...recommendations];
   }, [authorVideosData, suggestionsData, trendingData, author, permlink]);
-  
+
+  // Build dummy reactions from comment markers, using suggested videos as reaction sources
+  // Note: no dependency on videoDuration to keep the array reference stable
+  const reactions = useMemo(() => {
+    if (!commentMarkers || suggestedVideos.length === 0) return [];
+    return commentMarkers.slice(0, 10).map((m, i) => {
+      const video = suggestedVideos[i % suggestedVideos.length];
+      const videoAuthor = video?.author?.username || video?.author?.id || video?.author || video?.owner;
+      return {
+        id: `reaction-${i}`,
+        author: m.label,
+        avatar: m.avatar,
+        videoUrl: `${PLAYER_URL}/watch?v=${videoAuthor}/${video.permlink}&layout=desktop&mode=iframe`,
+        replyCount: m.replyCount,
+        pct: m.pct,
+      };
+    });
+  }, [commentMarkers, suggestedVideos]);
+
+  const handleSelectReaction = useCallback((index) => {
+    if (index < 0 || index >= (reactions?.length ?? 0)) return;
+    setSelectedReactionIndex(index);
+    setIsReactionPlayerVisible(true);
+    // Seek main video to this reaction's timeline position
+    const reaction = reactions[index];
+    if (reaction && videoDuration > 0) {
+      handleSeek(reaction.pct * videoDuration);
+    }
+  }, [reactions, videoDuration, handleSeek]);
+
   const isNetworkError = videoError && videoError.networkError;
   const isLoading = videoLoading || (suggestionsLoading && trendingLoading && authorVideosLoading);
 
@@ -226,21 +394,68 @@ function Watch() {
   }
 
   return (
-    <div className="play-container">
+    <div className={`play-container${isReactionPlayerVisible && reactions.length > 0 ? ` reaction-${reactionSize}` : ''}`}>
       <PlayVideo
         videoDetails={videoDetails}
         author={author}
         permlink={permlink}
         playlistData={showPlaylist ? playlistData : null}
         onClosePlaylist={() => setShowPlaylist(false)}
+        videoControls={{
+          currentTime,
+          duration: videoDuration,
+          isPlaying,
+          isFullscreen,
+          isVisible: controlsVisible,
+          onTogglePlay: handleTogglePlay,
+          onSeekBackward: handleSeekBackward,
+          onSeekForward: handleSeekForward,
+          onSeek: handleSeek,
+          onToggleFullscreen: handleToggleFullscreen,
+          onMouseMove: showControlsTemporarily,
+          markers: resolvedMarkers,
+          onMarkerSelect: handleSelectReaction,
+        }}
       />
 
-      {suggestedVideos.length > 0 && (
-        <Recommended suggestedVideos={suggestedVideos} />
-      )}
+      {/* Right column: Reaction Player + Recommended */}
+      <div className="right-column">
+        {isReactionPlayerVisible && reactions.length > 0 && (
+          <ReactionPlayer
+            reactions={reactions}
+            selectedIndex={selectedReactionIndex}
+            onSelectReaction={handleSelectReaction}
+            onClose={() => setIsReactionPlayerVisible(false)}
+            size={reactionSize}
+            onCycleSize={cycleReactionSize}
+            currentTime={currentTime}
+            duration={videoDuration}
+          />
+        )}
+
+        {suggestedVideos.length > 0 && (
+          <div className="right-column-videos">
+            <h4>More videos</h4>
+            <Card3 videos={suggestedVideos} loading={false} />
+          </div>
+        )}
+      </div>
 
       {suggestedVideos.length > 0 && (
         <div className="mobile-recommended">
+          {isReactionPlayerVisible && reactions.length > 0 && (
+            <ReactionPlayer
+              reactions={reactions}
+              selectedIndex={selectedReactionIndex}
+              onSelectReaction={handleSelectReaction}
+              onClose={() => setIsReactionPlayerVisible(false)}
+              size={reactionSize}
+              onCycleSize={cycleReactionSize}
+              currentTime={currentTime}
+              duration={videoDuration}
+              mobile
+            />
+          )}
           <h4>More videos</h4>
           <Card3 videos={suggestedVideos.slice(0, 12)} loading={false} />
         </div>

--- a/src/page/Watch.jsx
+++ b/src/page/Watch.jsx
@@ -275,7 +275,7 @@ function Watch() {
   }, [sendPlayerCommand]);
 
   const handleToggleMute = useCallback(() => {
-    sendPlayerCommand('toggle-mute');
+    sendPlayerCommand('toggleMute');
     setIsMuted(prev => !prev);
   }, [sendPlayerCommand]);
 

--- a/src/page/Watch.jsx
+++ b/src/page/Watch.jsx
@@ -11,6 +11,7 @@ import { recordWatch } from '../utils/watchHistory';
 import { Client } from '@hiveio/dhive';
 import { HIVE_API_NODES, PLAYER_URL } from '../utils/config';
 import ReactionPlayer from '../components/ReactionPlayer/ReactionPlayer';
+import { MdVideocam, MdChatBubble } from 'react-icons/md';
 
 const hiveClient = new Client(HIVE_API_NODES);
 
@@ -224,6 +225,17 @@ function Watch() {
     if (textarea) {
       textarea.scrollIntoView({ behavior: 'smooth', block: 'center' });
       setTimeout(() => textarea.focus(), 400);
+    }
+  }, []);
+
+  const handleReactToMoment = useCallback(() => {
+    // Activate the React tab in the comment section
+    const reactTab = document.querySelector('.comment-tabs .comment-tab:nth-child(2)');
+    if (reactTab) reactTab.click();
+    // Scroll the comment section into view
+    const commentWrap = document.querySelector('.vid-comment-wrap');
+    if (commentWrap) {
+      commentWrap.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
   }, []);
 
@@ -488,10 +500,13 @@ function Watch() {
   const reactionCountLabel = useMemo(() => {
     const videoCount = reactions.filter(r => r.type === 'video').length;
     const commentCount = reactions.length - videoCount;
-    if (videoCount > 0 && commentCount > 0) {
-      return `${videoCount} video, ${commentCount} comment`;
-    }
-    return String(reactions.length);
+    return (
+      <>
+        {videoCount > 0 && <><MdVideocam size={14} /> {videoCount}</>}
+        {videoCount > 0 && commentCount > 0 && <span style={{ margin: '0 4px' }}>·</span>}
+        {commentCount > 0 && <><MdChatBubble size={12} /> {commentCount}</>}
+      </>
+    );
   }, [reactions]);
 
   const handleSelectReaction = useCallback((index) => {
@@ -567,6 +582,8 @@ function Watch() {
           onToggleFullscreen: handleToggleFullscreen,
           onMouseMove: showControlsTemporarily,
           onToggleControls: toggleControlsVisibility,
+          onPause: pauseMainPlayer,
+          onReactToMoment: handleReactToMoment,
           markers: resolvedMarkers,
           onMarkerSelect: handleSelectReaction,
         }}

--- a/src/page/Watch.jsx
+++ b/src/page/Watch.jsx
@@ -118,6 +118,8 @@ function Watch() {
 
   // Comment-based timeline markers
   const [commentMarkers, setCommentMarkers] = useState(null);
+  const [markersRefreshKey, setMarkersRefreshKey] = useState(0);
+  const refreshMarkers = useCallback(() => setMarkersRefreshKey(k => k + 1), []);
 
   useEffect(() => {
     if (!author || !permlink || author === 'unknown') return;
@@ -128,19 +130,17 @@ function Watch() {
         const replies = await hiveClient.call('condenser_api', 'get_content_replies', [author, permlink]);
         if (cancelled || !replies || replies.length === 0) return;
 
-        // Pick 3 random indices to simulate video reactions, rest are comments
-        const videoIndices = new Set();
-        const shuffled = [...Array(replies.length).keys()].sort(() => Math.random() - 0.5);
-        for (let i = 0; i < Math.min(3, shuffled.length); i++) {
-          videoIndices.add(shuffled[i]);
-        }
-
         // Pre-render comment bodies as HTML
         let render;
         try { render = await getRenderer(); } catch (e) { render = null; }
 
-        // Build markers from top-level comments, placed randomly on the timeline
-        const markers = replies.map((comment, i) => {
+        // Only include comments that have parentTimestamp in their metadata
+        const markers = [];
+        for (const comment of replies) {
+          let meta = {};
+          try { meta = typeof comment.json_metadata === 'string' ? JSON.parse(comment.json_metadata) : (comment.json_metadata || {}); } catch (_) {}
+          const parentTimestamp = typeof meta.parentTimestamp === 'number' ? meta.parentTimestamp : null;
+
           const replyCount = comment.children || 0;
           let bodyHtml = '';
           if (render && comment.body) {
@@ -148,19 +148,39 @@ function Watch() {
           } else {
             bodyHtml = comment.body || '';
           }
-          return {
-            pct: Math.random(),
+
+          // Detect video reactions by checking for video metadata
+          // Ensure the URL points to play.3speak.tv for proper iframe embedding
+          let videoUrl = meta.video?.url || null;
+          if (videoUrl && !videoUrl.includes('play.3speak.tv')) {
+            // Try to extract video ID from embed.3speak.tv or other URL formats
+            // and convert to play.3speak.tv/embed?v=user/videoId
+            const match = videoUrl.match(/embed\.3speak\.tv\/(?:watch|embed|uploads)\/(.+)/);
+            if (match) {
+              videoUrl = `https://play.3speak.tv/embed?v=${comment.author}/${match[1]}`;
+            }
+          }
+
+          markers.push({
+            pct: parentTimestamp,
+            pctIsSeconds: true,
             avatar: `https://images.hive.blog/u/${comment.author}/avatar`,
             label: comment.author,
             permlink: comment.permlink,
             replyCount,
             body: bodyHtml,
-            isVideo: videoIndices.has(i),
-          };
-        });
+            isVideo: !!videoUrl,
+            videoUrl,
+          });
+        }
 
-        // Sort by position so they render left-to-right
-        markers.sort((a, b) => a.pct - b.pct);
+        // Sort by timestamp: timestamped first (ascending), then no-timestamp at end
+        markers.sort((a, b) => {
+          if (a.pct === null && b.pct === null) return 0;
+          if (a.pct === null) return 1;
+          if (b.pct === null) return -1;
+          return a.pct - b.pct;
+        });
 
         if (!cancelled) setCommentMarkers(markers);
       } catch (err) {
@@ -169,26 +189,43 @@ function Watch() {
     })();
 
     return () => { cancelled = true; };
-  }, [author, permlink]);
+  }, [author, permlink, markersRefreshKey]);
 
   // Resolve markers with actual time values when duration is known
   const resolvedMarkers = useMemo(() => {
     if (!commentMarkers || videoDuration <= 0) return undefined;
-    return commentMarkers.map(m => ({
-      time: Math.round(m.pct * videoDuration),
-      avatar: m.avatar,
-      label: m.label,
-      replyCount: m.replyCount,
-      isVideo: m.isVideo,
-    }));
+    return commentMarkers
+      .filter(m => m.pct !== null)
+      .map(m => ({
+        time: Math.round(m.pct),
+        avatar: m.avatar,
+        label: m.label,
+        replyCount: m.replyCount,
+        isVideo: m.isVideo,
+      }));
   }, [commentMarkers, videoDuration]);
 
   // Reaction player state
   const [selectedReactionIndex, setSelectedReactionIndex] = useState(0);
-  const [isReactionPlayerVisible, setIsReactionPlayerVisible] = useState(true);
+  const [isReactionPlayerVisible, setIsReactionPlayerVisible] = useState(() => {
+    return localStorage.getItem('3speak-reactions-visible') !== 'false';
+  });
   const [reactionSize, setReactionSize] = useState(() => {
     return localStorage.getItem('3speak-reaction-size') || 'small';
   });
+
+  const setReactionsVisible = useCallback((visible) => {
+    setIsReactionPlayerVisible(visible);
+    localStorage.setItem('3speak-reactions-visible', String(visible));
+  }, []);
+
+  const handleAddReaction = useCallback(() => {
+    const textarea = document.querySelector('.add-comment-wrap .textarea-box');
+    if (textarea) {
+      textarea.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      setTimeout(() => textarea.focus(), 400);
+    }
+  }, []);
 
   const cycleReactionSize = useCallback(() => {
     setReactionSize(prev => {
@@ -198,10 +235,21 @@ function Watch() {
     });
   }, []);
 
+  // Desktop: show controls on mouse movement, auto-hide after 3s
   const showControlsTemporarily = useCallback(() => {
     setControlsVisible(true);
     if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
     hideTimerRef.current = setTimeout(() => setControlsVisible(false), 3000);
+  }, []);
+
+  // Mobile: tap toggles controls on/off (with auto-hide when showing)
+  const toggleControlsVisibility = useCallback(() => {
+    setControlsVisible(prev => {
+      if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+      if (prev) return false;
+      hideTimerRef.current = setTimeout(() => setControlsVisible(false), 3000);
+      return true;
+    });
   }, []);
 
   const pauseMainPlayer = useCallback(() => {
@@ -397,27 +445,25 @@ function Watch() {
     return [...authorVideos, ...recommendations];
   }, [authorVideosData, suggestionsData, trendingData, author, permlink]);
 
-  // Build reactions from comment markers: 3 video reactions + rest are comments
-  // Note: no dependency on videoDuration to keep the array reference stable
+  // Build reactions from comment markers: video reactions use the embed URL from metadata
   const reactions = useMemo(() => {
     if (!commentMarkers) return [];
-    let videoIdx = 0;
-    return commentMarkers.slice(0, 10).map((m, i) => {
+    return commentMarkers.map((m, i) => {
       const base = {
         id: `reaction-${i}`,
         author: m.label,
         avatar: m.avatar,
         replyCount: m.replyCount,
         pct: m.pct,
+        pctIsSeconds: m.pctIsSeconds,
       };
-      if (m.isVideo && suggestedVideos.length > 0) {
-        const video = suggestedVideos[videoIdx % suggestedVideos.length];
-        const videoAuthor = video?.author?.username || video?.author?.id || video?.author || video?.owner;
-        videoIdx++;
+      if (m.isVideo && m.videoUrl) {
         return {
           ...base,
           type: 'video',
-          videoUrl: `${PLAYER_URL}/watch?v=${videoAuthor}/${video.permlink}&layout=desktop&mode=iframe`,
+          videoUrl: m.videoUrl,
+          permlink: m.permlink,
+          body: m.body,
         };
       }
       return {
@@ -427,16 +473,25 @@ function Watch() {
         permlink: m.permlink,
       };
     });
-  }, [commentMarkers, suggestedVideos]);
+  }, [commentMarkers]);
+
+  const reactionCountLabel = useMemo(() => {
+    const videoCount = reactions.filter(r => r.type === 'video').length;
+    const commentCount = reactions.length - videoCount;
+    if (videoCount > 0 && commentCount > 0) {
+      return `${videoCount} video, ${commentCount} comment`;
+    }
+    return String(reactions.length);
+  }, [reactions]);
 
   const handleSelectReaction = useCallback((index) => {
     if (index < 0 || index >= (reactions?.length ?? 0)) return;
     setSelectedReactionIndex(index);
-    setIsReactionPlayerVisible(true);
+    setReactionsVisible(true);
     // Seek main video to this reaction's timeline position
     const reaction = reactions[index];
     if (reaction && videoDuration > 0) {
-      handleSeek(reaction.pct * videoDuration);
+      handleSeek(reaction.pct);
     }
   }, [reactions, videoDuration, handleSeek]);
 
@@ -475,11 +530,42 @@ function Watch() {
           onSeekBackward: handleSeekBackward,
           onSeekForward: handleSeekForward,
           onSeek: handleSeek,
+          onRefreshReactions: refreshMarkers,
           onToggleFullscreen: handleToggleFullscreen,
           onMouseMove: showControlsTemporarily,
+          onToggleControls: toggleControlsVisibility,
           markers: resolvedMarkers,
           onMarkerSelect: handleSelectReaction,
         }}
+        mobileReactionPanel={
+          <>
+            {isReactionPlayerVisible && reactions.length > 0 && (
+              <ReactionPlayer
+                reactions={reactions}
+                selectedIndex={selectedReactionIndex}
+                onSelectReaction={handleSelectReaction}
+                onClose={() => setReactionsVisible(false)}
+                size={reactionSize}
+                onCycleSize={cycleReactionSize}
+                currentTime={currentTime}
+                duration={videoDuration}
+                mainIsPlaying={isPlaying}
+                onReactionPlay={pauseMainPlayer}
+                mobile
+              />
+            )}
+            {!isReactionPlayerVisible && reactions.length > 0 && (
+              <button className="show-reactions-btn" onClick={() => setReactionsVisible(true)}>
+                Show Reactions ({reactionCountLabel})
+              </button>
+            )}
+            {reactions.length === 0 && (
+              <button className="show-reactions-btn" onClick={handleAddReaction}>
+                Add Reaction
+              </button>
+            )}
+          </>
+        }
       />
 
       {/* Right column: Reaction Player + Recommended */}
@@ -489,7 +575,7 @@ function Watch() {
             reactions={reactions}
             selectedIndex={selectedReactionIndex}
             onSelectReaction={handleSelectReaction}
-            onClose={() => setIsReactionPlayerVisible(false)}
+            onClose={() => setReactionsVisible(false)}
             size={reactionSize}
             onCycleSize={cycleReactionSize}
             currentTime={currentTime}
@@ -497,6 +583,16 @@ function Watch() {
             mainIsPlaying={isPlaying}
             onReactionPlay={pauseMainPlayer}
           />
+        )}
+        {!isReactionPlayerVisible && reactions.length > 0 && (
+          <button className="show-reactions-btn" onClick={() => setReactionsVisible(true)}>
+            Show Reactions ({reactionCountLabel})
+          </button>
+        )}
+        {reactions.length === 0 && (
+          <button className="show-reactions-btn" onClick={handleAddReaction}>
+            Add Reaction
+          </button>
         )}
 
         {suggestedVideos.length > 0 && (
@@ -509,21 +605,6 @@ function Watch() {
 
       {suggestedVideos.length > 0 && (
         <div className="mobile-recommended">
-          {isReactionPlayerVisible && reactions.length > 0 && (
-            <ReactionPlayer
-              reactions={reactions}
-              selectedIndex={selectedReactionIndex}
-              onSelectReaction={handleSelectReaction}
-              onClose={() => setIsReactionPlayerVisible(false)}
-              size={reactionSize}
-              onCycleSize={cycleReactionSize}
-              currentTime={currentTime}
-              duration={videoDuration}
-              mainIsPlaying={isPlaying}
-              onReactionPlay={pauseMainPlayer}
-              mobile
-            />
-          )}
           <h4>More videos</h4>
           <Card3 videos={suggestedVideos.slice(0, 12)} loading={false} />
         </div>

--- a/src/page/Watch.jsx
+++ b/src/page/Watch.jsx
@@ -14,6 +14,22 @@ import ReactionPlayer from '../components/ReactionPlayer/ReactionPlayer';
 
 const hiveClient = new Client(HIVE_API_NODES);
 
+// Lazy-load the Hive markdown renderer
+let rendererPromise = null;
+const getRenderer = async () => {
+  if (!rendererPromise) {
+    rendererPromise = import('@snapie/renderer').then(({ createHiveRenderer }) => {
+      return createHiveRenderer({
+        ipfsGateway: 'https://ipfs-3speak.b-cdn.net',
+        convertHiveUrls: true,
+        usertagUrlFn: (account) => `/p/${account}`,
+        hashtagUrlFn: (tag) => `/t/${tag}`,
+      });
+    });
+  }
+  return rendererPromise;
+};
+
 // Number of author videos to show at the top of recommendations
 const AUTHOR_VIDEOS_COUNT = 4;
 
@@ -95,6 +111,7 @@ function Watch() {
   const [currentTime, setCurrentTime] = useState(0);
   const [videoDuration, setVideoDuration] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
+  const [isMuted, setIsMuted] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [controlsVisible, setControlsVisible] = useState(false);
   const hideTimerRef = useRef(null);
@@ -111,14 +128,34 @@ function Watch() {
         const replies = await hiveClient.call('condenser_api', 'get_content_replies', [author, permlink]);
         if (cancelled || !replies || replies.length === 0) return;
 
+        // Pick 3 random indices to simulate video reactions, rest are comments
+        const videoIndices = new Set();
+        const shuffled = [...Array(replies.length).keys()].sort(() => Math.random() - 0.5);
+        for (let i = 0; i < Math.min(3, shuffled.length); i++) {
+          videoIndices.add(shuffled[i]);
+        }
+
+        // Pre-render comment bodies as HTML
+        let render;
+        try { render = await getRenderer(); } catch (e) { render = null; }
+
         // Build markers from top-level comments, placed randomly on the timeline
-        const markers = replies.map((comment) => {
+        const markers = replies.map((comment, i) => {
           const replyCount = comment.children || 0;
+          let bodyHtml = '';
+          if (render && comment.body) {
+            try { bodyHtml = render(comment.body); } catch (_) { bodyHtml = comment.body; }
+          } else {
+            bodyHtml = comment.body || '';
+          }
           return {
             pct: Math.random(),
             avatar: `https://images.hive.blog/u/${comment.author}/avatar`,
             label: comment.author,
+            permlink: comment.permlink,
             replyCount,
+            body: bodyHtml,
+            isVideo: videoIndices.has(i),
           };
         });
 
@@ -142,6 +179,7 @@ function Watch() {
       avatar: m.avatar,
       label: m.label,
       replyCount: m.replyCount,
+      isVideo: m.isVideo,
     }));
   }, [commentMarkers, videoDuration]);
 
@@ -174,6 +212,11 @@ function Watch() {
   const handleTogglePlay = useCallback(() => {
     sendPlayerCommand('toggle-play');
     setIsPlaying(prev => !prev);
+  }, [sendPlayerCommand]);
+
+  const handleToggleMute = useCallback(() => {
+    sendPlayerCommand('toggle-mute');
+    setIsMuted(prev => !prev);
   }, [sendPlayerCommand]);
 
   const handleSeekBackward = useCallback(() => {
@@ -354,20 +397,34 @@ function Watch() {
     return [...authorVideos, ...recommendations];
   }, [authorVideosData, suggestionsData, trendingData, author, permlink]);
 
-  // Build dummy reactions from comment markers, using suggested videos as reaction sources
+  // Build reactions from comment markers: 3 video reactions + rest are comments
   // Note: no dependency on videoDuration to keep the array reference stable
   const reactions = useMemo(() => {
-    if (!commentMarkers || suggestedVideos.length === 0) return [];
+    if (!commentMarkers) return [];
+    let videoIdx = 0;
     return commentMarkers.slice(0, 10).map((m, i) => {
-      const video = suggestedVideos[i % suggestedVideos.length];
-      const videoAuthor = video?.author?.username || video?.author?.id || video?.author || video?.owner;
-      return {
+      const base = {
         id: `reaction-${i}`,
         author: m.label,
         avatar: m.avatar,
-        videoUrl: `${PLAYER_URL}/watch?v=${videoAuthor}/${video.permlink}&layout=desktop&mode=iframe`,
         replyCount: m.replyCount,
         pct: m.pct,
+      };
+      if (m.isVideo && suggestedVideos.length > 0) {
+        const video = suggestedVideos[videoIdx % suggestedVideos.length];
+        const videoAuthor = video?.author?.username || video?.author?.id || video?.author || video?.owner;
+        videoIdx++;
+        return {
+          ...base,
+          type: 'video',
+          videoUrl: `${PLAYER_URL}/watch?v=${videoAuthor}/${video.permlink}&layout=desktop&mode=iframe`,
+        };
+      }
+      return {
+        ...base,
+        type: 'comment',
+        body: m.body,
+        permlink: m.permlink,
       };
     });
   }, [commentMarkers, suggestedVideos]);
@@ -410,9 +467,11 @@ function Watch() {
           currentTime,
           duration: videoDuration,
           isPlaying,
+          isMuted,
           isFullscreen,
           isVisible: controlsVisible,
           onTogglePlay: handleTogglePlay,
+          onToggleMute: handleToggleMute,
           onSeekBackward: handleSeekBackward,
           onSeekForward: handleSeekForward,
           onSeek: handleSeek,

--- a/src/page/Watch.scss
+++ b/src/page/Watch.scss
@@ -93,4 +93,24 @@
         }
       }
     }
+
+    .show-reactions-btn {
+      width: 100%;
+      padding: 10px;
+      margin-bottom: 12px;
+      border: 1px solid var(--border-light, #333);
+      border-radius: 10px;
+      background: transparent;
+      color: var(--text-secondary, #aaa);
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.2s ease;
+
+      &:hover {
+        background: var(--bg-tertiary, rgba(255, 255, 255, 0.05));
+        color: var(--text-primary, #fff);
+        border-color: var(--border-color, #555);
+      }
+    }
 }

--- a/src/page/Watch.scss
+++ b/src/page/Watch.scss
@@ -95,6 +95,10 @@
     }
 
     .show-reactions-btn {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 4px;
       width: 100%;
       padding: 10px;
       margin-bottom: 12px;
@@ -106,6 +110,10 @@
       font-weight: 600;
       cursor: pointer;
       transition: all 0.2s ease;
+
+      svg {
+        vertical-align: middle;
+      }
 
       &:hover {
         background: var(--bg-tertiary, rgba(255, 255, 255, 0.05));

--- a/src/page/Watch.scss
+++ b/src/page/Watch.scss
@@ -6,6 +6,63 @@
     justify-content: space-between;
     flex-wrap: wrap;
 
+    .right-column {
+      flex-basis: 30%;
+      max-width: 30%;
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+
+      @include respond(phone) {
+        display: none;
+      }
+
+      .right-column-videos {
+        h4 {
+          font-size: 14px;
+          font-weight: 600;
+          color: var(--text-primary);
+          margin: 0 0 8px;
+        }
+
+        .card-container {
+          grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)) !important;
+          grid-row-gap: 10px !important;
+
+          .card .img-wrap {
+            aspect-ratio: 16 / 9;
+
+            img {
+              height: 100% !important;
+            }
+          }
+        }
+      }
+    }
+
+    // Size variants for reaction player (small is default)
+    &.reaction-medium {
+      .play-video {
+        flex-basis: 50%;
+        max-width: 50%;
+      }
+      .right-column {
+        flex-basis: 48%;
+        max-width: 48%;
+      }
+    }
+
+    &.reaction-big {
+      .play-video {
+        flex-basis: 30%;
+        max-width: 30%;
+      }
+      .right-column {
+        flex-basis: 68%;
+        max-width: 68%;
+      }
+    }
+
     .mobile-recommended {
       display: none;
       width: 100%;

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -11,6 +11,11 @@ const VIEWS_URL = import.meta.env.VITE_VIEWS_URL || 'https://views.3speak.tv';
 const TAG_FEED_URL = import.meta.env.VITE_THREESPEAK_TAG_FEED_URL || 'https://legacy.3speak.tv';
 const PLAYLISTS_API_URL = import.meta.env.VITE_PLAYLISTS_API_URL || 'https://3speak-playlists.okinoko.io/api';
 
+// 3Speak Embed upload (for video reactions)
+const EMBED_UPLOAD_URL = import.meta.env.VITE_EMBED_UPLOAD_URL || 'https://embed.3speak.tv/uploads';
+const EMBED_API_URL = import.meta.env.VITE_EMBED_API_URL || 'https://embed.3speak.tv';
+const EMBED_API_KEY = import.meta.env.VITE_EMBED_API_KEY || '';
+
 // Watch history threshold - number of days to show unwatched indicator
 const WATCH_HISTORY_THRESHOLD_DAYS = parseInt(import.meta.env.VITE_WATCH_HISTORY_THRESHOLD_DAYS || '14', 10);
 
@@ -33,5 +38,8 @@ export {
   VIEWS_URL,
   PLAYER_URL,
   PLAYLISTS_API_URL,
-  WATCH_HISTORY_THRESHOLD_DAYS
+  WATCH_HISTORY_THRESHOLD_DAYS,
+  EMBED_UPLOAD_URL,
+  EMBED_API_URL,
+  EMBED_API_KEY,
 };

--- a/src/utils/reputation.js
+++ b/src/utils/reputation.js
@@ -32,14 +32,16 @@ export async function getUserReputation(username) {
     }
 
     const reputation = await response.json();
-    
+    // 0 means no reputation data (new account) — treat as neutral (25)
+    const score = reputation || 25;
+
     // Cache the result
     repCache.set(username, {
-      rep: reputation,
+      rep: score,
       timestamp: Date.now()
     });
 
-    return reputation;
+    return score;
   } catch (error) {
     console.error('Error fetching reputation for', username, error);
     return 25; // Default to neutral on error (fail-open)
@@ -165,6 +167,20 @@ export async function filterByReputation(content) {
   }
   
   return filterItems(content);
+}
+
+/**
+ * Convert raw Hive author_reputation (bigint) to human-readable score (e.g. 72)
+ * @param {number|string} raw - Raw reputation from Hive API
+ * @returns {number|null}
+ */
+export function hiveRepToScore(raw) {
+  if (raw == null) return null;
+  const n = parseInt(raw);
+  if (isNaN(n) || n === 0) return 25;
+  const neg = n < 0;
+  const out = Math.log10(Math.abs(n));
+  return Math.floor(Math.max(out - 9, 0) * (neg ? -1 : 1) * 9 + 25);
 }
 
 /**


### PR DESCRIPTION
## Video Reactions & Reaction Chains

- Video reactions: upload or record reaction videos as Hive comments on any video/short
- Reaction chain overlay: walks up the Hive parent chain to build a breadcrumb from root video → intermediate reactions/comments → current short
- Origin card shows root video thumbnail, title, author, and playhead timestamp with link to watch page
- Intermediate chain steps shown as expandable cards with author badges and navigation links
- Collapsible overlay in shorts player (tap to expand/collapse)
- React tab in comments panel: pick file or record from webcam, TUS upload, publish as comment
- Comment-based video reactions on the watch page with inline ReactionPlayer component
- Reaction chain resolution resolves internal short permlinks for direct shorts player navigation

## ReactionPlayer Component

- Horizontal scrollable list of reaction videos displayed alongside the main video on the watch page
- Each reaction in the chain is rendered as an iframe-based video player with independent playback controls
- Supports three size modes: Small (S), Medium (M), and Large (L) — toggled via buttons in the panel header
- Builds and displays the full reaction chain by walking up the Hive blockchain parent-comment hierarchy
- Includes its own playback controls per reaction: play/pause, seek bar, mute/unmute, and fullscreen toggle
- Communicates with iframe players via postMessage API (play, pause, mute, unmute, seek, toggle-play)
- Mobile-responsive: collapsible panel with a toggle button, auto-collapses on small screens
- Renders a comment thread below each reaction using recursive CommentNode components
- Comment bodies are sanitized: strips embedded 3Speak <iframe> tags and "replied to @user" prefixes

## ReactVideoTab Component
- Inline panel in the comments section for uploading or recording reaction videos
- Supports two input modes: file upload (drag-and-drop or file picker) and webcam recording
- Uploads reaction videos via TUS protocol to the 3Speak embed API
- On upload completion, publishes the reaction as a Hive blockchain comment under the parent post
- Integrated into [CommentSection.jsx](vscode-webview://18l3ao702s3a09lnjpdoukuk6lkjggac9s7ca93f3pld24u2g0f1/src/components/playVideo/CommentSection.jsx) at both the top-level reply area and individual comment reply forms

## Shorts player (Short.jsx / Short.scss):

- Replace useState for currentTime/duration with useRef + direct DOM updates to eliminate ~4x/sec re-renders
- Add mute/unmute support: cookie-persisted state, mute sync via postMessage before play, top-right toggle button (mobile + desktop sidebar)
- Add gesture system: single tap = play/pause, double tap = upvote (heart animation), long press = mute toggle
- Add keyboard shortcuts: Space (play/pause), M (mute), Arrow Left/Right (seek 5s)
- Switch to native player looping (loop=1 param) instead of manual seek-on-ended
- Pause ALL other iframes on navigation (not just previous) to free mobile connections
- Reduce preload range (1 behind, 4 ahead) and pause+cleanup iframes leaving range
- Add "Loading shorts..." overlay until first player ready, with 6s force-show fallback
- Show thumbnail placeholder while individual players initialize
- Add user-specific feed mode via ?user= URL param (loads from per-user endpoint)
- Skip re-triggering play on enrichment re-renders (track prevVideoIdRef)
- Prevent concurrent loadMore calls with loadingMoreRef
- Add comments panel drag-to-close on mobile
- Pre-render comment bodies with @snapie/renderer (markdown/HTML)
- Replace ThumbsUp with Heart icon, add heart pop animation on vote
- Fix back navigation pushing duplicate history entries
- Add touch event guards to prevent click/touch double-fire

## Vote system (CommentVoteTooltip.jsx / UpvoteTooltip.scss):
- Redesign as centered modal popup with overlay (replaces inline tooltip)
- Replace native input[type=range] with custom div-based slider (track/fill/thumb) to fix React drag snap-back bug
- Fetch account data + dynamic props once on open via getDynamicProps(), use pure-math estimateLocal() during drag for instant feedback
- Add compact variant for watch page, close on Escape key
- Use on watch page (PlayVideo.jsx) replacing UpvoteTooltip with CommentVoteTooltip

## User shorts feed (new feature):
- Add fetchUserShortsList() and fetchUserShortsWithDetails() to hiveApi.js
- Add VITE_USER_SHORTS_API_URL env var (.env + .env.example)
- Add "Shorts" tab to UserProfilePage with infinite scroll
- Card3 gains linkPrefix and linkQuery props for customizable navigation
- Shorts cards show first 80 chars of hive_body as title

## Performance (hiveApi.js):
- Replace getAllShortsCached() pagination loop with in-memory Map indexes (_shortsByEmbedUrl, _shortsByPermlink)
- findShortByEmbedUrl/findShortByPermlink check Map first, paginate only as fallback
- Populate stats, caption, title from Hive post data in fetchCompleteShortData
- Add children count to reaction chain steps and child reactions

## Other changes:
- PayoutAmount: switch icon from IoChevronUpCircleOutline to FaHive
- AuthorBadge: increase avatar to 30px, tighter padding, stretch follow button
- Watch.jsx: fix toggleMute command name (toggle-mute → toggleMute)
- CommentSection: attach cached reputation to comment authors, reorder reply/shorts-link buttons
- reputation.js: add hiveRepToScore() for raw bigint conversion, treat 0 reputation as neutral (25)
- ReactionPlayer: change reply count badge background to neutral gray