### PR TITLE
minor changes

### DIFF
--- a/src/components/Cards/Card3.jsx
+++ b/src/components/Cards/Card3.jsx
@@ -1,7 +1,10 @@
 import PayoutAmount from "../PayoutAmount/PayoutAmount";
 import UpvoteCount from "../UpvoteCount/UpvoteCount";
 import ViewCount from "../ViewCount/ViewCount";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import { IoCalendarOutline } from "react-icons/io5";
+dayjs.extend(utc);
 import { MdDelete, MdError, MdPhoneIphone } from "react-icons/md";
 import { FaCog, FaFileAlt } from "react-icons/fa";
 import AddToPlaylistButton from "../AddToPlaylistButton/AddToPlaylistButton";
@@ -9,7 +12,7 @@ import TimeAgo from "../TimeAgo/TimeAgo";
 import { Link, useNavigate } from "react-router-dom";
 import PropTypes from "prop-types";
 import "./Cards.scss";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import img from "../../assets/image/speak.jpg";
 import { fixVideoThumbnail } from "../../utils/fixThumbnails";
 import AuthorBadge from "../AuthorBadge/AuthorBadge";
@@ -21,8 +24,6 @@ function Card3({ videos = [], loading = false, error = null, getContentForVideo 
   const navigate = useNavigate();
   const [modalUser, setModalUser] = useState(null);
   const { getViewCount } = useViewCounts(videos);
-  const [showTooltip, setShowTooltip] = useState(false);
-
   const formatViewCount = (views) => {
     if (views === null || views === undefined) return null;
     if (views >= 1000000) return `${(views / 1000000).toFixed(1)}M`;
@@ -30,11 +31,6 @@ function Card3({ videos = [], loading = false, error = null, getContentForVideo 
     return views.toLocaleString();
   };
 
-  useEffect(() => {
-  const close = () => setShowTooltip(false);
-  window.addEventListener("click", close);
-  return () => window.removeEventListener("click", close);
-}, []);
 
 
 
@@ -85,31 +81,14 @@ function Card3({ videos = [], loading = false, error = null, getContentForVideo 
 
               {/* Status Badges */}
               {video.status === 'scheduled' && video.publish_type === 'schedule' && (
-                <div
-                  className="status-badge scheduled"
-                  onMouseEnter={() => setShowTooltip(true)}
-                  onMouseLeave={() => setShowTooltip(false)}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    setShowTooltip((prev) => !prev);
-                  }}
-                >
+                <div className="status-badge scheduled">
                   <IoCalendarOutline size={18} />
-                  <span>Scheduled</span>
-
-                  {showTooltip && (
-                    <div className="schedule-tooltip">
-                      Scheduled for <br />
-                      <strong>
-                        {dayjs(video.publish_data?.scheduled_at).format(
-                          "MMM D, YYYY h:mm A"
-                        )}
-                      </strong>
-                    </div>
-                  )}
+                  <span>
+                    {video.publish_data?.scheduled_at
+                      ? dayjs.utc(video.publish_data.scheduled_at).local().format('MMM D, h:mm A')
+                      : 'Scheduled'}
+                  </span>
                 </div>
-
               )}
 
               {video.publish_type === 'publish_manual' && (

--- a/src/components/Cards/Cards.scss
+++ b/src/components/Cards/Cards.scss
@@ -403,43 +403,6 @@
     }
   }
 }
-.status-badge {
-  position: relative;
-  cursor: pointer;
-
-  .schedule-tooltip {
-    position: absolute;
-    top: 120%;
-    right: 0;
-    background: rgba(20, 20, 20, 0.96);
-    color: #fff;
-    padding: 8px 10px;
-    border-radius: 6px;
-    font-size: 11px;
-    white-space: nowrap;
-    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
-    z-index: 50;
-
-    animation: fadeIn 0.15s ease forwards;
-
-    &::before {
-      content: "";
-      position: absolute;
-      top: -5px;
-      right: 12px;
-      border-width: 6px;
-      border-style: solid;
-      border-color: transparent transparent rgba(241, 10, 10, 0.96)
-        transparent;
-    }
-  }
-}
-
-@media (hover: none) {
-  .status-badge span {
-    display: none;
-  }
-}
 
 
 @keyframes fadeIn {

--- a/src/components/Draft/VideoCard.jsx
+++ b/src/components/Draft/VideoCard.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import "./VideoCard.scss"
 import dayjs from "dayjs";
+import utc from 'dayjs/plugin/utc';
 import {  useNavigate } from 'react-router-dom';
 import { fixVideoThumbnail } from '../../utils/fixThumbnails';
+import fallbackImg from '../../assets/image/speak.jpg';
+dayjs.extend(utc);
 const VideoCard = ({  video, onEdit, onView, onDelete, onPublish}) => {
   const navigate = useNavigate()
   const handleNavigate = ()=>{
@@ -28,7 +31,7 @@ const VideoCard = ({  video, onEdit, onView, onDelete, onPublish}) => {
   return (
     <div className="video-card">
       <div className="thumbnail">
-        <img src={fixVideoThumbnail(video)} alt={video.title} />
+        <img src={fixVideoThumbnail(video)} alt={video.title} onError={(e) => (e.currentTarget.src = fallbackImg)} />
       </div>
       <div className="content">
         <h3 className="title">{video.title || ""}</h3>
@@ -38,6 +41,11 @@ const VideoCard = ({  video, onEdit, onView, onDelete, onPublish}) => {
             {getStatusLabel(video.status)}
           </span>
         </div>
+        {video.status === 'scheduled' && video.publish_data?.scheduled_at && (
+          <div className="scheduled-date">
+            Publishes {dayjs.utc(video.publish_data.scheduled_at).local().format('MMM D, YYYY [at] h:mm A')}
+          </div>
+        )}
         <div className="actions">
           {video.status === 'published' ? (
             <>

--- a/src/components/Draft/VideoCard.scss
+++ b/src/components/Draft/VideoCard.scss
@@ -103,7 +103,7 @@ $black: #212529;
       font-size: 12px;
       border-radius: 30px;
       font-weight: 500;
-      
+
       &--published {
         background-color: rgba($primary-blue, 0.1);
         color: $primary-blue;
@@ -113,10 +113,21 @@ $black: #212529;
         background-color: yellow;
         color: black;
       }
-      
+
       &--publish_manual {
         background-color: rgba($primary-red, 0.1);
         color: $primary-red;
+      }
+    }
+
+    .scheduled-date {
+      font-size: 12px;
+      color: #e6a800;
+      font-weight: 500;
+      margin-bottom: 10px;
+
+      [data-theme="dark"] & {
+        color: #ffc107;
       }
     }
     

--- a/src/components/ReactionPlayer/ReactionPlayer.jsx
+++ b/src/components/ReactionPlayer/ReactionPlayer.jsx
@@ -5,6 +5,7 @@ import { TbRewindBackward10, TbRewindForward10 } from 'react-icons/tb';
 import { Client } from '@hiveio/dhive';
 import { HIVE_API_NODES } from '../../utils/config';
 import './ReactionPlayer.scss';
+import { markByReputation } from '../../utils/reputation';
 
 const hiveClient = new Client(HIVE_API_NODES);
 
@@ -43,12 +44,29 @@ function strip3SpeakEmbeds(html) {
 }
 
 function CommentNode({ comment, depth }) {
+  const [collapsed, setCollapsed] = useState(false);
   const bodyHtml = depth === 0 ? strip3SpeakEmbeds(comment.body) : stripRepliedTo(comment.body || '');
+
+  if (comment.isLowReputation) return null;
+
+  if (collapsed) {
+    return (
+      <div className="rct-thread-comment" style={depth > 0 ? { marginLeft: `${Math.min(depth, 4) * 16}px` } : undefined}>
+        <div className="comment-collapsed-bar" onClick={() => setCollapsed(false)}>
+          <img className="comment-collapsed-avatar" src={comment.avatar} alt="" />
+          <span className="comment-collapsed-name">@{comment.author}</span>
+          <MdKeyboardArrowUp size={18} className="comment-collapsed-chevron" />
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="rct-thread-comment" style={depth > 0 ? { marginLeft: `${Math.min(depth, 4) * 16}px` } : undefined}>
       <div className="rct-thread-header">
         <img className="rct-thread-avatar" src={comment.avatar} alt="" />
         <span className="rct-thread-author">@{comment.author}</span>
+        <span className="comment-collapse-chevron" onClick={() => setCollapsed(true)}><MdKeyboardArrowUp size={18} /></span>
       </div>
       <div className="rct-thread-body markdown-view" dangerouslySetInnerHTML={{ __html: bodyHtml }} />
       {comment.children?.map((child, i) => (
@@ -208,8 +226,9 @@ function ReactionPlayer({
         };
 
         const tree = await buildTree(current.author, current.permlink, 0);
+        const markedTree = await markByReputation(tree);
         if (!cancelled) {
-          setNestedComments(tree);
+          setNestedComments(markedTree);
           setLoadingComments(false);
         }
       } catch (err) {
@@ -476,7 +495,7 @@ function ReactionPlayer({
         {!isVideo && (
           <div className="rct-comment-panel">
             <div className="rct-comment-thread">
-              <CommentNode comment={{ author: current.author, avatar: current.avatar, body: current.body, children: [] }} depth={0} />
+              <CommentNode comment={{ author: current.author, avatar: current.avatar, body: current.body, isLowReputation: current.isLowReputation, children: [] }} depth={0} />
               {loadingComments && <div className="rct-thread-loading">Loading replies...</div>}
               {nestedComments.map((reply, i) => (
                 <CommentNode key={i} comment={reply} depth={1} />
@@ -555,7 +574,7 @@ function ReactionPlayer({
       {isVideo && current.permlink && (
         <div className="rct-comment-panel rct-comment-panel--below">
           <div className="rct-comment-thread">
-            <CommentNode comment={{ author: current.author, avatar: current.avatar, body: current.body, children: [] }} depth={0} />
+            <CommentNode comment={{ author: current.author, avatar: current.avatar, body: current.body, isLowReputation: current.isLowReputation, children: [] }} depth={0} />
             {loadingComments && <div className="rct-thread-loading">Loading replies...</div>}
             {nestedComments.map((reply, i) => (
               <CommentNode key={i} comment={reply} depth={1} />
@@ -568,6 +587,7 @@ function ReactionPlayer({
       {/* Horizontal scrollable list */}
       <div className="reaction-list" ref={scrollRef}>
         {reactions.map((reaction, i) => {
+          if (reaction.isLowReputation) return null;
           // Insert divider before the first non-timestamped reaction
           const showDivider = reaction.pct === null && (i === 0 || reactions[i - 1].pct !== null);
           return (

--- a/src/components/ReactionPlayer/ReactionPlayer.scss
+++ b/src/components/ReactionPlayer/ReactionPlayer.scss
@@ -558,6 +558,16 @@
     margin: 4px 2px;
   }
 
+  // Low-reputation scroller item — greyed out but still clickable
+  .reaction-item--low-rep {
+    opacity: 0.4;
+    filter: grayscale(0.6);
+    &.active {
+      opacity: 0.7;
+      filter: grayscale(0.3);
+    }
+  }
+
   // Collapse/hide toggle button
   .mobile-rct-toggle {
     // Visible on all screen sizes (nav-btn styles apply)

--- a/src/components/playVideo/CommentSection.jsx
+++ b/src/components/playVideo/CommentSection.jsx
@@ -4,7 +4,7 @@ import './BlogContent.scss';
 import { BiDislike } from 'react-icons/bi';
 import { ImSpinner9 } from 'react-icons/im';
 import { TailChase } from 'ldrs/react';
-import { MdVideocam, MdComment } from 'react-icons/md';
+import { MdVideocam, MdComment, MdKeyboardArrowUp } from 'react-icons/md';
 import ReactVideoTab from '../ReactVideoModal/ReactVideoModal';
 import dayjs from 'dayjs';
 import { useAppStore } from '../../lib/store';
@@ -13,7 +13,7 @@ import UpvoteTooltip from '../tooltip/UpvoteTooltip';
 import CommentVoteTooltip from '../tooltip/CommentVoteTooltip';
 import {  toast } from 'sonner'
 import { estimate, getVotePower } from '../../utils/hiveUtils';
-import { filterByReputation, getUserReputation } from '../../utils/reputation';
+import { markByReputation, getUserReputation } from '../../utils/reputation';
 import Button from '../Button/Button';
 import AuthorBadge from '../AuthorBadge/AuthorBadge';
 import UpvoteCount from '../UpvoteCount/UpvoteCount';
@@ -147,17 +147,17 @@ function CommentSection({ videoDetails, author, permlink, currentTime, duration,
       try {
         const replies = await client.call('condenser_api', 'get_content_replies', [author, permlink]);
         const commentsWithChildren = await loadNestedComments(replies);
-        // Filter out spam accounts (negative reputation) — also caches reputations
-        const filteredComments = await filterByReputation(commentsWithChildren);
-        // Attach cached reputations to comment authors (all cache hits after filtering)
+        // Mark low-reputation accounts (rep < 15) — also caches reputations
+        const markedComments = await markByReputation(commentsWithChildren);
+        // Attach cached reputations to comment authors (all cache hits after marking)
         const attachRep = async (comments) => {
           for (const c of comments) {
             if (c.author?.username) c.author.reputation = await getUserReputation(c.author.username);
             if (c.children?.length) await attachRep(c.children);
           }
         };
-        await attachRep(filteredComments);
-        setCommentList(filteredComments);
+        await attachRep(markedComments);
+        setCommentList(markedComments);
         
         // Pre-render all comment bodies (createHiveRenderer returns a function directly)
         const render = await getRenderer();
@@ -174,7 +174,7 @@ function CommentSection({ videoDetails, author, permlink, currentTime, duration,
             comment.children.forEach(renderComment);
           }
         };
-        filteredComments.forEach(renderComment);
+        markedComments.forEach(renderComment);
         setRenderedBodies(rendered);
       } catch (error) {
         console.error('Failed to fetch comments from Hive:', error);
@@ -621,6 +621,7 @@ function Comment({
 }) {
   const isReplying = activeReply === comment.permlink;
   const [replyTab, setReplyTab] = useState('comment');
+  const [collapsed, setCollapsed] = useState(false);
 
   // Inherit timestamp from the parent comment (not editable)
   const replyTimestamp = comment?.parentTimestamp ?? null;
@@ -629,6 +630,19 @@ function Comment({
   useEffect(() => {
     if (isReplying) setReplyTab('comment');
   }, [isReplying]);
+
+  if (comment.isLowReputation) return null;
+
+  if (collapsed) {
+    return (
+      <div className="comment-container" style={{ marginLeft: depth > 0 ? '40px' : '0px' }}>
+        <div className="comment-collapsed-bar" onClick={() => setCollapsed(false)}>
+          <AuthorBadge author={comment?.author?.username} reputation={comment?.author?.reputation} noLink compact />
+          <MdKeyboardArrowUp size={18} className="comment-collapsed-chevron" />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="comment-container" style={{ marginLeft: depth > 0 ? '40px' : '0px' }} >
@@ -640,6 +654,7 @@ function Comment({
             {comment?.parentTimestamp != null && (
               <span className="comment-timestamp-badge" onClick={() => onSeek?.(comment.parentTimestamp)}>at {formatTimeInput(comment.parentTimestamp)}</span>
             )}
+            <span className="comment-collapse-chevron" onClick={() => setCollapsed(true)}><MdKeyboardArrowUp size={18} /></span>
           </div>
           <div className="markdown-view" dangerouslySetInnerHTML={{ __html: processedBody(comment?.body || '', comment?.permlink) }} />
           <div className="comment-action">
@@ -685,7 +700,6 @@ function Comment({
           </div>
         </div>
       </div>
-
       {isReplying && (
         <div className="add-comment-wrap sub" style={{ marginLeft: '40px' }}>
           {/* Tab headers + timestamp */}

--- a/src/components/playVideo/PlayVideo.jsx
+++ b/src/components/playVideo/PlayVideo.jsx
@@ -7,7 +7,7 @@ import UpvoteCount from "../UpvoteCount/UpvoteCount";
 import PayoutAmount from "../PayoutAmount/PayoutAmount";
 import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import { useQuery } from "@apollo/client";
-import { GET_PROFILE } from "../../graphql/queries";
+import { GET_PROFILE, GET_VIDEO } from "../../graphql/queries";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import BlogContent from "./BlogContent";
@@ -117,8 +117,12 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
     skip: !videoDetails?.author?.id,
   });
 
-  // Use spkvideo from videoDetails (already fetched by Watch.jsx)
-  const spkvideo = videoDetails?.spkvideo;
+  // Fetch spkvideo separately (resilient — doesn't block videoDetails)
+  const { data: videoData } = useQuery(GET_VIDEO, {
+    variables: { author, permlink },
+    skip: !author || !permlink,
+  });
+  const spkvideo = videoData?.socialPost?.spkvideo || videoDetails?.spkvideo;
   const profile = getUserProfile.data?.profile;
   
   // Memoized values

--- a/src/components/recommended/Recommended.jsx
+++ b/src/components/recommended/Recommended.jsx
@@ -30,6 +30,7 @@ function Recommended({suggestedVideos}) {
                 <img
                   src={fixVideoThumbnail(data)}
                   alt={data.title}
+                  onError={(e) => (e.currentTarget.src = 'https://media.3speak.tv/defaults/default_thumbnail.png')}
                 />
                 <AddToPlaylistButton
                   author={author}

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -53,7 +53,6 @@ export const GET_VIDEO_DETAILS = gql`
           }
         }
         body
-        spkvideo
         stats {
           num_comments
           num_votes

--- a/src/index.css
+++ b/src/index.css
@@ -814,3 +814,61 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 } */
 
+/* Chevron to hide a comment — right-aligned in header */
+.comment-collapse-chevron {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  color: var(--text-muted, #888);
+  cursor: pointer;
+  flex-shrink: 0;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--bg-tertiary, rgba(255,255,255,0.08));
+  transition: color 0.15s ease, background 0.15s ease;
+}
+.comment-collapse-chevron:hover {
+  color: var(--text-secondary, #aaa);
+  background: var(--bg-hover, rgba(255,255,255,0.14));
+}
+
+/* Collapsed comment bar — slim row with avatar + name, click to expand */
+.comment-collapsed-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  font-size: 12px;
+  color: var(--text-muted, #888);
+  background: var(--bg-tertiary, rgba(255,255,255,0.04));
+  border-radius: 6px;
+  cursor: pointer;
+  margin: 2px 0;
+  transition: background 0.15s ease;
+}
+.comment-collapsed-bar:hover {
+  background: var(--bg-hover, rgba(255,255,255,0.08));
+}
+.comment-collapsed-bar .author-badge {
+  flex-shrink: 0;
+}
+.comment-collapsed-avatar {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+.comment-collapsed-name {
+  font-size: 12px;
+  color: var(--text-secondary, #aaa);
+  white-space: nowrap;
+}
+.comment-collapsed-chevron {
+  margin-left: auto;
+  flex-shrink: 0;
+  color: var(--text-muted, #888);
+  transform: rotate(180deg);
+}
+
+

--- a/src/page/Short.jsx
+++ b/src/page/Short.jsx
@@ -10,7 +10,6 @@ import {
   ArrowDown,
   X,
   SlidersHorizontal,
-  MoreVertical,
   Loader2,
   Play,
   Pause,
@@ -50,6 +49,7 @@ import { PLAYER_URL } from '../utils/config';
 import { useNavigate, useLocation, Link } from 'react-router-dom';
 import { fixVideoThumbnail } from '../utils/fixThumbnails';
 import AuthorBadge from '../components/AuthorBadge/AuthorBadge';
+import { markByReputation } from '../utils/reputation';
 
 // Lazy-loaded Hive markdown renderer (same as CommentSection)
 let rendererPromise = null;
@@ -1068,7 +1068,8 @@ const VideoShort = () => {
     commentsFetchedRef.current.add(video.id);
 
     try {
-      const comments = await hiveApi.fetchPostComments(video.author, video.hivePermlink, user);
+      const rawComments = await hiveApi.fetchPostComments(video.author, video.hivePermlink, user);
+      const comments = await markByReputation(rawComments);
 
       // Pre-render comment bodies as HTML
       try {
@@ -1940,7 +1941,7 @@ const VideoShort = () => {
                     {rootStep && (
                       <div className="chainRoot">
                         {rootStep.thumbnail && (
-                          <img className="chainRootThumb" src={fixVideoThumbnail({ thumbnail: rootStep.thumbnail })} alt="" />
+                          <img className="chainRootThumb" src={fixVideoThumbnail({ thumbnail: rootStep.thumbnail })} alt="" onError={(e) => (e.currentTarget.src = 'https://media.3speak.tv/defaults/default_thumbnail.png')} />
                         )}
                         <div className="chainRootInfo">
                           <span className="chainRootTitle">{rootStep.title || 'Original video'}</span>
@@ -2291,6 +2292,7 @@ const CommentItem = ({
   renderedBodies
 }) => {
   const [showReplies, setShowReplies] = useState(false);
+  const [collapsed, setCollapsed] = useState(false);
   const maxDepth = 3;
 
   const isReplying = activeReply === comment.permlink;
@@ -2304,6 +2306,20 @@ const CommentItem = ({
       .replace(/\n?<sup>replied to \[.*?\]\([^)]*\)<\/sup>/g, '');
   };
 
+  if (comment.isLowReputation) return null;
+
+  if (collapsed) {
+    return (
+      <div className={`commentItem ${depth > 0 ? 'nested' : ''}`} style={{ marginLeft: depth > 0 ? '12px' : '0' }}>
+        <div className="comment-collapsed-bar" onClick={() => setCollapsed(false)}>
+          <img className="comment-collapsed-avatar" src={comment.user?.avatar} alt="" />
+          <span className="comment-collapsed-name">@{comment.user?.username}</span>
+          <ChevronUp size={16} className="comment-collapsed-chevron" />
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className={`commentItem ${depth > 0 ? 'nested' : ''}`} style={{ marginLeft: depth > 0 ? '12px' : '0' }}>
       <div className="commentAvatar">
@@ -2313,6 +2329,7 @@ const CommentItem = ({
         <div className="commentMeta">
           <span className="commentUsername">{comment.user?.username}</span>
           <span className="commentTime">{comment.timeAgo}</span>
+          <span className="comment-collapse-chevron" onClick={() => setCollapsed(true)}><ChevronUp size={16} /></span>
         </div>
         <div className="commentText markdown-view" dangerouslySetInnerHTML={{ __html: getCommentHtml() }} />
         <div className="commentActions">
@@ -2425,9 +2442,6 @@ const CommentItem = ({
           </div>
         )}
       </div>
-      <button className="commentMoreBtn">
-        <MoreVertical size={16} />
-      </button>
     </div>
   );
 };

--- a/src/page/Short.scss
+++ b/src/page/Short.scss
@@ -1413,12 +1413,6 @@
       }
     }
 
-    &:hover {
-      .commentMoreBtn {
-        opacity: 1;
-      }
-    }
-
     @media (max-width: 768px) {
       padding: 0.625rem 1rem;
       gap: 0.625rem;
@@ -1583,28 +1577,6 @@
 
     &:hover {
       text-decoration: underline;
-    }
-  }
-
-  .commentMoreBtn {
-    position: absolute;
-    right: 1rem;
-    top: 0.75rem;
-    background: none;
-    border: none;
-    color: var(--text-secondary);
-    cursor: pointer;
-    opacity: 0;
-    transition: opacity 150ms;
-    padding: 0.25rem;
-    border-radius: 50%;
-
-    &:hover {
-      background-color: var(--bg-hover);
-
-      [data-theme="dark"] & {
-        background-color: #272727;
-      }
     }
   }
 

--- a/src/page/Watch.jsx
+++ b/src/page/Watch.jsx
@@ -12,6 +12,7 @@ import { Client } from '@hiveio/dhive';
 import { HIVE_API_NODES, PLAYER_URL } from '../utils/config';
 import ReactionPlayer from '../components/ReactionPlayer/ReactionPlayer';
 import { MdVideocam, MdChatBubble } from 'react-icons/md';
+import { batchGetReputations, LOW_REP_THRESHOLD } from '../utils/reputation';
 
 const hiveClient = new Client(HIVE_API_NODES);
 
@@ -175,6 +176,14 @@ function Watch() {
             isVideo: !!videoUrl,
             videoUrl,
           });
+        }
+
+        // Batch-fetch reputations and mark low-rep authors
+        const authors = markers.map(m => m.label);
+        const reputations = await batchGetReputations(authors);
+        for (const m of markers) {
+          const rep = reputations.get(m.label) ?? 25;
+          m.isLowReputation = rep < LOW_REP_THRESHOLD;
         }
 
         // Sort by timestamp: timestamped first (ascending), then no-timestamp at end
@@ -473,11 +482,77 @@ function Watch() {
     };
   }, [triggerPlay, playlistData, showPlaylist, navigateToNextVideo]);
 
-  const { data: videoData, loading: videoLoading, error: videoError } = useQuery(GET_VIDEO_DETAILS, {
+  const { data: videoData, loading: videoLoading, error: videoError, refetch: refetchVideo } = useQuery(GET_VIDEO_DETAILS, {
     variables: { author, permlink },
   });
 
-  const videoDetails = videoData?.socialPost;
+  // Hive fallback: when GraphQL doesn't have the video, fetch directly from blockchain
+  const [hiveFallback, setHiveFallback] = useState(null);
+  const [hiveFallbackLoading, setHiveFallbackLoading] = useState(false);
+
+  useEffect(() => {
+    if (videoLoading || videoData?.socialPost || !author || author === 'unknown') return;
+
+    let cancelled = false;
+    setHiveFallbackLoading(true);
+
+    (async () => {
+      try {
+        const post = await hiveClient.call('condenser_api', 'get_content', [author, permlink]);
+        if (cancelled || !post || !post.author) { setHiveFallbackLoading(false); return; }
+
+        let meta = {};
+        try { meta = JSON.parse(post.json_metadata || '{}'); } catch (_) {}
+        const videoInfo = meta.video?.info || {};
+
+        // Build play_url from video metadata
+        let play_url = videoInfo.video_v2 || videoInfo.file || null;
+        if (!play_url && videoInfo.sourceMap) {
+          const videoSource = videoInfo.sourceMap.find(s => s.type === 'video');
+          if (videoSource) play_url = videoSource.url;
+        }
+
+        // Build thumbnail from metadata
+        let thumbnail_url = null;
+        if (videoInfo.sourceMap) {
+          const thumbSource = videoInfo.sourceMap.find(s => s.type === 'thumbnail');
+          if (thumbSource) thumbnail_url = thumbSource.url;
+        }
+        if (!thumbnail_url && meta.image?.[0]) thumbnail_url = meta.image[0];
+
+        const payout = parseFloat(post.total_payout_value) + parseFloat(post.curator_payout_value) + parseFloat(post.pending_payout_value || '0');
+
+        setHiveFallback({
+          title: post.title,
+          body: post.body,
+          author: {
+            id: post.author,
+            username: post.author,
+            profile: { name: post.author, images: { avatar: `https://images.hive.blog/u/${post.author}/avatar` } },
+          },
+          stats: {
+            num_comments: post.children || 0,
+            num_votes: post.active_votes?.length || 0,
+            total_hive_reward: payout,
+          },
+          community: post.category ? { _id: post.category, title: post.category } : null,
+          created_at: post.created,
+          tags: meta.tags || [],
+          parent_permlink: post.parent_permlink,
+          spkvideo: play_url ? { play_url, thumbnail_url, duration: videoInfo.duration || 0 } : null,
+          _hiveFallback: true,
+        });
+      } catch (err) {
+        console.error('Hive fallback failed:', err);
+      } finally {
+        if (!cancelled) setHiveFallbackLoading(false);
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [videoLoading, videoData, author, permlink]);
+
+  const videoDetails = videoData?.socialPost || hiveFallback;
 
   // Record watch history when video loads (if tracking is enabled)
   useEffect(() => {
@@ -566,6 +641,7 @@ function Watch() {
         replyCount: m.replyCount,
         pct: m.pct,
         pctIsSeconds: m.pctIsSeconds,
+        isLowReputation: m.isLowReputation ?? false,
       };
       if (m.isVideo && m.videoUrl) {
         return {
@@ -632,18 +708,19 @@ function Watch() {
   }, [reactions, searchParams]);
 
   const isNetworkError = videoError && videoError.networkError;
-  const isLoading = videoLoading || (suggestionsLoading && trendingLoading && authorVideosLoading);
+  const isLoading = videoLoading || hiveFallbackLoading || (suggestionsLoading && trendingLoading && authorVideosLoading);
 
   if (isLoading) {
     return <BarLoader />;
   }
 
-  if (videoError) {
-    return <div>Error loading data. Please try again.</div>;
-  }
-
-  if (isNetworkError) {
-    return <div>network error</div>;
+  if (videoError || !videoDetails) {
+    return (
+      <div className="watch-error">
+        <p>{isNetworkError ? 'Network error. Please check your connection.' : videoError ? 'Error loading video.' : 'Video not found or failed to load.'}</p>
+        <button className="watch-error-retry" onClick={() => refetchVideo()}>Retry</button>
+      </div>
+    );
   }
 
   return (

--- a/src/page/Watch.scss
+++ b/src/page/Watch.scss
@@ -1,5 +1,33 @@
 @use "../mixins.scss" as *;
 
+.watch-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  min-height: 40vh;
+  color: var(--text-secondary, #aaa);
+  font-size: 1.1rem;
+
+  p { margin: 0; }
+}
+
+.watch-error-retry {
+  padding: 8px 20px;
+  border: 1px solid var(--border-light, #444);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-primary, #fff);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.15s ease;
+
+  &:hover {
+    background: var(--bg-tertiary, rgba(255, 255, 255, 0.06));
+  }
+}
+
 .play-container{
     padding-bottom: 20px;
     display: flex;

--- a/src/utils/fixThumbnails.js
+++ b/src/utils/fixThumbnails.js
@@ -1,5 +1,6 @@
 import { Buffer } from "buffer";
 import bs58 from "bs58";
+import fallbackImg from "../assets/image/speak.jpg";
 
 const APP_BUNNY_IPFS_CDN = "https://ipfs-3speak.b-cdn.net";
 const APP_IMAGE_CDN_DOMAIN = "https://media.3speak.tv";
@@ -11,7 +12,7 @@ export function fixVideoThumbnail(video) {
 
   // 🚧 If no thumbnail, return a fallback image
   if (!thumbnail) {
-    return "https://media.3speak.tv/defaults/default_thumbnail.png";
+    return fallbackImg;
   }
 
   // 🧠 Handle IPFS URLs

--- a/src/utils/reputation.js
+++ b/src/utils/reputation.js
@@ -7,6 +7,8 @@
 
 const REPUTATION_API = 'https://api.syncad.com/reputation-api/accounts';
 
+export const LOW_REP_THRESHOLD = 15;
+
 // Cache to avoid repeated API calls for the same user
 const repCache = new Map();
 const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
@@ -65,7 +67,7 @@ export async function isLowReputation(username) {
  * @param {string[]} usernames - Array of usernames to lookup
  * @returns {Promise<Map<string, number>>} - Map of username to reputation
  */
-async function batchGetReputations(usernames) {
+export async function batchGetReputations(usernames) {
   const uniqueUsernames = [...new Set(usernames)];
   const results = new Map();
   
@@ -167,6 +169,46 @@ export async function filterByReputation(content) {
   }
   
   return filterItems(content);
+}
+
+/**
+ * Mark content by reputation without removing anything.
+ * Adds `isLowReputation: true` to items from authors with rep < LOW_REP_THRESHOLD.
+ * Recursively marks nested children/replies.
+ *
+ * @template T
+ * @param {T[]} content - Array of comments/posts to mark
+ * @returns {Promise<T[]>} - Same array with isLowReputation flag added
+ */
+export async function markByReputation(content) {
+  if (!content || content.length === 0) return [];
+
+  const allAuthors = collectAllAuthors(content);
+  const reputations = await batchGetReputations(allAuthors);
+
+  function markItems(items) {
+    return items.map(item => {
+      const authorName = typeof item.author === 'string'
+        ? item.author
+        : item.author?.username;
+
+      const reputation = reputations.get(authorName) ?? 25;
+      const marked = { ...item, isLowReputation: reputation < LOW_REP_THRESHOLD };
+
+      const nested = item.children || item.replies;
+      if (nested && nested.length > 0) {
+        if (item.children) {
+          marked.children = markItems(nested);
+        } else if (item.replies) {
+          marked.replies = markItems(nested);
+        }
+      }
+
+      return marked;
+    });
+  }
+
+  return markItems(content);
 }
 
 /**


### PR DESCRIPTION
Watch page Hive fallback, low-rep comment hiding, scheduled date display, cleanup

- Watch: fallback to Hive blockchain (condenser_api) when GraphQL returns null, with error/retry screen for truly missing videos
- Watch: separate spkvideo into its own GET_VIDEO query (matches upstream)
- Comments: mark low-reputation accounts (rep < 15) instead of filtering, hide their comments with isLowReputation flag in CommentSection, Shorts, and ReactionPlayer
- Reputation: add markByReputation(), batchGetReputations(), hiveRepToScore() utilities with LOW_REP_THRESHOLD constant
- Scheduled videos: show publish date directly on Card3 badge and VideoCard on the Draft page (UTC → local time conversion) **needs testing**
- Card3: fix missing dayjs import, remove tooltip-only scheduled date
- Thumbnails: use local speak.jpg fallback instead of external CDN URL, add onError fallbacks to Recommended and Short thumbnail images
- Shorts: remove non-functional three-dot comment button
- ReactionPlayer: grey out low-rep items in scroller, collapse comments