### PR TITLE
Fix/profile rendering optimization

### DIFF
--- a/src/components/Cards/Card3.jsx
+++ b/src/components/Cards/Card3.jsx
@@ -12,18 +12,18 @@ import TimeAgo from "../TimeAgo/TimeAgo";
 import { Link, useNavigate } from "react-router-dom";
 import PropTypes from "prop-types";
 import "./Cards.scss";
-import { useState, useMemo } from "react";
+import { useState, useMemo, memo } from "react";
 import img from "../../assets/image/speak.jpg";
 import { fixVideoThumbnail } from "../../utils/fixThumbnails";
 import AuthorBadge from "../AuthorBadge/AuthorBadge";
 import ProfileModal from "../modal/ProfileModal";
-import useViewCounts from "../../hooks/useViewCounts";
 
 
-function Card3({ videos = [], loading = false, error = null, getContentForVideo = null, isWatched = null, linkPrefix = '/watch', linkQuery = '' }) {
+function Card3({ videos = [], loading = false, error = null, getContentForVideo = null, isWatched = null, getViewCount = null, linkPrefix = '/watch', linkQuery = '' }) {
+  console.log('🔄 [Card3] Component re-rendered with', videos.length, 'videos');
+  
   const navigate = useNavigate();
   const [modalUser, setModalUser] = useState(null);
-  const { getViewCount } = useViewCounts(videos);
   const formatViewCount = (views) => {
     if (views === null || views === undefined) return null;
     if (views >= 1000000) return `${(views / 1000000).toFixed(1)}M`;
@@ -48,8 +48,6 @@ function Card3({ videos = [], loading = false, error = null, getContentForVideo 
         const postKey = `${video.author?.username || video.author || video.owner}/${
           video.permlink
         }`;
-        
-        console.log('🟠 [Card3] Rendering video card:', { index, postKey });
 
         return (
           <Link
@@ -57,8 +55,7 @@ function Card3({ videos = [], loading = false, error = null, getContentForVideo 
               video.permlink
             }${linkQuery}`}
             className="card"
-            // key={postKey}
-            key={`${postKey}-${index}`}
+            key={postKey}
           >
             {/* Thumbnail */}
             <div className="img-wrap">
@@ -142,7 +139,7 @@ function Card3({ videos = [], loading = false, error = null, getContentForVideo 
                 noLink
                 compact
               />
-              {getViewCount(video.author?.username || video.author || video.owner, video.permlink) !== null && (
+              {getViewCount && getViewCount(video.author?.username || video.author || video.owner, video.permlink) !== null && (
                 <ViewCount
                   views={getViewCount(video.author?.username || video.author || video.owner, video.permlink)}
                   watched={isWatched?.(video.author?.username || video.author || video.owner, video.permlink) === true}
@@ -191,7 +188,8 @@ Card3.propTypes = {
   error: PropTypes.string,
   getContentForVideo: PropTypes.func,
   isWatched: PropTypes.func,
+  getViewCount: PropTypes.func,
   linkPrefix: PropTypes.string,
 };
 
-export default Card3;
+export default memo(Card3);

--- a/src/components/Cards/Card3.jsx
+++ b/src/components/Cards/Card3.jsx
@@ -12,7 +12,7 @@ import TimeAgo from "../TimeAgo/TimeAgo";
 import { Link, useNavigate } from "react-router-dom";
 import PropTypes from "prop-types";
 import "./Cards.scss";
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import img from "../../assets/image/speak.jpg";
 import { fixVideoThumbnail } from "../../utils/fixThumbnails";
 import AuthorBadge from "../AuthorBadge/AuthorBadge";
@@ -31,18 +31,25 @@ function Card3({ videos = [], loading = false, error = null, getContentForVideo 
     return views.toLocaleString();
   };
 
-
-
+  // Memoize video processing to prevent re-computing thumbnails on every render
+  const processedVideos = useMemo(() => {
+    return videos.map(video => ({
+      ...video,
+      _processedThumbnail: fixVideoThumbnail(video)
+    }));
+  }, [videos]);
 
   if (loading && videos.length === 0) return <div>Loading...</div>;
   if (error) return <div>Error: {error}</div>;
 
   return (
     <div className="card-container">
-      {videos.map((video, index) => {
+      {processedVideos.map((video, index) => {
         const postKey = `${video.author?.username || video.author || video.owner}/${
           video.permlink
         }`;
+        
+        console.log('🟠 [Card3] Rendering video card:', { index, postKey });
 
         return (
           <Link
@@ -56,9 +63,7 @@ function Card3({ videos = [], loading = false, error = null, getContentForVideo 
             {/* Thumbnail */}
             <div className="img-wrap">
               <img
-                // src={video.images?.thumbnail}
-                src={fixVideoThumbnail(video)}
-                // src={video.images?.thumbnail || img}
+                src={video._processedThumbnail}
                 alt="thumbnail"
                 onError={(e) => (e.currentTarget.src = img)}
                 loading="lazy"

--- a/src/components/Userprofilepage/UserProfilePage.jsx
+++ b/src/components/Userprofilepage/UserProfilePage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState, useCallback } from 'react'
 import { getFollowers } from '../../hive-api/api';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import icon from "../../../public/images/stack.png"
@@ -8,7 +8,7 @@ import { Quantum } from 'ldrs/react'
 import 'ldrs/react/Quantum.css'
 import { useInfiniteQuery, useQueryClient as useReactQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
-import { FEED_URL } from '../../utils/config';
+import { VIEWS_URL } from '../../utils/config';
 import Card3 from '../Cards/Card3';
 import { IoMdShare, IoMdAdd } from 'react-icons/io';
 import { IoLogoRss } from 'react-icons/io5';
@@ -21,6 +21,7 @@ import { toast } from 'sonner';
 import { useContentBatch } from '../../hooks/useContentBatch';
 import { useWatchHistory } from '../../hooks/useWatchHistory';
 import { fetchUserShortsWithDetails } from '../../hive-api/hiveApi';
+import useViewCounts from '../../hooks/useViewCounts';
 
 
 
@@ -86,24 +87,19 @@ function UserProfilePage() {
 
       // GET_TOTAL_COUNT_OF_FOLLOWING
       // const { username } = useParams();
-      useEffect(()=>{
-        getFollowersCount(user)
-      },[])
+      useEffect(() => {
+        if (user) {
+          getFollowersCount(user)
+        }
+      }, [user])
 
- const LIMIT = 100;
+ const LIMIT = 20;
 
 const fetchVideos = async ({ pageParam = 0 }) => {
-  let url;
-    if (pageParam === 0) {
-    // first 100 videos
-    url = `${FEED_URL}/apiv2/feeds/@${user}`;
-  } else {
-    // next batches
-    url = `${FEED_URL}/apiv2/feeds/@${user}/more?skip=${pageParam}`;
-  }
+  const url = `${VIEWS_URL}/api/my-videos?username=${user}&limit=${LIMIT}&offset=${pageParam}&status=published&sort=newest`;
 
   const res = await axios.get(url);
-  return res.data;
+  return res.data?.data?.videos || [];
 };
 
       
@@ -117,11 +113,11 @@ const {
   queryKey: ["UserProfilePage", user],
   queryFn: fetchVideos,
   getNextPageParam: (lastPage, allPages) => {
-    // If the last page has items, calculate next skip value
-    if (lastPage.length > 0) {
-      return allPages.flat().length; // next skip = total items loaded so far
+    // If the last page has LIMIT items, there might be more
+    if (lastPage.length === LIMIT) {
+      return allPages.flat().length; // next offset = total items loaded so far
     }
-    return undefined; // stop if no more data
+    return undefined; // stop if last page had fewer than LIMIT items
   },
 });
 
@@ -150,20 +146,22 @@ const {
             });
 
             // Flatten shorts pages and map to Card3 format
-            const shortsVideos = (shortsData?.pages || []).flatMap(page =>
-              (page?.shorts || []).map(s => ({
-                author: s.author,
-                permlink: s.permlink,
-                title: (s.caption || s.title || '').slice(0, 80),
-                images: { thumbnail: s.thumbnailUrl },
-                duration: 0,
-                stats: {
-                  total_hive_reward: parseFloat(s.stats?.payout) || 0,
-                  num_votes: s.stats?.likes || 0,
-                },
-                created_at: s.createdAt,
-              }))
-            );
+            const shortsVideos = useMemo(() => (
+              (shortsData?.pages || []).flatMap(page =>
+                (page?.shorts || []).map(s => ({
+                  author: s.author,
+                  permlink: s.permlink,
+                  title: (s.caption || s.title || '').slice(0, 80),
+                  images: { thumbnail: s.thumbnailUrl },
+                  duration: 0,
+                  stats: {
+                    total_hive_reward: parseFloat(s.stats?.payout) || 0,
+                    num_votes: s.stats?.likes || 0,
+                  },
+                  created_at: s.createdAt,
+                }))
+              )
+            ), [shortsData?.pages]);
 
         useEffect(() => {
               const handleScroll = () => {
@@ -184,13 +182,16 @@ const {
             }, [show, isFetchingNextPage, hasNextPage, fetchNextPage, isFetchingNextShortsPage, hasNextShortsPage, fetchNextShortsPage]);
 
             // Flatten all pages into a single array
-            const videos = data?.pages.flat() || [];
+            const videos = useMemo(() => data?.pages.flat() || [], [data?.pages]);
 
             // Batch fetch content data
             const { getContentForVideo } = useContentBatch(videos);
 
             // Batch check watch history
             const { isWatched } = useWatchHistory(videos);
+            
+            // Batch fetch view counts
+            const { getViewCount } = useViewCounts(videos);
 
       // const { loading, error, data } = useQuery(GET_SOCIAL_FEED_BY_CREATOR, {
       //   variables: { id: user },
@@ -204,7 +205,7 @@ const {
           const follower = await getFollowers(user)
         setFollower(follower)
         } catch (err){
-          console(err)
+          console.error(err)
         }
       }
 
@@ -290,7 +291,7 @@ const {
         <span>No Video Data Available</span>
       </div>
     ) : (
-      <Card3 videos={videos} loading={isFetchingNextPage} getContentForVideo={getContentForVideo} isWatched={isWatched} />
+      <Card3 videos={videos} loading={isFetchingNextPage} getContentForVideo={getContentForVideo} isWatched={isWatched} getViewCount={getViewCount} />
     )
   ) : show === "shorts" ? (
     isShortsLoading ? (
@@ -301,7 +302,7 @@ const {
         <span>No Shorts Available</span>
       </div>
     ) : (
-      <Card3 videos={shortsVideos} loading={isFetchingNextShortsPage} linkPrefix="/shorts" linkQuery={`&user=${user}`} />
+      <Card3 videos={shortsVideos} loading={isFetchingNextShortsPage} linkPrefix="/shorts" linkQuery={`&user=${user}`} getViewCount={getViewCount} />
     )
   ) : show === "playlists" ? (
     <>

--- a/src/hooks/useContentBatch.js
+++ b/src/hooks/useContentBatch.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { batchGetContent } from '../utils/hiveUtils';
 import { useAppStore } from '../lib/store';
 
@@ -9,7 +9,8 @@ import { useAppStore } from '../lib/store';
  */
 export function useContentBatch(videos) {
   const { user } = useAppStore();
-  const [contentData, setContentData] = useState(new Map());
+  const contentDataRef = useRef(new Map());
+  const [version, setVersion] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
@@ -44,14 +45,13 @@ export function useContentBatch(videos) {
           fetchedRef.current.add(`${post.author}/${post.permlink}`);
         }
 
-        // Merge with existing data
-        setContentData((prev) => {
-          const merged = new Map(prev);
-          for (const [key, value] of results) {
-            merged.set(key, value);
-          }
-          return merged;
-        });
+        // Merge with existing data in ref
+        for (const [key, value] of results) {
+          contentDataRef.current.set(key, value);
+        }
+        
+        // Trigger re-render without changing Map reference
+        setVersion(v => v + 1);
       } catch (err) {
         console.error('useContentBatch error:', err);
         setError(err);
@@ -69,13 +69,13 @@ export function useContentBatch(videos) {
    * @param {string} permlink
    * @returns {Object|null} - { payout, voters, isVoted } or null if not loaded
    */
-  const getContentForVideo = (author, permlink) => {
+  const getContentForVideo = useCallback((author, permlink) => {
     const key = `${author}/${permlink}`;
-    return contentData.get(key) || null;
-  };
+    return contentDataRef.current.get(key) || null;
+  }, []); // Empty deps - always stable!
 
   return {
-    contentData,
+    contentData: contentDataRef.current,
     getContentForVideo,
     loading,
     error,

--- a/src/hooks/useViewCounts.js
+++ b/src/hooks/useViewCounts.js
@@ -10,7 +10,8 @@ const BATCH_SIZE = 50;
  * @returns {Object} - { viewCounts, loading, getViewCount }
  */
 const useViewCounts = (videos) => {
-  const [viewCounts, setViewCounts] = useState({});
+  const viewCountsRef = useRef({});
+  const [version, setVersion] = useState(0);
   const [loading, setLoading] = useState(false);
   const fetchedRef = useRef(new Set());
 
@@ -56,12 +57,15 @@ const useViewCounts = (videos) => {
           );
 
           if (response.data.success) {
-            setViewCounts((prev) => ({ ...prev, ...response.data.data }));
+            // Update ref directly
+            Object.assign(viewCountsRef.current, response.data.data);
             // Mark as fetched
             batch.forEach((v) => {
               const author = getAuthor(v);
               fetchedRef.current.add(`${author}/${v.permlink}`);
             });
+            // Trigger re-render
+            setVersion(v => v + 1);
           }
         } catch (err) {
           console.error('Failed to fetch view counts:', err.response?.data || err.message);
@@ -76,12 +80,12 @@ const useViewCounts = (videos) => {
 
   const getViewCount = useCallback(
     (author, permlink) => {
-      return viewCounts[`${author}/${permlink}`] ?? null;
+      return viewCountsRef.current[`${author}/${permlink}`] ?? null;
     },
-    [viewCounts]
+    []
   );
 
-  return { viewCounts, loading, getViewCount };
+  return { viewCounts: viewCountsRef.current, loading, getViewCount };
 };
 
 export default useViewCounts;

--- a/src/hooks/useWatchHistory.js
+++ b/src/hooks/useWatchHistory.js
@@ -10,7 +10,8 @@ import { WATCH_HISTORY_THRESHOLD_DAYS } from '../utils/config';
  */
 export function useWatchHistory(videos) {
   const { user } = useAppStore();
-  const [watchedData, setWatchedData] = useState(new Map());
+  const watchedDataRef = useRef(new Map());
+  const [version, setVersion] = useState(0);
   const [loading, setLoading] = useState(false);
   const fetchedRef = useRef(new Set());
 
@@ -58,14 +59,13 @@ export function useWatchHistory(videos) {
       try {
         const results = await batchCheckWatched(user, postsToFetch);
 
-        // Merge new results with existing data
-        setWatchedData(prev => {
-          const merged = new Map(prev);
-          results.forEach((value, key) => {
-            merged.set(key, value);
-          });
-          return merged;
+        // Merge new results with existing data in ref
+        results.forEach((value, key) => {
+          watchedDataRef.current.set(key, value);
         });
+        
+        // Trigger re-render without changing Map reference
+        setVersion(v => v + 1);
       } catch (error) {
         console.error('Error fetching watch history:', error);
       } finally {
@@ -80,17 +80,17 @@ export function useWatchHistory(videos) {
   const isWatched = useCallback((author, permlink) => {
     if (!user) return null; // null = unknown (not logged in)
     const key = `${author}/${permlink}`;
-    return watchedData.has(key);
-  }, [watchedData, user]);
+    return watchedDataRef.current.has(key);
+  }, [user]);
 
   // Helper function to get watch data for a video
   const getWatchData = useCallback((author, permlink) => {
     const key = `${author}/${permlink}`;
-    return watchedData.get(key) || null;
-  }, [watchedData]);
+    return watchedDataRef.current.get(key) || null;
+  }, []);
 
   return {
-    watchedData,
+    watchedData: watchedDataRef.current,
     isWatched,
     getWatchData,
     loading,

--- a/src/utils/fixThumbnails.js
+++ b/src/utils/fixThumbnails.js
@@ -8,20 +8,10 @@ const APP_IMAGE_CDN_DOMAIN = "https://media.3speak.tv";
 export { fallbackImg };
 
 export function fixVideoThumbnail(video) {
-  console.log('🟡 [fixVideoThumbnail] Processing video:', video);
   const thumbnail = video?.images?.thumbnail || video?.thumbUrl || video?.spkvideo?.thumbnail_url || video?.thumbnailUrl || video?.thumbnail;
-  console.log('🟡 [fixVideoThumbnail] Extracted thumbnail:', thumbnail);
-  console.log('🟡 [fixVideoThumbnail] Available thumbnail fields:', {
-    'images.thumbnail': video?.images?.thumbnail,
-    'thumbUrl': video?.thumbUrl,
-    'spkvideo.thumbnail_url': video?.spkvideo?.thumbnail_url,
-    'thumbnailUrl': video?.thumbnailUrl,
-    'thumbnail': video?.thumbnail
-  });
 
   // Validate thumbnail exists and is not just whitespace
   if (!thumbnail || typeof thumbnail !== 'string' || thumbnail.trim() === '') {
-    console.log('🔴 [fixVideoThumbnail] No valid thumbnail found, using fallback');
     return fallbackImg;
   }
 
@@ -29,7 +19,6 @@ export function fixVideoThumbnail(video) {
 
   // 🧠 Handle malformed double-embedded URLs (IPFS path containing full HTTP URLs)
   if (cleanThumbnail.includes('/ipfs/http')) {
-    console.log('🔴 [fixVideoThumbnail] Detected double-embedded URL, extracting inner URL:', cleanThumbnail);
     // Extract the actual HTTP URL from the malformed path
     const match = cleanThumbnail.match(/\/ipfs\/(https?:\/\/.+)/);
     if (match && match[1]) {
@@ -42,37 +31,28 @@ export function fixVideoThumbnail(video) {
     const ipfsHash = cleanThumbnail.replace("ipfs://", "").trim();
     // Validate IPFS hash exists
     if (!ipfsHash || ipfsHash === '') {
-      console.log('🔴 [fixVideoThumbnail] Empty IPFS hash, using fallback');
       return fallbackImg;
     }
-    const result = `${APP_BUNNY_IPFS_CDN}/ipfs/${ipfsHash}`;
-    console.log('🟣 [fixVideoThumbnail] IPFS URL detected, converted to:', result);
-    return result;
+    return `${APP_BUNNY_IPFS_CDN}/ipfs/${ipfsHash}`;
   }
 
   // 🧠 If already using images.hive.blog, return as-is (avoid double-proxying)
   if (cleanThumbnail.includes("images.hive.blog")) {
-    console.log('🟣 [fixVideoThumbnail] Already proxied, returning as-is:', cleanThumbnail);
     return cleanThumbnail;
   }
 
   // 🧠 Handle media.3speak.tv URLs with Hive proxy
   if (cleanThumbnail.includes(APP_IMAGE_CDN_DOMAIN)) {
     const encoded = bs58.encode(Buffer.from(cleanThumbnail));
-    const result = `https://images.hive.blog/p/${encoded}?format=jpeg&mode=cover&width=340&height=191`;
-    console.log('🟣 [fixVideoThumbnail] media.3speak.tv URL, proxying through Hive:', result);
-    return result;
+    return `https://images.hive.blog/p/${encoded}?format=jpeg&mode=cover&width=340&height=191`;
   }
 
   // 🧠 Handle regular HTTP URLs with Hive proxy
   if (cleanThumbnail.startsWith("http")) {
     const encoded = bs58.encode(Buffer.from(cleanThumbnail));
-    const result = `https://images.hive.blog/p/${encoded}?format=jpeg&mode=cover&width=340&height=191`;
-    console.log('🟣 [fixVideoThumbnail] HTTP URL, proxying through Hive:', result);
-    return result;
+    return `https://images.hive.blog/p/${encoded}?format=jpeg&mode=cover&width=340&height=191`;
   }
 
   // Return as-is for any other format
-  console.log('🟣 [fixVideoThumbnail] No special handling, returning as-is:', cleanThumbnail);
   return cleanThumbnail;
 }

--- a/src/utils/fixThumbnails.js
+++ b/src/utils/fixThumbnails.js
@@ -8,30 +8,71 @@ const APP_IMAGE_CDN_DOMAIN = "https://media.3speak.tv";
 export { fallbackImg };
 
 export function fixVideoThumbnail(video) {
+  console.log('🟡 [fixVideoThumbnail] Processing video:', video);
   const thumbnail = video?.images?.thumbnail || video?.thumbUrl || video?.spkvideo?.thumbnail_url || video?.thumbnailUrl || video?.thumbnail;
+  console.log('🟡 [fixVideoThumbnail] Extracted thumbnail:', thumbnail);
+  console.log('🟡 [fixVideoThumbnail] Available thumbnail fields:', {
+    'images.thumbnail': video?.images?.thumbnail,
+    'thumbUrl': video?.thumbUrl,
+    'spkvideo.thumbnail_url': video?.spkvideo?.thumbnail_url,
+    'thumbnailUrl': video?.thumbnailUrl,
+    'thumbnail': video?.thumbnail
+  });
 
-  if (!thumbnail) {
+  // Validate thumbnail exists and is not just whitespace
+  if (!thumbnail || typeof thumbnail !== 'string' || thumbnail.trim() === '') {
+    console.log('🔴 [fixVideoThumbnail] No valid thumbnail found, using fallback');
     return fallbackImg;
   }
 
+  const cleanThumbnail = thumbnail.trim();
+
+  // 🧠 Handle malformed double-embedded URLs (IPFS path containing full HTTP URLs)
+  if (cleanThumbnail.includes('/ipfs/http')) {
+    console.log('🔴 [fixVideoThumbnail] Detected double-embedded URL, extracting inner URL:', cleanThumbnail);
+    // Extract the actual HTTP URL from the malformed path
+    const match = cleanThumbnail.match(/\/ipfs\/(https?:\/\/.+)/);
+    if (match && match[1]) {
+      return match[1]; // Return the inner URL directly
+    }
+  }
+
   // 🧠 Handle IPFS URLs
-  if (thumbnail.includes("ipfs://")) {
-    const ipfsHash = thumbnail.replace("ipfs://", "");
-    return `${APP_BUNNY_IPFS_CDN}/ipfs/${ipfsHash}`;
+  if (cleanThumbnail.includes("ipfs://")) {
+    const ipfsHash = cleanThumbnail.replace("ipfs://", "").trim();
+    // Validate IPFS hash exists
+    if (!ipfsHash || ipfsHash === '') {
+      console.log('🔴 [fixVideoThumbnail] Empty IPFS hash, using fallback');
+      return fallbackImg;
+    }
+    const result = `${APP_BUNNY_IPFS_CDN}/ipfs/${ipfsHash}`;
+    console.log('🟣 [fixVideoThumbnail] IPFS URL detected, converted to:', result);
+    return result;
+  }
+
+  // 🧠 If already using images.hive.blog, return as-is (avoid double-proxying)
+  if (cleanThumbnail.includes("images.hive.blog")) {
+    console.log('🟣 [fixVideoThumbnail] Already proxied, returning as-is:', cleanThumbnail);
+    return cleanThumbnail;
   }
 
   // 🧠 Handle media.3speak.tv URLs with Hive proxy
-  if (thumbnail.includes(APP_IMAGE_CDN_DOMAIN)) {
-    const encoded = bs58.encode(Buffer.from(thumbnail));
-    return `https://images.hive.blog/p/${encoded}?format=jpeg&mode=cover&width=340&height=191`;
+  if (cleanThumbnail.includes(APP_IMAGE_CDN_DOMAIN)) {
+    const encoded = bs58.encode(Buffer.from(cleanThumbnail));
+    const result = `https://images.hive.blog/p/${encoded}?format=jpeg&mode=cover&width=340&height=191`;
+    console.log('🟣 [fixVideoThumbnail] media.3speak.tv URL, proxying through Hive:', result);
+    return result;
   }
 
   // 🧠 Handle regular HTTP URLs with Hive proxy
-  if (thumbnail.startsWith("http")) {
-    const encoded = bs58.encode(Buffer.from(thumbnail));
-    return `https://images.hive.blog/p/${encoded}?format=jpeg&mode=cover&width=340&height=191`;
+  if (cleanThumbnail.startsWith("http")) {
+    const encoded = bs58.encode(Buffer.from(cleanThumbnail));
+    const result = `https://images.hive.blog/p/${encoded}?format=jpeg&mode=cover&width=340&height=191`;
+    console.log('🟣 [fixVideoThumbnail] HTTP URL, proxying through Hive:', result);
+    return result;
   }
 
   // Return as-is for any other format
-  return thumbnail;
+  console.log('🟣 [fixVideoThumbnail] No special handling, returning as-is:', cleanThumbnail);
+  return cleanThumbnail;
 }


### PR DESCRIPTION
Fixes critical performance issue where profile pages caused infinite re-renders, crashing browsers due to memory exhaustion.

### Changes:
- Optimized thumbnail processing with validation and memoization (now regular image urls work, check user @coolmole for examples)
- Refactored data hooks to use refs for stable callbacks
- Moved `useViewCounts` to parent component
- Wrapped Card3 with React.memo
- Moved from Legacy Profile Feed to Pancreas API (views.3speak.tv)

### Impact:
Reduced re-renders from 8+ per data update to 2-4 per pagination event (expected behavior). Users can now browse profiles without browser crashes.