### PR TITLE
add reshares, shorts watch history, playback modes, and thumbnail fixes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -174,7 +174,9 @@ function App() {
 
   const openLoginModal = () => {
     setLoginProof(Math.floor(Date.now() / 1000)); // Fresh timestamp when modal opens
-    loginInProgress.current = true;
+    if (!aioha.isLoggedIn()) {
+      loginInProgress.current = true; // Only guard during fresh login, not account switch
+    }
     setLoginModalOpen(true);
   }
 

--- a/src/components/PlaylistBar/PlaylistBar.jsx
+++ b/src/components/PlaylistBar/PlaylistBar.jsx
@@ -2,7 +2,7 @@ import { useRef, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { MdPlaylistPlay, MdSkipPrevious, MdSkipNext } from 'react-icons/md';
 import { IoClose } from 'react-icons/io5';
-import { fixVideoThumbnail } from '../../utils/fixThumbnails';
+import { fixVideoThumbnail, fallbackImg } from '../../utils/fixThumbnails';
 import './PlaylistBar.scss';
 
 function PlaylistBar({ playlist, videos, currentIndex, onClose }) {
@@ -101,7 +101,7 @@ function PlaylistBar({ playlist, videos, currentIndex, onClose }) {
               <img
                 src={fixVideoThumbnail(video)}
                 alt={video.title}
-                onError={(e) => (e.currentTarget.src = 'https://media.3speak.tv/defaults/default_thumbnail.png')}
+                onError={(e) => (e.currentTarget.src = fallbackImg)}
               />
               <span className="position">{index + 1}</span>
               {video.duration > 0 && (

--- a/src/components/ShortsPreloader.jsx
+++ b/src/components/ShortsPreloader.jsx
@@ -1,13 +1,16 @@
 import { useEffect } from 'react';
 import { preloadShorts } from '../hive-api/hiveApi';
+import { useAppStore } from '../lib/store';
 
 /**
  * Invisible component that kicks off shorts preloading as soon as the app mounts.
  * By the time the user navigates to /shorts, the first batch is usually ready.
  */
 function ShortsPreloader() {
+  const { user } = useAppStore();
+
   useEffect(() => {
-    preloadShorts(10);
+    preloadShorts(10, user);
   }, []);
 
   return null;

--- a/src/components/nav/Nav.jsx
+++ b/src/components/nav/Nav.jsx
@@ -10,7 +10,7 @@ import { useGetMyQuery } from "../../hooks/getUserDetails";
 import ThemeToggle from "./ThemeToggle";
 import { AiOutlineClose} from "react-icons/ai";
 import { IoCloudUploadSharp } from "react-icons/io5";
-import { MdOutlineDashboard, MdOutlineDynamicFeed, MdOutlineLeaderboard } from "react-icons/md";
+import { MdOutlineDashboard, MdOutlineDynamicFeed, MdOutlineLeaderboard, MdPlaylistPlay } from "react-icons/md";
 import { FaFire, FaRegSmile } from "react-icons/fa";
 import { LuNewspaper } from "react-icons/lu";
 import apple_icon from "../../assets/image/app-store.png"
@@ -114,6 +114,9 @@ function Nav({ setSideBar, toggleProfileNav, openLoginModal }) {
               </Link>
               {authenticated && <Link to="/studio" className="side-link-n" onClick={handleNav}>
                 <IoCloudUploadSharp className="icon" /> <span>Upload Video</span>
+              </Link>}
+              {authenticated && <Link to="/profile?tab=playlists" className="side-link-n" onClick={handleNav}>
+                <MdPlaylistPlay className="icon" /> <span>My Playlists</span>
               </Link>}
               <Link to="/firstupload" className="side-link-n" onClick={handleNav}>
                 <FaRegSmile className="icon"/> <span>First Uploads</span>

--- a/src/components/recommended/Recommended.jsx
+++ b/src/components/recommended/Recommended.jsx
@@ -6,7 +6,7 @@ import AuthorBadge from "../AuthorBadge/AuthorBadge";
 import ViewCount from "../ViewCount/ViewCount";
 import UpvoteCount from "../UpvoteCount/UpvoteCount";
 import PayoutAmount from "../PayoutAmount/PayoutAmount";
-import { fixVideoThumbnail } from "../../utils/fixThumbnails";
+import { fixVideoThumbnail, fallbackImg } from "../../utils/fixThumbnails";
 import AddToPlaylistButton from "../AddToPlaylistButton/AddToPlaylistButton";
 
 
@@ -30,7 +30,7 @@ function Recommended({suggestedVideos}) {
                 <img
                   src={fixVideoThumbnail(data)}
                   alt={data.title}
-                  onError={(e) => (e.currentTarget.src = 'https://media.3speak.tv/defaults/default_thumbnail.png')}
+                  onError={(e) => (e.currentTarget.src = fallbackImg)}
                 />
                 <AddToPlaylistButton
                   author={author}

--- a/src/hive-api/hiveApi.js
+++ b/src/hive-api/hiveApi.js
@@ -53,8 +53,9 @@ async function hiveRpc(method, params) {
 const _shortsByEmbedUrl = new Map(); // embed_url → short object
 const _shortsByPermlink = new Map(); // permlink → short object
 
-export async function fetchShortsList(page = 1, limit = 20) {
-  const url = `${SHORTS_API}?page=${page}&limit=${limit}&seed=${SHORTS_SEED}`;
+export async function fetchShortsList(page = 1, limit = 20, currentuser = null) {
+  let url = `${SHORTS_API}?page=${page}&limit=${limit}&seed=${SHORTS_SEED}`;
+  if (currentuser) url += `&currentuser=${encodeURIComponent(currentuser)}`;
   const response = await axios.get(url);
   console.log('Fetching shorts list data:', response.data);
 
@@ -599,7 +600,7 @@ export async function findShortByPermlink(permlink) {
 ------------------------------ */
 
 export async function fetchShortsWithDetails(page = 1, limit = 10, loggedInUser = null) {
-  const shortsList = await fetchShortsList(page, limit);
+  const shortsList = await fetchShortsList(page, limit, loggedInUser);
 
   if (!shortsList?.shorts) {
     throw new Error("Failed to fetch shorts list");
@@ -761,10 +762,10 @@ let _preloadPromise = null;
  * Preloads the first page of shorts in the background.
  * Safe to call multiple times — only runs once until consumed.
  */
-export function preloadShorts(limit = 5) {
+export function preloadShorts(limit = 5, currentuser = null) {
   if (_preloadedShorts || _preloadPromise) return; // already preloading or done
   regenerateShortsSeed();
-  _preloadPromise = fetchShortsWithDetails(1, limit)
+  _preloadPromise = fetchShortsWithDetails(1, limit, currentuser)
     .then((data) => {
       _preloadedShorts = data;
       _preloadPromise = null;

--- a/src/hooks/useUserPlaylists.js
+++ b/src/hooks/useUserPlaylists.js
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { HIVE_API_URL, PLAYLISTS_API_URL } from '../utils/config';
+import { fallbackImg } from '../utils/fixThumbnails';
 
 /**
  * Fetch thumbnail URL from Hive post metadata
@@ -91,7 +92,7 @@ export function getPlaylistThumbnail(playlist) {
   }
 
   // Fallback to default
-  return 'https://media.3speak.tv/defaults/default_thumbnail.png';
+  return fallbackImg;
 }
 
 export default useUserPlaylists;

--- a/src/page/PlaylistView.jsx
+++ b/src/page/PlaylistView.jsx
@@ -17,7 +17,7 @@ import {
 import { toast } from 'sonner';
 import './PlaylistView.scss';
 import { HIVE_API_URL, PLAYLISTS_API_URL } from '../utils/config';
-import { fixVideoThumbnail } from '../utils/fixThumbnails';
+import { fixVideoThumbnail, fallbackImg } from '../utils/fixThumbnails';
 import AuthorBadge from '../components/AuthorBadge/AuthorBadge';
 
 dayjs.extend(relativeTime);
@@ -55,7 +55,7 @@ async function fetchVideosForPlaylist(items) {
       }
 
       // Extract thumbnail
-      let thumbnail = 'https://media.3speak.tv/defaults/default_thumbnail.png';
+      let thumbnail = null;
       if (metadata.image?.[0]) {
         thumbnail = metadata.image[0];
       }
@@ -400,7 +400,7 @@ function PlaylistView() {
                     <img
                       src={fixVideoThumbnail(video)}
                       alt={video.title}
-                      onError={(e) => (e.currentTarget.src = 'https://media.3speak.tv/defaults/default_thumbnail.png')}
+                      onError={(e) => (e.currentTarget.src = fallbackImg)}
                     />
                     {video.duration > 0 && (
                       <span className="duration">

--- a/src/page/ProfilePage.jsx
+++ b/src/page/ProfilePage.jsx
@@ -51,6 +51,12 @@ function ProfilePage() {
     const tab = searchParams.get('tab');
     return tab === 'playlists' ? 'playlists' : 'video';
   });
+  // Sync tab state when URL search params change (e.g. navigating from sidebar)
+  useEffect(() => {
+    const tab = searchParams.get('tab');
+    if (tab === 'playlists') setShow('playlists');
+  }, [searchParams]);
+
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [newPlaylistName, setNewPlaylistName] = useState('');
   const [newPlaylistAccess, setNewPlaylistAccess] = useState('public');

--- a/src/page/Short.jsx
+++ b/src/page/Short.jsx
@@ -4,7 +4,6 @@ import {
   Heart,
   MessageSquare,
   Share2,
-  RefreshCw,
   Music2,
   ArrowUp,
   ArrowDown,
@@ -22,7 +21,12 @@ import {
   MessageSquareText,
   Camera,
   Volume2,
-  VolumeX
+  VolumeX,
+  Repeat,
+  ChevronsUp,
+  Square,
+  RotateCcw,
+  Repeat2
 } from 'lucide-react';
 import { GiTwoCoins } from 'react-icons/gi';
 
@@ -42,12 +46,14 @@ const HiveIcon = ({ size = 24, className = '' }) => (
 );
 import hiveApi, { regenerateShortsSeed, consumePreloadedShorts, hasShortsPreloaded, preloadShorts, fetchUserShortsWithDetails } from '../hive-api/hiveApi';
 import { useAppStore } from '../lib/store';
+import { recordWatch } from '../utils/watchHistory';
+import { recordReshare, getResharesForVideo, deleteReshare } from '../utils/reshares';
 import axios from 'axios';
 import { toast } from 'sonner';
 import CommentVoteTooltip from '../components/tooltip/CommentVoteTooltip';
 import { PLAYER_URL } from '../utils/config';
 import { useNavigate, useLocation, Link } from 'react-router-dom';
-import { fixVideoThumbnail } from '../utils/fixThumbnails';
+import { fixVideoThumbnail, fallbackImg } from '../utils/fixThumbnails';
 import AuthorBadge from '../components/AuthorBadge/AuthorBadge';
 import { markByReputation } from '../utils/reputation';
 
@@ -69,7 +75,7 @@ const getRenderer = async () => {
 
 /* ================= COMPONENT ================= */
 const VideoShort = () => {
-  const { user, authenticated } = useAppStore();
+  const { user, authenticated, watchHistoryEnabled } = useAppStore();
   const [currentIndex, setCurrentIndex] = useState(0);
   const [videos, setVideos] = useState([]);
   const [showComments, setShowComments] = useState(false);
@@ -91,6 +97,16 @@ const VideoShort = () => {
     const cookie = document.cookie.split('; ').find(c => c.startsWith('shorts_muted='));
     return cookie ? cookie.split('=')[1] !== '0' : false;
   });
+  // Playback mode: 'auto-replay' (loop), 'auto-swipe' (next near end), 'none' (stop + replay)
+  const [playbackMode, setPlaybackMode] = useState(() => {
+    const cookie = document.cookie.split('; ').find(c => c.startsWith('shorts_playback_mode='));
+    return cookie ? cookie.split('=')[1] : 'auto-replay';
+  });
+  const playbackModeRef = useRef(playbackMode);
+  const [showModeIndicator, setShowModeIndicator] = useState(false);
+  const [videoEnded, setVideoEnded] = useState(false);
+  const modeIndicatorTimeoutRef = useRef(null);
+  const autoSwipeTriggeredRef = useRef(false);
   // currentTime/duration as refs instead of state to avoid re-renders on every timeupdate (~4x/sec)
   // Progress bar is updated directly via DOM refs
   const currentTimeRef = useRef(0);
@@ -119,6 +135,11 @@ const VideoShort = () => {
 
   // Rendered comment bodies (permlink -> HTML string)
   const [renderedBodies, setRenderedBodies] = useState({});
+
+  // Reshare state
+  const [reshareCount, setReshareCount] = useState(0);
+  const [hasReshared, setHasReshared] = useState(false);
+  const [reshareUsers, setReshareUsers] = useState([]); // [{username, reshared_at}]
 
   // Reply state
   const [activeReply, setActiveReply] = useState(null);
@@ -256,6 +277,22 @@ const VideoShort = () => {
     if (muteIconTimeoutRef.current) clearTimeout(muteIconTimeoutRef.current);
     muteIconTimeoutRef.current = setTimeout(() => setShowMuteIcon(false), 600);
   }, [isMuted, sendCommand]);
+
+  // Cycle playback mode: auto-replay → auto-swipe → none → auto-replay
+  const cyclePlaybackMode = useCallback(() => {
+    const modes = ['auto-replay', 'auto-swipe', 'none'];
+    const nextMode = modes[(modes.indexOf(playbackMode) + 1) % modes.length];
+    setPlaybackMode(nextMode);
+    playbackModeRef.current = nextMode;
+    document.cookie = `shorts_playback_mode=${nextMode}; path=/; max-age=${365 * 24 * 3600}`;
+    // Reset ended state when switching modes
+    setVideoEnded(false);
+    autoSwipeTriggeredRef.current = false;
+    // Show mode indicator
+    setShowModeIndicator(true);
+    if (modeIndicatorTimeoutRef.current) clearTimeout(modeIndicatorTimeoutRef.current);
+    modeIndicatorTimeoutRef.current = setTimeout(() => setShowModeIndicator(false), 1500);
+  }, [playbackMode, videos, currentIndex]);
 
   // Pause video while vote popup is open, resume when it closes (only if was playing)
   useEffect(() => {
@@ -443,9 +480,25 @@ const VideoShort = () => {
             if (data.paused !== undefined) {
               setIsPlaying(!data.paused);
             }
-            // NOTE: We intentionally do NOT sync muted state from the player.
-            // Our React state (isMuted / isMutedRef) is the source of truth.
-            // Looping is handled natively by the player via loop=1 param.
+            // Auto-swipe: trigger swipe when near end of video
+            if (playbackModeRef.current === 'auto-swipe' && data.duration > 0 && !autoSwipeTriggeredRef.current) {
+              const remaining = data.duration - data.currentTime;
+              if (remaining <= 1.0 && remaining >= 0) {
+                autoSwipeTriggeredRef.current = true;
+                handleNext();
+              }
+            }
+            // None mode: pause video near end and show replay button
+            // Works even if iframe was loaded with loop=1 (catches it before loop restarts)
+            if (playbackModeRef.current === 'none' && data.duration > 0 && !autoSwipeTriggeredRef.current) {
+              const remaining = data.duration - data.currentTime;
+              if (remaining <= 0.3 && remaining >= 0) {
+                autoSwipeTriggeredRef.current = true; // Reuse flag to prevent multiple triggers
+                sendCommandToVideo(currentVid, 'pause');
+                setVideoEnded(true);
+                setIsPlaying(false);
+              }
+            }
           }
           break;
 
@@ -468,9 +521,10 @@ const VideoShort = () => {
           break;
 
         case '3speak-ended':
-          // Looping is handled natively by the player via loop=1 param.
-          // The player should not fire this event when loop=1 is set,
-          // but if it does, no action needed.
+          if (isFromCurrentVideo && playbackModeRef.current === 'none') {
+            setVideoEnded(true);
+            setIsPlaying(false);
+          }
           break;
 
         case '3speak-state':
@@ -507,8 +561,15 @@ const VideoShort = () => {
     // Update URL with current video (without page reload)
     updateUrlWithCurrentVideo(currentVid);
 
+    // Record watch history — use hivePermlink so WatchedView can look it up via Hive API
+    if (user && watchHistoryEnabled !== false && currentVid.author && (currentVid.hivePermlink || currentVid.permlink)) {
+      recordWatch(user, currentVid.author, currentVid.hivePermlink || currentVid.permlink, { short: true });
+    }
+
     // Reset player state
     setIsPlaying(false);
+    setVideoEnded(false);
+    autoSwipeTriggeredRef.current = false;
     currentTimeRef.current = 0;
     durationRef.current = 0;
     updateProgressBar();
@@ -648,13 +709,40 @@ const VideoShort = () => {
     })();
   }, [currentIndex, videos, user]);
 
+  // Fetch reshare data when current video changes
+  useEffect(() => {
+    const currentVid = videos[currentIndex];
+    if (!currentVid) return;
+    const author = currentVid.author;
+    const permlink = currentVid.hivePermlink || currentVid.permlink;
+    if (!author || !permlink) return;
+
+    // Reset state for new video
+    setReshareCount(0);
+    setHasReshared(false);
+    setReshareUsers([]);
+
+    (async () => {
+      try {
+        const { reshares, count } = await getResharesForVideo(author, permlink);
+        setReshareCount(count);
+        setReshareUsers(reshares);
+        if (user) {
+          setHasReshared(reshares.some(r => r.username === user));
+        }
+      } catch (err) {
+        console.warn('Failed to fetch reshares:', err);
+      }
+    })();
+  }, [currentIndex, videos, user]);
+
   // Cleanup on unmount — preload fresh shorts for the next visit
   useEffect(() => {
     return () => {
       if (playPauseTimeoutRef.current) {
         clearTimeout(playPauseTimeoutRef.current);
       }
-      preloadShorts(10);
+      preloadShorts(10, user);
     };
   }, []);
 
@@ -785,20 +873,26 @@ const VideoShort = () => {
           }
         } else {
           // Default global feed
-          // Try preloaded data first (already fetched when the app loaded)
-          if (!hasShortsPreloaded()) {
-            setLoading(true);
+          // Only use preloaded data for guests — logged-in users need
+          // currentuser filtering to exclude already-watched shorts
+          if (!user) {
+            if (!hasShortsPreloaded()) {
+              setLoading(true);
+            }
+
+            const preloaded = await consumePreloadedShorts();
+            if (preloaded?.success) {
+              const formattedVideos = formatShorts(preloaded.shorts);
+              await applySharedVideoLogic(formattedVideos, preloaded);
+              setLoading(false);
+              return;
+            }
+          } else {
+            // Discard any stale preloaded data that lacks currentuser filtering
+            consumePreloadedShorts();
           }
 
-          const preloaded = await consumePreloadedShorts();
-          if (preloaded?.success) {
-            const formattedVideos = formatShorts(preloaded.shorts);
-            await applySharedVideoLogic(formattedVideos, preloaded);
-            setLoading(false);
-            return;
-          }
-
-          // No preload available — generate a fresh seed and fetch
+          // Fetch with currentuser parameter so watched shorts are filtered out
           setLoading(true);
           regenerateShortsSeed();
           const data = await hiveApi.fetchShortsWithDetails(1, 10, user);
@@ -1311,6 +1405,28 @@ const VideoShort = () => {
           toast.error('Failed to share');
         }
       }
+    }
+  };
+
+  /* ---------- RESHARE FUNCTIONALITY ---------- */
+  const handleReshare = async () => {
+    if (!currentVideo || !user) {
+      toast.error('Log in to reshare');
+      return;
+    }
+    if (hasReshared) return;
+
+    const author = currentVideo.author;
+    const permlink = currentVideo.hivePermlink || currentVideo.permlink;
+
+    const result = await recordReshare(user, author, permlink);
+    if (result) {
+      setHasReshared(true);
+      setReshareCount(prev => prev + 1);
+      setReshareUsers(prev => [...prev, { username: user, reshared_at: Math.floor(Date.now() / 1000) }]);
+      toast.success('Reshared!');
+    } else {
+      toast.error('Failed to reshare');
     }
   };
 
@@ -1876,6 +1992,16 @@ const VideoShort = () => {
             <div className={`heartAnimation ${showHeartAnimation ? 'visible' : ''}`}>
               <Heart size={80} fill="#ff2d55" color="#ff2d55" />
             </div>
+            {/* Playback mode toggle button */}
+            <div className="playbackModeIndicator"
+              onClick={(e) => { e.stopPropagation(); cyclePlaybackMode(); }}
+              onTouchStart={(e) => e.stopPropagation()}
+              onTouchEnd={(e) => { e.stopPropagation(); e.preventDefault(); cyclePlaybackMode(); }}
+            >
+              {playbackMode === 'auto-replay' ? <Repeat size={16} /> :
+               playbackMode === 'auto-swipe' ? <ChevronsUp size={18} /> :
+               <Square size={14} />}
+            </div>
             {/* Mute/unmute toggle button */}
             <div className="muteIndicator"
               onClick={(e) => { e.stopPropagation(); toggleMute(); }}
@@ -1884,6 +2010,32 @@ const VideoShort = () => {
             >
               {isMuted ? <VolumeX size={18} /> : <Volume2 size={18} />}
             </div>
+            {/* Playback mode fading text indicator */}
+            <div className={`modeIndicatorText ${showModeIndicator ? 'visible' : ''}`}>
+              {playbackMode === 'auto-replay' ? 'Auto-Replay' :
+               playbackMode === 'auto-swipe' ? 'Auto-Swipe' :
+               'Manual'}
+            </div>
+            {/* Replay button for 'none' mode when video ends */}
+            {videoEnded && playbackMode === 'none' && (
+              <div className="replayOverlay"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setVideoEnded(false);
+                  sendCommand('seek', { time: 0 });
+                  setTimeout(() => sendCommand('play'), 100);
+                }}
+                onTouchEnd={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  setVideoEnded(false);
+                  sendCommand('seek', { time: 0 });
+                  setTimeout(() => sendCommand('play'), 100);
+                }}
+              >
+                <RotateCcw size={56} />
+              </div>
+            )}
           </div>
 
           {/* Progress bar */}
@@ -1932,7 +2084,7 @@ const VideoShort = () => {
                     {rootStep && (
                       <div className="chainRoot">
                         {rootStep.thumbnail && (
-                          <img className="chainRootThumb" src={fixVideoThumbnail({ thumbnail: rootStep.thumbnail })} alt="" onError={(e) => (e.currentTarget.src = 'https://media.3speak.tv/defaults/default_thumbnail.png')} />
+                          <img className="chainRootThumb" src={fixVideoThumbnail({ thumbnail: rootStep.thumbnail })} alt="" onError={(e) => (e.currentTarget.src = fallbackImg)} />
                         )}
                         <div className="chainRootInfo">
                           <span className="chainRootTitle">{rootStep.title || 'Original video'}</span>
@@ -2045,6 +2197,32 @@ const VideoShort = () => {
           })()}
 
           <div className="bottomOverlay">
+            {/* Reshare avatars — users who reshared (except ourselves) */}
+            {reshareUsers.filter(r => r.username !== user).length > 0 && (
+              <div className="reshareAvatars" onClick={(e) => e.stopPropagation()}>
+                {reshareUsers
+                  .filter(r => r.username !== user)
+                  .slice(0, 5)
+                  .map(r => (
+                    <div
+                      key={r.username}
+                      className="reshareAvatarWrap"
+                      title={`@${r.username}`}
+                      onClick={(e) => { e.stopPropagation(); handleProfileNavigation(r.username); }}
+                    >
+                      <img
+                        src={`https://images.hive.blog/u/${r.username}/avatar`}
+                        alt={r.username}
+                        className="reshareAvatar"
+                      />
+                      <Repeat2 size={14} className="reshareBadge" />
+                    </div>
+                  ))}
+                {reshareUsers.filter(r => r.username !== user).length > 5 && (
+                  <span className="reshareMore">+{reshareUsers.filter(r => r.username !== user).length - 5}</span>
+                )}
+              </div>
+            )}
             <div className="userRow" onClick={(e) => e.stopPropagation()}>
               <AuthorBadge
                 author={currentVideo.author}
@@ -2121,11 +2299,11 @@ const VideoShort = () => {
             <span className="actionLabel">Share</span>
           </div>
 
-          <div className="actionItem" onClick={(e) => e.stopPropagation()}>
-            <div className="actionButton">
-              <RefreshCw size={24} className="flipped" />
+          <div className="actionItem" onClick={(e) => { e.stopPropagation(); handleReshare(); }}>
+            <div className={`actionButton ${hasReshared ? 'reshared' : ''}`}>
+              <Repeat2 size={24} />
             </div>
-            <span className="actionLabel">{currentVideo.stats.remixes || 0}</span>
+            <span className="actionLabel">{reshareCount || 0}</span>
           </div>
 
           <div className="albumArt"  onClick={(e) => {
@@ -2135,6 +2313,7 @@ const VideoShort = () => {
                   }}>
             <img src={currentVideo.albumArt} alt="" />
           </div>
+
         </div>
 
         {/* NAVIGATION */}

--- a/src/page/Short.scss
+++ b/src/page/Short.scss
@@ -313,6 +313,79 @@
     }
   }
 
+  .playbackModeIndicator {
+    position: absolute;
+    top: 12px;
+    right: 56px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.2);
+    pointer-events: auto;
+    cursor: pointer;
+    z-index: 6;
+    transition: background 0.2s;
+
+    &:hover {
+      background: rgba(0, 0, 0, 0.4);
+    }
+
+    svg {
+      color: #fff;
+    }
+  }
+
+  .modeIndicatorText {
+    position: absolute;
+    top: 56px;
+    right: 12px;
+    padding: 6px 14px;
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    font-size: 13px;
+    font-weight: 500;
+    white-space: nowrap;
+    pointer-events: none;
+    z-index: 6;
+    opacity: 0;
+    transform: translateY(-4px);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+
+    &.visible {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .replayOverlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 5;
+    pointer-events: auto;
+    cursor: pointer;
+    background: rgba(0, 0, 0, 0.3);
+
+    svg {
+      color: #fff;
+      filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.5));
+      transition: transform 0.2s ease;
+    }
+
+    &:hover svg {
+      transform: scale(1.1);
+    }
+  }
+
   @keyframes heartPop {
     0% {
       opacity: 1;
@@ -432,10 +505,10 @@
       padding: 8px;
       background: rgba(0, 0, 0, 0.2);
       box-shadow: none;
-      // Position left of the mute button (top-right)
+      // Position left of playback mode toggle (top-right: back | mode | mute)
       top: 12px;
       left: auto;
-      right: 56px;
+      right: 100px;
 
       @media (max-width: 767px) {
         display: flex;
@@ -729,6 +802,7 @@
 
     .userRow,
     .subscribeBtn,
+    .reshareAvatars,
     button {
       pointer-events: auto;
     }
@@ -737,6 +811,68 @@
       padding-right: 5rem;
       padding-bottom: 1.25rem;
       z-index: 20;
+    }
+  }
+
+  .reshareAvatars {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0;
+    margin-bottom: 6px;
+
+    .reshareAvatarWrap {
+      position: relative;
+      cursor: pointer;
+      margin-right: 4px;
+      transition: transform 0.15s;
+
+      &:hover {
+        transform: scale(1.15);
+        z-index: 1;
+      }
+    }
+
+    .reshareAvatar {
+      width: 36px;
+      height: 36px;
+      border-radius: 50%;
+      border: 1.5px solid rgba(255, 255, 255, 0.4);
+      object-fit: cover;
+      display: block;
+    }
+
+    .reshareBadge {
+      position: absolute;
+      top: -3px;
+      right: -3px;
+      width: 18px;
+      height: 18px;
+      background: var(--bg-primary);
+      border-radius: 50%;
+      padding: 2px;
+      color: var(--text-primary);
+      border: 1.5px solid var(--border-light);
+    }
+
+    .reshareMore {
+      font-size: 12px;
+      color: rgba(255, 255, 255, 0.8);
+      font-weight: 500;
+      margin-left: 10px;
+      text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
+    }
+
+    @media (max-width: 768px) {
+      .reshareAvatar {
+        width: 33px;
+        height: 33px;
+      }
+
+      .reshareBadge {
+        width: 16px;
+        height: 16px;
+      }
     }
   }
 
@@ -975,6 +1111,19 @@
       }
     }
 
+    &.reshared {
+      svg {
+        color: #e53935;
+      }
+
+      @media (max-width: 768px) {
+        svg {
+          color: #e53935;
+          filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.8));
+        }
+      }
+    }
+
     &.reward {
       svg {
         color: var(--text-primary);
@@ -1038,6 +1187,7 @@
       display: none;
     }
   }
+
 
   .navigationArrows {
     position: absolute;

--- a/src/page/WatchedView.jsx
+++ b/src/page/WatchedView.jsx
@@ -10,6 +10,8 @@ import { useAppStore } from '../lib/store';
 import { getWatchHistory, deleteWatchHistoryEntry } from '../utils/watchHistory';
 import { HIVE_API_URL } from '../utils/config';
 import { toast } from 'sonner';
+import { fixVideoThumbnail, fallbackImg } from '../utils/fixThumbnails';
+import { findShortByEmbedUrl } from '../hive-api/hiveApi';
 import './WatchedView.scss';
 
 /**
@@ -42,7 +44,7 @@ async function fetchVideosFromHistory(items) {
       }
 
       // Extract thumbnail
-      let thumbnail = 'https://media.3speak.tv/defaults/default_thumbnail.png';
+      let thumbnail = null;
       if (metadata.image?.[0]) {
         thumbnail = metadata.image[0];
       }
@@ -50,13 +52,33 @@ async function fetchVideosFromHistory(items) {
       // Extract duration from video metadata
       const duration = metadata.video?.info?.duration || 0;
 
+      // Detect shorts: use API flag first, fall back to metadata heuristics
+      const isShort = item.short === true
+        || (metadata.tags || []).includes('shorts')
+        || (!!metadata.video?.platform && duration > 0 && duration <= 60);
+
+      // For shorts, look up the player/embed permlink from the shorts DB
+      let embedPermlink = null;
+      if (isShort) {
+        try {
+          const shortEntry = await findShortByEmbedUrl(post.author, post.permlink);
+          if (shortEntry) {
+            embedPermlink = shortEntry.permlink;
+          }
+        } catch (e) {
+          console.error('Failed to look up short embed permlink:', e);
+        }
+      }
+
       return {
         author: post.author,
         permlink: post.permlink,
+        embedPermlink,
         title: post.title,
         created_at: post.created,
         images: { thumbnail },
         duration,
+        isShort,
         watched_at: item.last_watched_at || item.watched_at,
         watch_count: item.watch_count || 1,
       };
@@ -76,6 +98,7 @@ function WatchedView() {
   const queryClient = useQueryClient();
   const { user: authenticatedUser, watchHistoryEnabled, setWatchHistoryEnabled } = useAppStore();
   const [deletedKeys, setDeletedKeys] = useState(new Set());
+  const [activeTab, setActiveTab] = useState('videos');
 
   // Check if viewing own watch history
   const isOwner = authenticatedUser && username?.toLowerCase() === authenticatedUser.toLowerCase();
@@ -101,7 +124,10 @@ function WatchedView() {
   });
 
   const allVideos = data?.pages.flatMap(page => page.videos) || [];
-  const videos = allVideos.filter(v => !deletedKeys.has(`${v.author}/${v.permlink}`));
+  const nonDeleted = allVideos.filter(v => !deletedKeys.has(`${v.author}/${v.permlink}`));
+  const videosList = nonDeleted.filter(v => !v.isShort);
+  const shortsList = nonDeleted.filter(v => v.isShort);
+  const videos = activeTab === 'shorts' ? shortsList : videosList;
 
   const handleDelete = useCallback(async (e, author, permlink) => {
     e.preventDefault();
@@ -161,7 +187,7 @@ function WatchedView() {
                 @{username}
               </Link>
               <span className="separator">-</span>
-              <span>{videos.length} videos</span>
+              <span>{nonDeleted.length} watched</span>
             </div>
           </div>
         </div>
@@ -183,25 +209,45 @@ function WatchedView() {
         </div>
       </div>
 
+      {/* Tabs */}
+      <div className="watched-tabs">
+        <button
+          className={`tab-btn ${activeTab === 'videos' ? 'active' : ''}`}
+          onClick={() => setActiveTab('videos')}
+        >
+          Videos ({videosList.length})
+        </button>
+        <button
+          className={`tab-btn ${activeTab === 'shorts' ? 'active' : ''}`}
+          onClick={() => setActiveTab('shorts')}
+        >
+          Shorts ({shortsList.length})
+        </button>
+      </div>
+
       {/* Videos List */}
       <div className="watched-videos">
         {videos.length === 0 ? (
           <div className="empty-wrap">
             <img src={icon} alt="" />
-            <span>No watched videos yet</span>
+            <span>No watched {activeTab === 'shorts' ? 'shorts' : 'videos'} yet</span>
           </div>
         ) : (
           <div className="video-list">
             {videos.map((video, index) => (
               <Link
                 key={`${video.author}-${video.permlink}`}
-                to={`/watch?v=${video.author}/${video.permlink}`}
+                to={video.isShort
+                  ? `/shorts?v=${video.author}/${video.embedPermlink || video.permlink}`
+                  : `/watch?v=${video.author}/${video.permlink}`}
                 className="video-item"
               >
                 <span className="video-position">{index + 1}</span>
                 <div className="video-thumbnail">
-                  <img src={video.images?.thumbnail} alt={video.title} />
-                  {video.duration > 0 && (
+                  <img src={fixVideoThumbnail(video)} alt={video.title} onError={(e) => (e.currentTarget.src = fallbackImg)} />
+                  {video.isShort ? (
+                    <span className="short-badge">Short</span>
+                  ) : video.duration > 0 && (
                     <span className="duration">
                       {Math.floor(video.duration / 60)}:{String(Math.floor(video.duration % 60)).padStart(2, '0')}
                     </span>

--- a/src/page/WatchedView.scss
+++ b/src/page/WatchedView.scss
@@ -139,6 +139,36 @@
     }
   }
 
+  // Tabs
+  .watched-tabs {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 16px;
+
+    .tab-btn {
+      padding: 8px 20px;
+      border: 1px solid var(--border-light);
+      background: transparent;
+      color: var(--text-secondary);
+      border-radius: 20px;
+      font-size: 13px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.2s ease;
+
+      &:hover {
+        background: var(--card-bg-hover, rgba(255, 255, 255, 0.05));
+        color: var(--text-primary);
+      }
+
+      &.active {
+        background: var(--accent-primary, #667eea);
+        border-color: var(--accent-primary, #667eea);
+        color: #fff;
+      }
+    }
+  }
+
   // Video List
   .watched-videos {
     .video-list {
@@ -205,6 +235,20 @@
           color: #000;
           font-size: 11px;
           border-radius: 4px;
+        }
+
+        .short-badge {
+          position: absolute;
+          bottom: 6px;
+          right: 6px;
+          padding: 2px 6px;
+          background: var(--accent-primary, #e31337);
+          color: #fff;
+          font-size: 10px;
+          font-weight: 600;
+          border-radius: 4px;
+          text-transform: uppercase;
+          letter-spacing: 0.5px;
         }
       }
 

--- a/src/utils/fixThumbnails.js
+++ b/src/utils/fixThumbnails.js
@@ -5,12 +5,11 @@ import fallbackImg from "../assets/image/speak.jpg";
 const APP_BUNNY_IPFS_CDN = "https://ipfs-3speak.b-cdn.net";
 const APP_IMAGE_CDN_DOMAIN = "https://media.3speak.tv";
 
+export { fallbackImg };
 
 export function fixVideoThumbnail(video) {
-  const thumbnail = video?.images?.thumbnail || video?.thumbUrl || video?.spkvideo?.thumbnail_url || video?.thumbnail;
+  const thumbnail = video?.images?.thumbnail || video?.thumbUrl || video?.spkvideo?.thumbnail_url || video?.thumbnailUrl || video?.thumbnail;
 
-
-  // 🚧 If no thumbnail, return a fallback image
   if (!thumbnail) {
     return fallbackImg;
   }

--- a/src/utils/reshares.js
+++ b/src/utils/reshares.js
@@ -1,0 +1,92 @@
+import axios from 'axios';
+import { PLAYLISTS_API_URL } from './config';
+
+/**
+ * Record a reshare (idempotent — duplicates are ignored)
+ */
+export async function recordReshare(username, author, permlink) {
+  if (!username || !author || !permlink) return null;
+  try {
+    const response = await axios.put(`${PLAYLISTS_API_URL}/reshares`, {
+      username,
+      author,
+      permlink,
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Failed to record reshare:', error);
+    return null;
+  }
+}
+
+/**
+ * Get all reshares for a video
+ * @returns {Promise<{reshares: Array<{username: string, reshared_at: number}>, count: number}>}
+ */
+export async function getResharesForVideo(author, permlink, limit = 50, offset = 0) {
+  if (!author || !permlink) return { reshares: [], count: 0 };
+  try {
+    const response = await axios.get(
+      `${PLAYLISTS_API_URL}/reshares/${author}/${permlink}?limit=${limit}&offset=${offset}`
+    );
+    return {
+      reshares: response.data.reshares || [],
+      count: response.data.count || 0,
+    };
+  } catch (error) {
+    console.error('Failed to get reshares:', error);
+    return { reshares: [], count: 0 };
+  }
+}
+
+/**
+ * Get reshare count for a video
+ */
+export async function getReshareCount(author, permlink) {
+  if (!author || !permlink) return 0;
+  try {
+    const response = await axios.get(
+      `${PLAYLISTS_API_URL}/reshares/${author}/${permlink}/count`
+    );
+    return response.data.count || 0;
+  } catch (error) {
+    console.error('Failed to get reshare count:', error);
+    return 0;
+  }
+}
+
+/**
+ * Check if a user has reshared a video
+ * @returns {Promise<{reshared: boolean, reshared_at?: number}>}
+ */
+export async function hasUserReshared(username, author, permlink) {
+  if (!username || !author || !permlink) return { reshared: false };
+  try {
+    const response = await axios.get(
+      `${PLAYLISTS_API_URL}/reshares/${username}/${author}/${permlink}`
+    );
+    return {
+      reshared: response.data.reshared || false,
+      reshared_at: response.data.reshared_at,
+    };
+  } catch (error) {
+    console.error('Failed to check reshare:', error);
+    return { reshared: false };
+  }
+}
+
+/**
+ * Delete a reshare
+ */
+export async function deleteReshare(username, author, permlink) {
+  if (!username || !author || !permlink) return false;
+  try {
+    await axios.delete(
+      `${PLAYLISTS_API_URL}/reshares/${username}/${author}/${permlink}`
+    );
+    return true;
+  } catch (error) {
+    console.error('Failed to delete reshare:', error);
+    return false;
+  }
+}

--- a/src/utils/watchHistory.js
+++ b/src/utils/watchHistory.js
@@ -6,18 +6,18 @@ import { PLAYLISTS_API_URL } from './config';
  * @param {string} username - The user who watched
  * @param {string} author - Video author
  * @param {string} permlink - Video permlink
+ * @param {object} [options] - Optional fields
+ * @param {boolean} [options.short] - Whether this is a short
  */
-export async function recordWatch(username, author, permlink) {
+export async function recordWatch(username, author, permlink, options = {}) {
   if (!username || !author || !permlink) {
     return null;
   }
 
   try {
-    const response = await axios.put(`${PLAYLISTS_API_URL}/watch-history`, {
-      username,
-      author,
-      permlink,
-    });
+    const body = { username, author, permlink };
+    if (options.short != null) body.short = options.short;
+    const response = await axios.put(`${PLAYLISTS_API_URL}/watch-history`, body);
     return response.data;
   } catch (error) {
     console.error('Failed to record watch:', error);


### PR DESCRIPTION
- Add reshare feature for shorts: reshare button (red when active, one-time),
  reshare count, and reshare user avatars with badge above author row
- Record shorts watch history with correct Hive permlink and short flag
- Add currentuser param to shortssorted API to filter already-watched shorts;
  skip preloaded data for logged-in users to ensure filtering applies
- Add Videos/Shorts tabs to watch history with proper shorts detection via
  API short flag; resolve embed permlinks for shorts navigation
- Add playback mode toggle (auto-replay / auto-swipe / manual) with overlay
  replay button and persistent cookie preference
- Fix broken fallback thumbnail URL across all components (use local asset)
- Add thumbnailUrl to fixVideoThumbnail extraction chain and export fallbackImg
- Add My Playlists link to mobile nav menu
- Sync profile page tab state when navigating via URL params
- Fix account switch login guard (only block during fresh login)
- Remove old remixes button (RefreshCw) from shorts sidebar
- New reshares.js utility with full CRUD (record, list, count, check, delete)