### PR TITLE
Translation system, autoplay-next, ambient glow, and various UX fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,7 +113,7 @@ VITE_USER_SHORTS_API_URL=
 # Video editor iframe URL
 # Use http://localhost:9091 for local development
 # Use https://editor.3speak.tv for production
-VITE_EDITOR_URL=
+VITE_EDITOR_URLS=
 
 # ===========================================
 # Feature Flags
@@ -121,6 +121,15 @@ VITE_EDITOR_URL=
 
 # Show editor features: Remix and Clip buttons (true/false)
 VITE_FEATURE_EDITOR=false
+
+# ===========================================
+# Translation API Configuration
+# ===========================================
+
+# LibreTranslate API endpoint
+# Use http://localhost:5000 for local development
+# Use https://3speak-translator.okinoko.io for production
+VITE_TRANSLATE_API_URL=
 
 # ===========================================
 # HiveSigner Configuration

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Logs
 logs
+logs/
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/src/components/AmbientGlow/AmbientGlow.jsx
+++ b/src/components/AmbientGlow/AmbientGlow.jsx
@@ -1,0 +1,104 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import './AmbientGlow.scss';
+
+const GLOW_STORAGE_KEY = '3speak-ambient-glow';
+const CANVAS_W = 32;
+const CANVAS_H = 18;
+const FPS_INTERVAL = 1000 / 10; // ~10 fps for smooth glow transitions
+
+// Modes: 'off' → 'page' (subtle) → 'vivid' (bright) → 'off'
+const MODES = ['off', 'page', 'vivid'];
+
+const readStoredMode = () => {
+  const stored = localStorage.getItem(GLOW_STORAGE_KEY);
+  if (MODES.includes(stored)) return stored;
+  // Legacy values
+  if (stored === '1' || stored === 'card') return 'page';
+  return 'off';
+};
+
+export const useAmbientGlow = () => {
+  const [glowMode, setGlowMode] = useState(readStoredMode);
+
+  const toggleGlow = useCallback(() => {
+    setGlowMode(prev => {
+      const idx = MODES.indexOf(prev);
+      const next = MODES[(idx + 1) % MODES.length];
+      localStorage.setItem(GLOW_STORAGE_KEY, next);
+      return next;
+    });
+  }, []);
+
+  return { glowMode, toggleGlow };
+};
+
+/**
+ * AmbientGlow — renders a fixed canvas (portalled to document.body) that
+ * samples video frames and CSS-blurs them into a full-page ambient light effect.
+ * Desktop only — disabled on mobile via CSS.
+ *
+ * Modes:
+ *   'off'   — no glow
+ *   'page'  — subtle ambient glow (lower saturation)
+ *   'vivid' — bright/saturated glow
+ *
+ * @param {() => HTMLVideoElement|null} getVideoEl — getter for the video element
+ * @param {string} glowMode — 'off' | 'page' | 'vivid'
+ */
+const AmbientGlow = ({ getVideoEl, glowMode }) => {
+  const canvasRef = useRef(null);
+  const getVideoElRef = useRef(getVideoEl);
+  getVideoElRef.current = getVideoEl;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    if (glowMode === 'off') {
+      const ctx = canvas.getContext('2d');
+      if (ctx) ctx.clearRect(0, 0, canvas.width, canvas.height);
+      return;
+    }
+
+    const ctx = canvas.getContext('2d', { willReadFrequently: false });
+    if (!ctx) return;
+
+    canvas.width = CANVAS_W;
+    canvas.height = CANVAS_H;
+
+    let rafId = null;
+    let lastDraw = 0;
+
+    const draw = (now) => {
+      rafId = requestAnimationFrame(draw);
+      if (now - lastDraw < FPS_INTERVAL) return;
+      lastDraw = now;
+
+      const videoEl = getVideoElRef.current?.();
+      if (!videoEl || videoEl.readyState < 2) return;
+
+      try {
+        ctx.drawImage(videoEl, 0, 0, CANVAS_W, CANVAS_H);
+      } catch (e) {
+        // CORS / SecurityError — ignore
+      }
+    };
+
+    rafId = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(rafId);
+  }, [glowMode]);
+
+  const activeClass = glowMode !== 'off' ? ` active glow-${glowMode}` : '';
+
+  return createPortal(
+    <canvas
+      className={`page-glow-canvas${activeClass}`}
+      ref={canvasRef}
+      aria-hidden="true"
+    />,
+    document.body
+  );
+};
+
+export default AmbientGlow;

--- a/src/components/AmbientGlow/AmbientGlow.scss
+++ b/src/components/AmbientGlow/AmbientGlow.scss
@@ -1,0 +1,50 @@
+.page-glow-canvas {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  z-index: 0;
+  pointer-events: none;
+  image-rendering: auto;
+  transition: opacity 0.6s ease;
+
+  // --- Dark theme (default) ---
+
+  // 'page' — subtle: low brightness, moderate saturation
+  &.glow-page {
+    filter: blur(90px) saturate(2) brightness(0.35) contrast(1.4);
+  }
+
+  // 'vivid' — bright: higher brightness, higher saturation
+  &.glow-vivid {
+    filter: blur(90px) saturate(3) brightness(0.6) contrast(1.4);
+  }
+
+  &.active {
+    opacity: 0.8;
+  }
+
+  // --- Light theme ---
+  :root:not([data-theme="dark"]) & {
+    // 'page' — subtle: low saturation
+    &.glow-page {
+      filter: blur(90px) saturate(1.5) brightness(2.0) contrast(1.4);
+    }
+
+    // 'vivid' — saturated: high saturation
+    &.glow-vivid {
+      filter: blur(90px) saturate(6) brightness(2.0) contrast(1.4);
+    }
+
+    &.active {
+      opacity: 0.5;
+    }
+  }
+
+  // Disabled on mobile (canvas drawImage doesn't work with hardware video compositing)
+  @media (max-width: 768px) {
+    display: none;
+  }
+}

--- a/src/components/LanguageSelector/LanguageSelector.jsx
+++ b/src/components/LanguageSelector/LanguageSelector.jsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import { MdTranslate } from 'react-icons/md';
+import { SUPPORTED_LANGUAGES, getTargetLanguage, setTargetLanguage } from '../../utils/translate';
+import './LanguageSelector.scss';
+
+export default function LanguageSelector({ onChange }) {
+  const [lang, setLang] = useState(getTargetLanguage);
+
+  const handleChange = (e) => {
+    const code = e.target.value;
+    setLang(code);
+    setTargetLanguage(code);
+    onChange?.(code);
+  };
+
+  return (
+    <div className="language-selector">
+      <MdTranslate size={16} />
+      <select value={lang} onChange={handleChange}>
+        {SUPPORTED_LANGUAGES.map(l => (
+          <option key={l.code} value={l.code}>
+            {l.native}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/components/LanguageSelector/LanguageSelector.scss
+++ b/src/components/LanguageSelector/LanguageSelector.scss
@@ -1,0 +1,26 @@
+.language-selector {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--text-secondary, #9ca3af);
+
+  svg {
+    flex-shrink: 0;
+  }
+
+  select {
+    background: var(--bg-secondary, #1a1a2e);
+    color: var(--text-primary, #fff);
+    border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+    border-radius: 6px;
+    padding: 3px 6px;
+    font-size: 12px;
+    cursor: pointer;
+    outline: none;
+
+    &:focus {
+      border-color: var(--accent-primary, #e53935);
+    }
+  }
+}

--- a/src/components/LanguageSelector/translate-common.scss
+++ b/src/components/LanguageSelector/translate-common.scss
@@ -1,0 +1,81 @@
+// Shared translate button + translation block styles
+.comment-translate-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  font-weight: 400;
+  font-family: inherit;
+  color: var(--text-secondary, #aaa);
+  background: none;
+  border: 1px solid var(--border-light, rgba(255, 255, 255, 0.1));
+  border-radius: 6px;
+  padding: 3px 10px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, color 0.15s ease;
+
+  &:hover {
+    color: var(--text-primary, #fff);
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+
+  .spinner {
+    animation: translate-spin 1s linear infinite;
+  }
+}
+
+.comment-translation {
+  margin: 6px 0 4px;
+  padding: 8px 12px;
+  border-left: 3px solid var(--accent-primary, #e53935);
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 0 6px 6px 0;
+
+  .comment-translation-header {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-secondary, #aaa);
+    margin-bottom: 4px;
+  }
+
+  .comment-translation-dismiss {
+    margin-left: auto;
+    background: none;
+    border: none;
+    color: var(--text-secondary, #aaa);
+    font-size: 16px;
+    cursor: pointer;
+    line-height: 1;
+    padding: 0 2px;
+
+    &:hover {
+      color: var(--text-primary, #fff);
+    }
+  }
+
+  p {
+    font-size: 13px;
+    color: var(--text-primary, #fff);
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  &--error p {
+    color: var(--accent-primary, #e53935);
+    font-size: 12px;
+  }
+}
+
+@keyframes translate-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}

--- a/src/components/ReactionPlayer/ReactionPlayer.jsx
+++ b/src/components/ReactionPlayer/ReactionPlayer.jsx
@@ -1,11 +1,13 @@
 import { Fragment, useRef, useState, useEffect, useCallback } from 'react';
-import { MdChevronLeft, MdChevronRight, MdClose, MdAspectRatio, MdVideocam, MdComment, MdKeyboardArrowDown, MdKeyboardArrowUp } from 'react-icons/md';
+import { MdChevronLeft, MdChevronRight, MdClose, MdAspectRatio, MdVideocam, MdComment, MdKeyboardArrowDown, MdKeyboardArrowUp, MdTranslate } from 'react-icons/md';
 import { FaPlay, FaPause, FaExpand, FaCompress, FaVolumeUp, FaVolumeMute } from 'react-icons/fa';
 import { TbRewindBackward10, TbRewindForward10 } from 'react-icons/tb';
 import { Client } from '@hiveio/dhive';
 import { HIVE_API_NODES } from '../../utils/config';
 import './ReactionPlayer.scss';
 import { markByReputation } from '../../utils/reputation';
+import { translateText, getTargetLanguage } from '../../utils/translate';
+import TranslateButton from '../TranslateButton/TranslateButton';
 
 const hiveClient = new Client(HIVE_API_NODES);
 
@@ -25,7 +27,7 @@ const getRenderer = async () => {
   return rendererPromise;
 };
 
-const SIZE_LABELS = { small: 'S', medium: 'M', standard: 'Std', large: 'Cin' };
+const SIZE_LABELS = { small: 'S', medium: 'M', standard: 'Std', big: 'Big', cinema: 'Cin' };
 
 function stripRepliedTo(html) {
   if (!html) return '';
@@ -45,7 +47,21 @@ function strip3SpeakEmbeds(html) {
 
 function CommentNode({ comment, depth, collapsible = true }) {
   const [collapsed, setCollapsed] = useState(false);
+  const [translatedText, setTranslatedText] = useState(null);
+  const [isTranslating, setIsTranslating] = useState(false);
+  const [translateError, setTranslateError] = useState(false);
   const bodyHtml = depth === 0 ? strip3SpeakEmbeds(comment.body) : stripRepliedTo(comment.body || '');
+
+  const handleTranslate = async (langCode) => {
+    if (!comment.body) return;
+    setTranslateError(false);
+    setIsTranslating(true);
+    try {
+      const result = await translateText(comment.body, langCode || getTargetLanguage());
+      if (result) setTranslatedText(result);
+    } catch { setTranslateError(true); }
+    finally { setIsTranslating(false); }
+  };
 
   if (comment.isLowReputation) return null;
 
@@ -69,6 +85,18 @@ function CommentNode({ comment, depth, collapsible = true }) {
         {collapsible && <span className="comment-collapse-chevron" onClick={() => setCollapsed(true)}><MdKeyboardArrowUp size={18} /></span>}
       </div>
       <div className="rct-thread-body markdown-view" dangerouslySetInnerHTML={{ __html: bodyHtml }} />
+      {translatedText && (
+        <div className="comment-translation">
+          <div className="comment-translation-header">
+            <MdTranslate size={12} />
+            <span>Translation</span>
+            <button className="comment-translation-dismiss" onClick={() => setTranslatedText(null)}>&times;</button>
+          </div>
+          <p>{translatedText}</p>
+        </div>
+      )}
+      {translateError && <div className="comment-translation comment-translation--error"><p>Translation failed</p></div>}
+      <TranslateButton onTranslate={handleTranslate} isTranslating={isTranslating} compact />
       {comment.children?.map((child, i) => (
         <CommentNode key={i} comment={child} depth={depth + 1} />
       ))}

--- a/src/components/ReactionPlayer/ReactionPlayer.scss
+++ b/src/components/ReactionPlayer/ReactionPlayer.scss
@@ -1,4 +1,5 @@
 @use "../../mixins.scss" as mix;
+@import '../LanguageSelector/translate-common';
 
 .reaction-player {
   background: var(--card-bg, #1a1a2e);

--- a/src/components/TranslateButton/TranslateButton.jsx
+++ b/src/components/TranslateButton/TranslateButton.jsx
@@ -1,0 +1,140 @@
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import { createPortal } from 'react-dom';
+import { MdTranslate } from 'react-icons/md';
+import { ImSpinner9 } from 'react-icons/im';
+import { SUPPORTED_LANGUAGES, getTargetLanguage, setTargetLanguage } from '../../utils/translate';
+import './TranslateButton.scss';
+
+export default function TranslateButton({ onTranslate, isTranslating, compact }) {
+  const [open, setOpen] = useState(false);
+  const btnRef = useRef(null);
+  const menuRef = useRef(null);
+  const [pos, setPos] = useState({ top: 0, left: 0, flip: false });
+
+  // Compute position when opening
+  const updatePosition = useCallback(() => {
+    if (!btnRef.current) return;
+    const rect = btnRef.current.getBoundingClientRect();
+    const menuHeight = 264; // max-height 260 + 4 padding
+    const spaceAbove = rect.top;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const flip = spaceAbove < menuHeight && spaceBelow > spaceAbove;
+
+    setPos({
+      top: flip ? rect.bottom + 4 : rect.top - 4,
+      left: rect.left,
+      flip,
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    updatePosition();
+
+    // Close on click/touch outside
+    const handleClickOutside = (e) => {
+      if (
+        menuRef.current && !menuRef.current.contains(e.target) &&
+        btnRef.current && !btnRef.current.contains(e.target)
+      ) {
+        setOpen(false);
+      }
+    };
+
+    // Close on external scroll (ignore scroll events from the dropdown itself)
+    const handleScroll = (e) => {
+      if (menuRef.current && menuRef.current.contains(e.target)) return;
+      setOpen(false);
+    };
+
+    const handleResize = () => setOpen(false);
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('touchstart', handleClickOutside);
+    window.addEventListener('resize', handleResize);
+    window.addEventListener('scroll', handleScroll, true);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('touchstart', handleClickOutside);
+      window.removeEventListener('resize', handleResize);
+      window.removeEventListener('scroll', handleScroll, true);
+    };
+  }, [open, updatePosition]);
+
+  const handlePick = (code) => {
+    setTargetLanguage(code);
+    setOpen(false);
+    onTranslate?.(code);
+  };
+
+  // Prevent wheel events from propagating to the page behind the dropdown
+  const handleWheel = useCallback((e) => {
+    const el = menuRef.current;
+    if (!el) return;
+    const { scrollTop, scrollHeight, clientHeight } = el;
+    const atTop = scrollTop === 0 && e.deltaY < 0;
+    const atBottom = scrollTop + clientHeight >= scrollHeight && e.deltaY > 0;
+    // Only stop propagation when not at boundary (or always, to prevent page scroll)
+    if (!atTop && !atBottom) {
+      e.stopPropagation();
+    }
+    // Always prevent default to stop the page from scrolling
+    e.preventDefault();
+  }, []);
+
+  const saved = getTargetLanguage();
+
+  // Sort: selected language first, then the rest in original order
+  const sortedLanguages = useMemo(() => {
+    if (!saved) return SUPPORTED_LANGUAGES;
+    const selected = SUPPORTED_LANGUAGES.find(l => l.code === saved);
+    if (!selected) return SUPPORTED_LANGUAGES;
+    return [selected, ...SUPPORTED_LANGUAGES.filter(l => l.code !== saved)];
+  }, [saved]);
+
+  const menu = open && createPortal(
+    <div
+      className="translate-lang-menu"
+      ref={menuRef}
+      style={{
+        position: 'fixed',
+        top: pos.flip ? `${pos.top}px` : 'auto',
+        bottom: pos.flip ? 'auto' : `${window.innerHeight - pos.top}px`,
+        left: `${pos.left}px`,
+      }}
+      onWheel={handleWheel}
+      onTouchStart={(e) => e.stopPropagation()}
+      onTouchMove={(e) => e.stopPropagation()}
+    >
+      {sortedLanguages.map(l => (
+        <button
+          key={l.code}
+          className={`translate-lang-item${l.code === saved ? ' selected' : ''}`}
+          onClick={() => handlePick(l.code)}
+        >
+          <span className="translate-lang-native">{l.native}</span>
+          <span className="translate-lang-name">{l.name}</span>
+        </button>
+      ))}
+    </div>,
+    document.body
+  );
+
+  return (
+    <>
+      <div className="translate-btn-wrap" ref={btnRef}>
+        <button
+          className="comment-translate-btn"
+          onClick={() => setOpen(o => !o)}
+          disabled={isTranslating}
+        >
+          {isTranslating
+            ? <ImSpinner9 size={compact ? 10 : 12} className="spinner" />
+            : <MdTranslate size={compact ? 12 : 14} />}
+          <span>{isTranslating ? (compact ? '...' : 'Translating...') : 'Translate'}</span>
+        </button>
+      </div>
+      {menu}
+    </>
+  );
+}

--- a/src/components/TranslateButton/TranslateButton.scss
+++ b/src/components/TranslateButton/TranslateButton.scss
@@ -1,0 +1,66 @@
+.translate-btn-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.translate-lang-menu {
+  // Positioned via JS (portal on document.body)
+  background: var(--bg-secondary, #1a1a2e);
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  border-radius: 8px;
+  padding: 4px 0;
+  min-width: 180px;
+  max-height: 260px;
+  overflow-y: auto;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  z-index: 99999;
+
+  // Scrollbar
+  &::-webkit-scrollbar {
+    width: 5px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.15);
+    border-radius: 3px;
+  }
+}
+
+.translate-lang-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 12px;
+  border: none;
+  background: none;
+  color: var(--text-secondary, #aaa);
+  font-size: 12px;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.1s ease, color 0.1s ease;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--text-primary, #fff);
+  }
+
+  &.selected {
+    color: var(--accent-primary, #e53935);
+    font-weight: 700;
+    background: rgba(229, 57, 53, 0.08);
+  }
+
+  .translate-lang-native {
+    flex-shrink: 0;
+  }
+
+  .translate-lang-name {
+    font-size: 11px;
+    opacity: 0.6;
+  }
+}

--- a/src/components/VideoControls/VideoControls.jsx
+++ b/src/components/VideoControls/VideoControls.jsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { FaPlay, FaPause, FaExpand, FaCompress, FaVolumeUp, FaVolumeMute, FaVideo, FaCog } from 'react-icons/fa';
-import { TbRewindBackward10, TbRewindForward10, TbArrowsMaximize, TbPictureInPicture, TbBulbFilled, TbMoonFilled } from 'react-icons/tb';
+import { TbRewindBackward10, TbRewindForward10, TbArrowsMaximize, TbPictureInPicture, TbBulbFilled, TbMoonFilled, TbSunFilled, TbPlayerTrackNextFilled } from 'react-icons/tb';
 import './VideoControls.scss';
 
 function formatTime(seconds) {
@@ -21,11 +21,13 @@ function VideoControls({
   buffered,
   isPlaying,
   isMuted,
+  volume,
   isFullscreen,
   onSeekBackward,
   onSeekForward,
   onTogglePlay,
   onToggleMute,
+  onVolumeChange,
   onToggleFullscreen,
   onSeek,
   isVisible,
@@ -40,6 +42,8 @@ function VideoControls({
   onQualityChange,
   glowMode,
   onToggleGlow,
+  autoplayNext,
+  onToggleAutoplay,
 }) {
   const resolvedMarkers = markers || [];
 
@@ -50,6 +54,20 @@ function VideoControls({
   const [hoveredMarker, setHoveredMarker] = useState(null);
   const trackRef = useRef(null);
   const [dragProgress, setDragProgress] = useState(null); // non-null while dragging
+
+  // Volume slider — fully ref-driven to avoid React re-render lag
+  const volSliderRef = useRef(null);
+  const volDraggingRef = useRef(false);
+
+  // Sync slider from prop only when user is NOT dragging
+  useEffect(() => {
+    if (volDraggingRef.current || !volSliderRef.current) return;
+    const displayVol = isMuted ? 0 : (volume ?? 1);
+    volSliderRef.current.value = displayVol;
+    const pct = (displayVol * 100).toFixed(0);
+    volSliderRef.current.style.background =
+      `linear-gradient(to right, var(--accent-primary, #e53935) ${pct}%, rgba(255,255,255,0.3) ${pct}%)`;
+  }, [volume, isMuted]);
   const progress = dragProgress !== null ? dragProgress : (duration > 0 ? (currentTime / duration) * 100 : 0);
   const bufferedPercent = (buffered || 0) * 100;
 
@@ -227,9 +245,35 @@ function VideoControls({
               <FaVideo size={13} />
             </button>
           )}
-          <button className="vc-btn" onClick={onToggleMute} title={isMuted ? 'Unmute' : 'Mute'}>
-            {isMuted ? <FaVolumeMute size={14} /> : <FaVolumeUp size={14} />}
-          </button>
+          <div className="vc-volume-group">
+            <button className="vc-btn" onClick={onToggleMute} title={isMuted ? 'Unmute' : 'Mute'}>
+              {isMuted ? <FaVolumeMute size={14} /> : <FaVolumeUp size={14} />}
+            </button>
+            {onVolumeChange && (
+              <div className="vc-volume-slider-wrap">
+                <input
+                  ref={volSliderRef}
+                  type="range"
+                  className="vc-volume-slider"
+                  min="0"
+                  max="1"
+                  step="0.01"
+                  defaultValue={isMuted ? 0 : (volume ?? 1)}
+                  onPointerDown={() => { volDraggingRef.current = true; }}
+                  onPointerUp={() => { volDraggingRef.current = false; }}
+                  onInput={(e) => {
+                    const val = parseFloat(e.target.value);
+                    const pct = (val * 100).toFixed(0);
+                    e.target.style.background =
+                      `linear-gradient(to right, var(--accent-primary, #e53935) ${pct}%, rgba(255,255,255,0.3) ${pct}%)`;
+                    if (val > 0 && isMuted) onToggleMute();
+                    onVolumeChange(val);
+                  }}
+                  onChange={() => {}}
+                />
+              </div>
+            )}
+          </div>
           {onCycleReactionSize && (
             <button className="vc-btn vc-btn--resize" onClick={onCycleReactionSize} title={`Player size: ${reactionSizeLabel || 'Standard'}`}>
               <TbArrowsMaximize size={15} />
@@ -241,13 +285,24 @@ function VideoControls({
               <TbPictureInPicture size={16} />
             </button>
           )} */}
+          {onToggleAutoplay && (
+            <button
+              className={`vc-btn vc-btn--autoplay${autoplayNext ? ' active' : ''}`}
+              onClick={onToggleAutoplay}
+              title={autoplayNext ? 'Autoplay: on' : 'Autoplay: off'}
+            >
+              <TbPlayerTrackNextFilled size={15} />
+            </button>
+          )}
           {onToggleGlow && (
             <button
-              className={`vc-btn vc-btn--glow${glowMode === 'page' ? ' active' : ''}`}
+              className={`vc-btn vc-btn--glow${glowMode !== 'off' ? ' active' : ''}`}
               onClick={onToggleGlow}
-              title={glowMode === 'off' ? 'Ambient light on' : 'Ambient light off'}
+              title={glowMode === 'off' ? 'Ambient light: subtle' : glowMode === 'page' ? 'Ambient light: vivid' : 'Ambient light: off'}
             >
-              {glowMode === 'off' ? <TbMoonFilled size={15} /> : <TbBulbFilled size={15} />}
+              {glowMode === 'off' && <TbMoonFilled size={15} />}
+              {glowMode === 'page' && <TbBulbFilled size={15} />}
+              {glowMode === 'vivid' && <TbSunFilled size={15} />}
             </button>
           )}
           {qualityLevels && qualityLevels.length > 0 && (

--- a/src/components/VideoControls/VideoControls.scss
+++ b/src/components/VideoControls/VideoControls.scss
@@ -216,6 +216,12 @@
       transform: scale(0.92);
     }
 
+    &--autoplay {
+      &.active {
+        color: var(--accent-primary, #e53935);
+      }
+    }
+
     &--glow {
       &.active {
         color: #fbbf24;
@@ -257,6 +263,67 @@
     margin-left: 8px;
     white-space: nowrap;
     user-select: none;
+  }
+
+  // Volume group — icon + slider on hover (desktop only)
+  .vc-volume-group {
+    display: flex;
+    align-items: center;
+    position: relative;
+
+    .vc-volume-slider-wrap {
+      width: 0;
+      overflow: hidden;
+      transition: width 0.2s ease;
+    }
+
+    &:hover .vc-volume-slider-wrap {
+      width: 80px;
+    }
+
+    .vc-volume-slider {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 70px;
+      height: 4px;
+      margin: 0 5px;
+      border-radius: 2px;
+      outline: none;
+      cursor: pointer;
+      // background is set inline via style prop for dynamic fill color
+
+      &::-webkit-slider-runnable-track {
+        height: 4px;
+        background: transparent;
+        border-radius: 2px;
+      }
+
+      &::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        appearance: none;
+        width: 12px;
+        height: 12px;
+        margin-top: -4px;
+        border-radius: 50%;
+        background: #fff;
+        cursor: pointer;
+      }
+
+      &::-moz-range-track {
+        height: 4px;
+        background: transparent;
+        border-radius: 2px;
+      }
+
+      &::-moz-range-thumb {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: #fff;
+        border: none;
+        cursor: pointer;
+      }
+    }
   }
 
   // Quality picker
@@ -394,10 +461,15 @@
       z-index: 1;
     }
 
-    // Hide resize and glow buttons on mobile
+    // Hide resize, glow, autoplay, and volume slider on mobile
     .vc-btn--resize,
-    .vc-btn--glow {
+    .vc-btn--glow,
+    .vc-btn--autoplay {
       display: none;
+    }
+
+    .vc-volume-slider-wrap {
+      display: none !important;
     }
 
     // When visible: show gradient + controls (not progress bar — already visible)

--- a/src/components/modal/EditorModal.jsx
+++ b/src/components/modal/EditorModal.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { X, Loader2 } from 'lucide-react';
-import { EDITOR_URL } from '../../utils/config';
+import { getEditorUrl } from '../../utils/config';
 import { useAppStore } from '../../lib/store';
 import './EditorModal.scss';
 
@@ -14,6 +14,34 @@ function EditorModal({ isOpen, onClose, videoUrl, videoName, videoType, clipStar
   const [renderedVideoUrl, setRenderedVideoUrl] = useState(null);
   const pollIntervalRef = useRef(null);
 
+  // Resolved editor URL (picked from the configured list on each open)
+  const [resolvedUrl, setResolvedUrl] = useState(null);
+  const [resolving, setResolving] = useState(false);
+  const [resolveError, setResolveError] = useState(false);
+
+  // Resolve a working editor URL when the modal opens
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    setResolving(true);
+    setResolveError(false);
+    setResolvedUrl(null);
+    setEditorReady(false);
+    mediaLoadedRef.current = false;
+
+    getEditorUrl().then(url => {
+      if (cancelled) return;
+      if (url) {
+        setResolvedUrl(url);
+      } else {
+        setResolveError(true);
+      }
+      setResolving(false);
+    });
+
+    return () => { cancelled = true; };
+  }, [isOpen]);
+
   // Lock body scroll when open
   useEffect(() => {
     if (isOpen) {
@@ -26,10 +54,10 @@ function EditorModal({ isOpen, onClose, videoUrl, videoName, videoType, clipStar
 
   // Send message to editor iframe
   const sendToEditor = useCallback((message) => {
-    if (iframeRef.current?.contentWindow) {
-      iframeRef.current.contentWindow.postMessage(message, new URL(EDITOR_URL).origin);
+    if (iframeRef.current?.contentWindow && resolvedUrl) {
+      iframeRef.current.contentWindow.postMessage(message, new URL(resolvedUrl).origin);
     }
-  }, []);
+  }, [resolvedUrl]);
 
   // Send theme to editor when ready or when theme changes
   useEffect(() => {
@@ -40,12 +68,12 @@ function EditorModal({ isOpen, onClose, videoUrl, videoName, videoType, clipStar
 
   // Listen for messages from editor iframe
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen || !resolvedUrl) return;
 
     const handleMessage = (event) => {
       // Validate origin
       try {
-        const editorOrigin = new URL(EDITOR_URL).origin;
+        const editorOrigin = new URL(resolvedUrl).origin;
         if (event.origin !== editorOrigin) return;
       } catch {
         return;
@@ -84,7 +112,7 @@ function EditorModal({ isOpen, onClose, videoUrl, videoName, videoType, clipStar
 
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
-  }, [isOpen, videoUrl, videoName, videoType, clipStart, clipEnd, sendToEditor]);
+  }, [isOpen, resolvedUrl, videoUrl, videoName, videoType, clipStart, clipEnd, sendToEditor]);
 
   // Handle render request from editor
   const handleRenderRequest = async (timeline) => {
@@ -160,13 +188,15 @@ function EditorModal({ isOpen, onClose, videoUrl, videoName, videoType, clipStar
   }, []);
 
   const handleClose = () => {
-    if (!window.confirm('Are you sure you want to close the editor? Unsaved changes will be lost.')) {
+    if (editorReady && !window.confirm('Are you sure you want to close the editor? Unsaved changes will be lost.')) {
       return;
     }
     setEditorReady(false);
     setRenderStatus(null);
     setRenderProgress(0);
     setRenderedVideoUrl(null);
+    setResolvedUrl(null);
+    setResolveError(false);
     mediaLoadedRef.current = false;
     if (pollIntervalRef.current) clearInterval(pollIntervalRef.current);
     onClose();
@@ -186,19 +216,32 @@ function EditorModal({ isOpen, onClose, videoUrl, videoName, videoType, clipStar
       <div className="editor-modal-overlay" onClick={handleClose}></div>
       <div className="editor-modal-content">
         <div className="editor-modal-body">
-          <iframe
-            ref={iframeRef}
-            src={EDITOR_URL}
-            className="editor-iframe"
-            allow="cross-origin-isolated; camera; microphone"
-            title="3Speak Video Editor"
-          />
+          {/* Show iframe only after a working URL is resolved */}
+          {resolvedUrl && (
+            <iframe
+              ref={iframeRef}
+              src={resolvedUrl}
+              className="editor-iframe"
+              allow="cross-origin-isolated; camera; microphone"
+              title="3Speak Video Editor"
+            />
+          )}
 
-          {/* Loading overlay */}
-          {!editorReady && (
+          {/* Loading overlay — resolving URL or waiting for editor ready */}
+          {(resolving || (!editorReady && !resolveError)) && (
             <div className="editor-loading-overlay">
               <Loader2 size={40} className="spinner" />
-              <span>Loading editor...</span>
+              <span>{resolving ? 'Finding available editor...' : 'Loading editor...'}</span>
+            </div>
+          )}
+
+          {/* Error: no editor available */}
+          {resolveError && (
+            <div className="editor-loading-overlay">
+              <span>No editor server is currently available. Please try again later.</span>
+              <button className="render-btn" onClick={handleClose} style={{ marginTop: 16 }}>
+                Close
+              </button>
             </div>
           )}
 

--- a/src/components/playVideo/CommentSection.jsx
+++ b/src/components/playVideo/CommentSection.jsx
@@ -4,7 +4,9 @@ import './BlogContent.scss';
 import { BiDislike } from 'react-icons/bi';
 import { ImSpinner9 } from 'react-icons/im';
 import { TailChase } from 'ldrs/react';
-import { MdVideocam, MdComment, MdKeyboardArrowUp } from 'react-icons/md';
+import { MdVideocam, MdComment, MdKeyboardArrowUp, MdTranslate } from 'react-icons/md';
+import useTranslation from '../../hooks/useTranslation';
+import TranslateButton from '../TranslateButton/TranslateButton';
 import ReactVideoTab from '../ReactVideoModal/ReactVideoModal';
 import dayjs from 'dayjs';
 import { useAppStore } from '../../lib/store';
@@ -64,6 +66,7 @@ function parseTimeInput(str) {
 
 function CommentSection({ videoDetails, author, permlink, currentTime, duration, onSeek, onPause, onRefreshReactions }) {
   const { user } = useAppStore();
+  const { translate, getTranslation, clearTranslation, translating } = useTranslation();
   const [commentInfo, setCommentInfo] = useState('');
   const [activeTab, setActiveTab] = useState('comment'); // 'comment' | 'react'
   const [replyText, setReplyText] = useState("");
@@ -582,7 +585,10 @@ function CommentSection({ videoDetails, author, permlink, currentTime, duration,
       currentTime={currentTime}
       duration={duration}
       onRefreshReactions={onRefreshReactions}
-
+      onTranslate={translate}
+      getTranslation={getTranslation}
+      clearTranslation={clearTranslation}
+      translating={translating}
         />
       )) )}
     </div>
@@ -621,10 +627,32 @@ function Comment({
       currentTime,
       duration,
       onRefreshReactions,
+      onTranslate,
+      getTranslation,
+      clearTranslation,
+      translating,
 }) {
   const isReplying = activeReply === comment.permlink;
   const [replyTab, setReplyTab] = useState('comment');
   const [collapsed, setCollapsed] = useState(false);
+  const [translatedText, setTranslatedText] = useState(null);
+  const [translateError, setTranslateError] = useState(false);
+
+  const handleTranslate = async (langCode) => {
+    if (!comment?.body) return;
+    setTranslateError(false);
+    try {
+      const result = await onTranslate?.(comment.permlink, comment.body, langCode);
+      if (result) setTranslatedText(result);
+    } catch {
+      setTranslateError(true);
+    }
+  };
+
+  const handleDismissTranslation = () => {
+    setTranslatedText(null);
+    clearTranslation?.(comment.permlink);
+  };
 
   // Inherit timestamp from the parent comment (not editable)
   const replyTimestamp = comment?.parentTimestamp ?? null;
@@ -660,6 +688,21 @@ function Comment({
             <span className="comment-collapse-chevron" onClick={() => setCollapsed(true)}><MdKeyboardArrowUp size={18} /></span>
           </div>
           <div className="markdown-view" dangerouslySetInnerHTML={{ __html: processedBody(comment?.body || '', comment?.permlink) }} />
+          {translatedText && (
+            <div className="comment-translation">
+              <div className="comment-translation-header">
+                <MdTranslate size={13} />
+                <span>Translation</span>
+                <button className="comment-translation-dismiss" onClick={handleDismissTranslation}>&times;</button>
+              </div>
+              <p>{translatedText}</p>
+            </div>
+          )}
+          {translateError && (
+            <div className="comment-translation comment-translation--error">
+              <p>Translation failed. Is the translation service running?</p>
+            </div>
+          )}
           <div className="comment-action">
             <UpvoteCount
               count={comment?.stats?.num_likes ?? 0}
@@ -668,6 +711,10 @@ function Comment({
             />
             <PayoutAmount amount={comment?.stats?.total_hive_reward} />
             <div className="comment-action-right">
+              <TranslateButton
+                onTranslate={handleTranslate}
+                isTranslating={!!translating?.[comment.permlink]}
+              />
               {comment.hasVideo && (
                 <Link
                   to={`/shorts?v=${comment.shortAuthor || comment.author?.username}/${comment.shortPermlink || comment.permlink}`}
@@ -794,6 +841,10 @@ function Comment({
       currentTime={currentTime}
       duration={duration}
       onRefreshReactions={onRefreshReactions}
+      onTranslate={onTranslate}
+      getTranslation={getTranslation}
+      clearTranslation={clearTranslation}
+      translating={translating}
             />
           ))}
         </div>

--- a/src/components/playVideo/CommentSection.scss
+++ b/src/components/playVideo/CommentSection.scss
@@ -20,6 +20,18 @@
     color: var(--text-secondary);
     margin-top: 15px;
   }
+
+  .comments-header-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-top: 15px;
+
+    h4 {
+      margin-top: 0;
+    }
+  }
 }
 /* Loader for comments */
 .vid-comment-wrap {
@@ -221,4 +233,6 @@
   gap: 8px;
   margin-top: 8px;
 }
+
+@import '../LanguageSelector/translate-common';
 

--- a/src/components/playVideo/PlayVideo.jsx
+++ b/src/components/playVideo/PlayVideo.jsx
@@ -3,7 +3,7 @@ import "./PlayVideo.scss";
 import VideoControls from "../VideoControls/VideoControls";
 import ViewCount from "../ViewCount/ViewCount";
 import { LuTimer } from "react-icons/lu";
-import { MdReplay } from "react-icons/md";
+import { MdReplay, MdPlayArrow } from "react-icons/md";
 import UpvoteCount from "../UpvoteCount/UpvoteCount";
 import PayoutAmount from "../PayoutAmount/PayoutAmount";
 import { useEffect, useState, useCallback, useMemo, useRef } from "react";
@@ -27,7 +27,8 @@ import 'ldrs/react/TailChase.css';
 import { getFollowers, getRelationshipBetweenAccounts } from "../../hive-api/api";
 import CommentVoteTooltip from "../tooltip/CommentVoteTooltip";
 import axios from "axios";
-import { FEED_URL, HIVE_API_URL, EDITOR_URL, FEATURE_EDITOR } from '../../utils/config';
+import { FEED_URL, HIVE_API_URL, FEATURE_EDITOR } from '../../utils/config';
+import { fixVideoThumbnail, fallbackImg } from '../../utils/fixThumbnails';
 import { isLoggedIn, followWithAioha } from "../../hive-api/aioha";
 import { MdPlaylistAdd, MdWatchLater, MdKeyboardArrowDown, MdKeyboardArrowUp, MdAdd, MdClose, MdShare, MdAttachMoney, MdPersonAdd, MdInfo } from "react-icons/md";
 import { FaHeart } from "react-icons/fa";
@@ -39,13 +40,13 @@ import { removeFromPlaylist } from "../../utils/playlistOperations";
 import { useQueryClient } from "@tanstack/react-query";
 import AuthorBadge from "../AuthorBadge/AuthorBadge";
 import Button from "../Button/Button";
-import { Repeat2, Scissors, Film } from 'lucide-react';
+import { Repeat2, Scissors, Tornado } from 'lucide-react';
 import { recordReshare, getResharesForVideo } from '../../utils/reshares';
 import EditorModal from '../modal/EditorModal';
 
 dayjs.extend(relativeTime);
 
-const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlaylist, videoControls, mobileReactionPanel, videoRef, wrapperRef }) => {
+const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlaylist, videoControls, mobileReactionPanel, cinemaReactionPanel, videoRef, wrapperRef }) => {
   const { user, authenticated } = useAppStore();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -501,9 +502,37 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
                 playsInline
               />
               {videoControls?.videoEnded && (
-                <div className="video-replay-overlay" onClick={videoControls.onReplay}>
-                  <button className="video-replay-btn" title="Replay">
+                <div className="video-ended-overlay">
+                  <button className="video-replay-btn" onClick={videoControls.onReplay} title="Replay">
                     <MdReplay size={48} />
+                  </button>
+                  {!videoControls.autoplayNext && videoControls.endSuggestions?.length > 0 && (
+                    <div className="video-ended-suggestions">
+                      {videoControls.endSuggestions.map((v, i) => {
+                        const vAuthor = v?.author?.username || v?.author?.id || v?.author || v?.owner;
+                        return (
+                          <a
+                            key={`${vAuthor}-${v.permlink}-${i}`}
+                            className="video-ended-card"
+                            href={`/watch?v=${vAuthor}/${v.permlink}`}
+                            onClick={(e) => { e.preventDefault(); navigate(`/watch?v=${vAuthor}/${v.permlink}`); }}
+                          >
+                            <img src={fixVideoThumbnail(v)} alt={v.title} onError={(e) => (e.currentTarget.src = fallbackImg)} />
+                            <div className="video-ended-card-info">
+                              <span className="video-ended-card-title">{v.title?.length > 40 ? v.title.slice(0, 40) + '...' : v.title}</span>
+                              <span className="video-ended-card-author">@{vAuthor}</span>
+                            </div>
+                          </a>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              )}
+              {videoControls?.autoplayBlocked && !videoControls?.videoEnded && (
+                <div className="video-replay-overlay" onClick={videoControls.onAutoplayTap}>
+                  <button className="video-replay-btn" title="Play">
+                    <MdPlayArrow size={48} />
                   </button>
                 </div>
               )}
@@ -511,6 +540,7 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
                 <>
                   <div
                     className="video-interact-overlay"
+                    style={showTooltip ? { pointerEvents: 'none' } : undefined}
                     onMouseMove={() => {
                       if (window.innerWidth > 767) videoControls.onMouseMove();
                     }}
@@ -531,10 +561,12 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
                     buffered={videoControls.buffered}
                     isPlaying={videoControls.isPlaying}
                     isMuted={videoControls.isMuted}
+                    volume={videoControls.volume}
                     isFullscreen={videoControls.isFullscreen}
                     isVisible={videoControls.isVisible}
                     onTogglePlay={videoControls.onTogglePlay}
                     onToggleMute={videoControls.onToggleMute}
+                    onVolumeChange={videoControls.onVolumeChange}
                     onSeekBackward={videoControls.onSeekBackward}
                     onSeekForward={videoControls.onSeekForward}
                     onSeek={videoControls.onSeek}
@@ -550,6 +582,8 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
                     onQualityChange={videoControls.onQualityChange}
                     glowMode={videoControls.glowMode}
                     onToggleGlow={videoControls.onToggleGlow}
+                    autoplayNext={videoControls.autoplayNext}
+                    onToggleAutoplay={videoControls.onToggleAutoplay}
                   />
                 </>
               )}
@@ -712,18 +746,19 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
               <button
                 className="remix-btn"
                 onClick={handleRemix}
-                title={videoControls?.duration > 60 ? 'Remix only available for videos under 60s' : 'Remix in editor'}
-                disabled={videoControls?.duration > 60}
+                title={!authenticated ? 'Log in to remix' : !videoUrlSelected || !videoControls?.duration ? 'Loading video...' : videoControls.duration > 60 ? 'Remix only available for videos under 60s' : 'Remix in editor'}
+                disabled={!authenticated || !videoUrlSelected || !videoControls?.duration || videoControls.duration > 60}
               >
-                <Scissors size={16} />
+                <Tornado size={16} />
                 <span className="tools-row-label">Remix</span>
               </button>
               <button
                 className={`clip-btn${clipMode ? ' active' : ''}`}
                 onClick={clipMode ? handleCancelClip : handleStartClipMode}
-                title={clipMode ? 'Cancel clip' : 'Clip video'}
+                title={!authenticated ? 'Log in to clip' : clipMode ? 'Cancel clip' : 'Clip video'}
+                disabled={!authenticated}
               >
-                <Film size={16} />
+                <Scissors size={16} />
                 <span className="tools-row-label">Clip</span>
               </button>
             </div>
@@ -733,7 +768,7 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
         {FEATURE_EDITOR && clipMode && (
           <div className="clip-bar">
             <div className="clip-bar-info">
-              <Film size={16} />
+              <Scissors size={16} />
               <span className="clip-bar-label">
                 {clipMode === 'start' && 'Seek to the start of your clip'}
                 {clipMode === 'end' && `Start: ${formatTime(clipStart)} — Now seek to the end`}
@@ -787,6 +822,13 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
         {mobileReactionPanel && (
           <div className="mobile-reactions-slot">
             {mobileReactionPanel}
+          </div>
+        )}
+
+        {/* Cinema mode reactions slot — between description and comments (desktop) */}
+        {cinemaReactionPanel && (
+          <div className="cinema-reactions-slot">
+            {cinemaReactionPanel}
           </div>
         )}
 
@@ -965,6 +1007,7 @@ PlayVideo.propTypes = {
   }),
   onClosePlaylist: PropTypes.func,
   mobileReactionPanel: PropTypes.node,
+  cinemaReactionPanel: PropTypes.node,
   videoRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   wrapperRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
 };

--- a/src/components/playVideo/PlayVideo.scss
+++ b/src/components/playVideo/PlayVideo.scss
@@ -678,6 +678,99 @@
   cursor: pointer;
 }
 
+.video-ended-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 6;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  background: rgba(0, 0, 0, 0.65);
+  padding: 16px;
+}
+
+.video-ended-suggestions {
+  display: flex;
+  gap: 10px;
+  width: 100%;
+  padding: 0 16px;
+  box-sizing: border-box;
+}
+
+.video-ended-card {
+  flex: 1;
+  min-width: 0;
+  border-radius: 8px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.1);
+  text-decoration: none;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.2s;
+
+  // Staggered fade + zoom-in animation from left to right
+  opacity: 0;
+  transform: scale(0.85) translateY(8px);
+  animation: endcard-in 0.4s ease forwards;
+
+  @for $i from 1 through 5 {
+    &:nth-child(#{$i}) {
+      animation-delay: #{($i - 1) * 0.08}s;
+    }
+  }
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.18);
+    transform: scale(1.03);
+  }
+
+  img {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    object-fit: cover;
+    display: block;
+  }
+
+  .video-ended-card-info {
+    padding: 6px 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .video-ended-card-title {
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .video-ended-card-author {
+    font-size: 11px;
+    opacity: 0.6;
+  }
+
+  @media (max-width: 768px) {
+    .video-ended-card-title { font-size: 11px; }
+    .video-ended-card-author { font-size: 10px; }
+  }
+}
+
+@keyframes endcard-in {
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
 .video-replay-btn {
   display: flex;
   align-items: center;
@@ -880,6 +973,15 @@
 
         @include mix.respond(phone) {
             display: block;
+        }
+    }
+
+    // Cinema mode reactions slot — shown on desktop in cinema mode only
+    .cinema-reactions-slot {
+        margin-top: 16px;
+
+        @include mix.respond(phone) {
+            display: none;
         }
     }
 }

--- a/src/hooks/useTranslation.js
+++ b/src/hooks/useTranslation.js
@@ -1,0 +1,43 @@
+import { useRef, useState, useCallback } from 'react';
+import { translateText, getTargetLanguage } from '../utils/translate';
+
+export default function useTranslation() {
+  const cacheRef = useRef({}); // key: `${permlink}:${lang}` → translated text
+  const [translating, setTranslating] = useState({}); // permlink → true
+
+  const translate = useCallback(async (permlink, text, langCode) => {
+    const lang = langCode || getTargetLanguage();
+    const key = `${permlink}:${lang}`;
+
+    if (cacheRef.current[key]) return cacheRef.current[key];
+
+    setTranslating(prev => ({ ...prev, [permlink]: true }));
+    try {
+      const result = await translateText(text, lang);
+      cacheRef.current[key] = result;
+      return result;
+    } finally {
+      setTranslating(prev => {
+        const next = { ...prev };
+        delete next[permlink];
+        return next;
+      });
+    }
+  }, []);
+
+  const getTranslation = useCallback((permlink) => {
+    const lang = getTargetLanguage();
+    return cacheRef.current[`${permlink}:${lang}`] || null;
+  }, []);
+
+  const clearTranslation = useCallback((permlink) => {
+    // Remove all cached translations for this permlink
+    for (const k of Object.keys(cacheRef.current)) {
+      if (k.startsWith(`${permlink}:`)) {
+        delete cacheRef.current[k];
+      }
+    }
+  }, []);
+
+  return { translate, getTranslation, clearTranslation, translating };
+}

--- a/src/page/Short.jsx
+++ b/src/page/Short.jsx
@@ -27,11 +27,15 @@ import {
   Square,
   RotateCcw,
   Repeat2,
-  Scissors,
+  WandSparkles,
   Moon,
   Lightbulb,
+  Sun,
 } from 'lucide-react';
 import { GiTwoCoins } from 'react-icons/gi';
+import { MdTranslate } from 'react-icons/md';
+import useTranslation from '../hooks/useTranslation';
+import TranslateButton from '../components/TranslateButton/TranslateButton';
 
 // Custom Hive Icon Component
 const HiveIcon = ({ size = 24, className = '' }) => (
@@ -63,6 +67,7 @@ import ShortsIcon from '../components/icons/ShortsIcon';
 import { markByReputation } from '../utils/reputation';
 import { getVotePower, getDynamicProps } from '../utils/hiveUtils';
 import { commentWithAioha, isLoggedIn } from '../hive-api/aioha';
+import AmbientGlow, { useAmbientGlow } from '../components/AmbientGlow/AmbientGlow';
 import EditorModal from '../components/modal/EditorModal';
 
 // Lazy-loaded Hive markdown renderer (same as CommentSection)
@@ -84,6 +89,7 @@ const getRenderer = async () => {
 /* ================= COMPONENT ================= */
 const VideoShort = () => {
   const { user, authenticated, watchHistoryEnabled } = useAppStore();
+  const { translate: onTranslate, getTranslation, clearTranslation, translating } = useTranslation();
   const [currentIndex, setCurrentIndex] = useState(0);
   const currentIndexRef = useRef(0);
   currentIndexRef.current = currentIndex;
@@ -109,25 +115,15 @@ const VideoShort = () => {
   const [editorVideoUrl, setEditorVideoUrl] = useState(null);
   const [editorVideoName, setEditorVideoName] = useState(null);
 
-  // Ambient glow (desktop only)
-  const GLOW_STORAGE_KEY = '3speak-ambient-glow';
-  const pageGlowRef = useRef(null);
-  const [glowMode, setGlowMode] = useState(() => {
-    const stored = localStorage.getItem(GLOW_STORAGE_KEY);
-    if (stored === 'page' || stored === '1' || stored === 'card') return 'page';
-    return 'off';
-  });
-  const toggleGlow = useCallback(() => {
-    setGlowMode(prev => {
-      const next = prev === 'off' ? 'page' : 'off';
-      localStorage.setItem(GLOW_STORAGE_KEY, next);
-      return next;
-    });
-  }, []);
+  // Ambient glow
+  const { glowMode, toggleGlow } = useAmbientGlow();
 
   // Player state
   const [isPlaying, setIsPlaying] = useState(false);
   const [isMuted, setIsMuted] = useState(() => {
+    const stored = localStorage.getItem('3speak-muted');
+    if (stored !== null) return stored === '1';
+    // Fallback: read legacy cookie
     const cookie = document.cookie.split('; ').find(c => c.startsWith('shorts_muted='));
     return cookie ? cookie.split('=')[1] !== '0' : false;
   });
@@ -330,6 +326,7 @@ const VideoShort = () => {
     sendCommand(command);
     setIsMuted(newMuted);
     isMutedRef.current = newMuted;
+    localStorage.setItem('3speak-muted', newMuted ? '1' : '0');
     document.cookie = `shorts_muted=${newMuted ? '1' : '0'}; path=/; max-age=${365 * 24 * 3600}`;
     // Show mute/unmute icon feedback
     setShowMuteIcon(true);
@@ -407,7 +404,13 @@ const VideoShort = () => {
     e.stopPropagation();
     // Skip click if it was synthesized from a recent touch (touch handler already processed it)
     if (recentTouchRef.current) return;
-    if (showComments || mouseLongPressHandledRef.current) return;
+    if (mouseLongPressHandledRef.current) return;
+
+    // When comments panel is open, allow simple play/pause but skip double-tap gestures
+    if (showComments) {
+      togglePlayPause();
+      return;
+    }
 
     tapCountRef.current += 1;
     if (tapCountRef.current === 1) {
@@ -1608,7 +1611,13 @@ const VideoShort = () => {
     touchStartYRef.current = null;
 
     // Gesture tap detection — only if it wasn't a swipe or long press
-    if (wasSwipe || gestureHandledRef.current || showComments) return;
+    if (wasSwipe || gestureHandledRef.current) return;
+
+    // When comments panel is open, allow simple play/pause but skip double-tap gestures
+    if (showComments) {
+      togglePlayPause();
+      return;
+    }
 
     tapCountRef.current += 1;
     if (tapCountRef.current === 1) {
@@ -1896,43 +1905,6 @@ const VideoShort = () => {
     navigate(`/p/${username}`);
   };
 
-  // Ambient glow: draw video frames to a tiny canvas (desktop only)
-  useEffect(() => {
-    const canvas = pageGlowRef.current;
-    if (!canvas) return;
-
-    if (glowMode === 'off') {
-      const ctx = canvas.getContext('2d');
-      if (ctx) ctx.clearRect(0, 0, canvas.width, canvas.height);
-      return;
-    }
-
-    const video = videoElRef.current;
-    if (!video) return;
-
-    const ctx = canvas.getContext('2d', { willReadFrequently: false });
-    if (!ctx) return;
-
-    canvas.width = 32;
-    canvas.height = 18;
-
-    let rafId = null;
-    let lastDraw = 0;
-    const FPS_INTERVAL = 1000 / 4;
-
-    const draw = (now) => {
-      rafId = requestAnimationFrame(draw);
-      if (now - lastDraw < FPS_INTERVAL) return;
-      lastDraw = now;
-      if (video.readyState >= 2 && !video.paused) {
-        ctx.drawImage(video, 0, 0, 32, 18);
-      }
-    };
-
-    rafId = requestAnimationFrame(draw);
-    return () => cancelAnimationFrame(rafId);
-  }, [glowMode, currentIndex]);
-
   /* ---------- RENDER ---------- */
 
   if (loading && videos.length === 0) {
@@ -1972,7 +1944,7 @@ const VideoShort = () => {
 
   return (
     <main className="short-main">
-      <canvas className={`page-glow-canvas${glowMode === 'page' ? ' active' : ''}`} ref={pageGlowRef} aria-hidden="true" />
+      <AmbientGlow getVideoEl={() => videoElRef.current} glowMode={glowMode} />
       <div
         tabIndex={0}
         ref={keyboardRef}
@@ -2103,14 +2075,16 @@ const VideoShort = () => {
             <div className={`heartAnimation ${showHeartAnimation ? 'visible' : ''}`}>
               <Heart size={80} fill="#ff2d55" color="#ff2d55" />
             </div>
-            {/* Ambient glow toggle (desktop only) */}
-            <div className={`glowIndicator${glowMode === 'page' ? ' active' : ''}`}
+            {/* Ambient glow toggle */}
+            <div className={`glowIndicator${glowMode !== 'off' ? ' active' : ''}`}
               onClick={(e) => { e.stopPropagation(); toggleGlow(); }}
               onTouchStart={(e) => e.stopPropagation()}
               onTouchEnd={(e) => { e.stopPropagation(); e.preventDefault(); toggleGlow(); }}
-              title={glowMode === 'off' ? 'Ambient light on' : 'Ambient light off'}
+              title={glowMode === 'off' ? 'Ambient light: subtle' : glowMode === 'page' ? 'Ambient light: vivid' : 'Ambient light: off'}
             >
-              {glowMode === 'off' ? <Moon size={16} /> : <Lightbulb size={16} />}
+              {glowMode === 'off' && <Moon size={16} />}
+              {glowMode === 'page' && <Lightbulb size={16} />}
+              {glowMode === 'vivid' && <Sun size={16} />}
             </div>
             {/* Playback mode toggle button */}
             <div className="playbackModeIndicator"
@@ -2435,10 +2409,10 @@ const VideoShort = () => {
             <span className="actionLabel">{reshareCount || 0}</span>
           </div>
 
-          {FEATURE_EDITOR && (
+          {FEATURE_EDITOR && authenticated && (
             <div className="actionItem" onClick={(e) => { e.stopPropagation(); handleRemix(); }}>
               <div className="actionButton">
-                <Scissors size={24} />
+                <WandSparkles size={24} />
               </div>
               <span className="actionLabel">Remix</span>
             </div>
@@ -2482,9 +2456,6 @@ const VideoShort = () => {
           <span className="commentsTitle">Comments</span>
           <span className="commentsCount">{currentVideo.stats.comments}</span>
           <div className="commentsHeaderActions">
-            {/* <button className="headerBtn">
-              <SlidersHorizontal size={20} />
-            </button> */}
             <button className="headerBtn" onClick={handleToggleComments}>
               <X size={20} />
             </button>
@@ -2531,6 +2502,10 @@ const VideoShort = () => {
                 postingComment={postingComment}
                 user={user}
                 renderedBodies={renderedBodies}
+                onTranslate={onTranslate}
+                getTranslation={getTranslation}
+                clearTranslation={clearTranslation}
+                translating={translating}
               />
             ))
           )}
@@ -2600,11 +2575,26 @@ const CommentItem = ({
   handlePostComment,
   postingComment,
   user,
-  renderedBodies
+  renderedBodies,
+  onTranslate,
+  getTranslation,
+  clearTranslation,
+  translating,
 }) => {
   const [showReplies, setShowReplies] = useState(false);
   const [collapsed, setCollapsed] = useState(false);
+  const [translatedText, setTranslatedText] = useState(null);
+  const [translateError, setTranslateError] = useState(false);
   const maxDepth = 3;
+
+  const handleTranslate = async (langCode) => {
+    if (!comment?.body) return;
+    setTranslateError(false);
+    try {
+      const result = await onTranslate?.(comment.permlink, comment.body, langCode);
+      if (result) setTranslatedText(result);
+    } catch { setTranslateError(true); }
+  };
 
   const isReplying = activeReply === comment.permlink;
 
@@ -2643,7 +2633,19 @@ const CommentItem = ({
           <span className="comment-collapse-chevron" onClick={() => setCollapsed(true)}><ChevronUp size={16} /></span>
         </div>
         <div className="commentText markdown-view" dangerouslySetInnerHTML={{ __html: getCommentHtml() }} />
+        {translatedText && (
+          <div className="comment-translation">
+            <div className="comment-translation-header">
+              <MdTranslate size={12} />
+              <span>Translation</span>
+              <button className="comment-translation-dismiss" onClick={() => { setTranslatedText(null); clearTranslation?.(comment.permlink); }}>&times;</button>
+            </div>
+            <p>{translatedText}</p>
+          </div>
+        )}
+        {translateError && <div className="comment-translation comment-translation--error"><p>Translation failed</p></div>}
         <div className="commentActions">
+          <TranslateButton onTranslate={handleTranslate} isTranslating={!!translating?.[comment.permlink]} compact />
           <button
             className={`commentActionBtn ${comment.has_voted ? 'liked' : ''}`}
             onClick={() => toggleVoteTooltip(comment.author, comment.permlink)}
@@ -2752,6 +2754,10 @@ const CommentItem = ({
                 postingComment={postingComment}
                 user={user}
                 renderedBodies={renderedBodies}
+                onTranslate={onTranslate}
+                getTranslation={getTranslation}
+                clearTranslation={clearTranslation}
+                translating={translating}
               />
             ))}
           </div>

--- a/src/page/Short.scss
+++ b/src/page/Short.scss
@@ -1,3 +1,5 @@
+@import '../components/LanguageSelector/translate-common';
+
 .short-main {
   flex: 1;
   display: flex;
@@ -9,36 +11,6 @@
   height: calc(100vh - 64px);
   max-height: calc(100vh - 64px);
   background-color: transparent;
-
-  // Page-level ambient glow canvas
-  .page-glow-canvas {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    filter: blur(90px) saturate(3) brightness(0.6);
-    opacity: 0;
-    z-index: 0;
-    pointer-events: none;
-    image-rendering: auto;
-    transition: opacity 0.6s ease;
-
-    &.active {
-      opacity: 0.8;
-    }
-
-    :root:not([data-theme="dark"]) & {
-      filter: blur(90px) saturate(6) brightness(1.8) contrast(0.6);
-      &.active {
-        opacity: 0.5;
-      }
-    }
-
-    @media (max-width: 768px) {
-      display: none;
-    }
-  }
 
   @media (max-width: 768px) {
     position: absolute;
@@ -349,10 +321,6 @@
 
   .glowIndicator {
     right: 100px;
-    // Only show on desktop
-    @media (max-width: 768px) {
-      display: none;
-    }
 
     &.active svg {
       color: #fbbf24;

--- a/src/page/Watch.jsx
+++ b/src/page/Watch.jsx
@@ -7,13 +7,14 @@ import { GET_RELATED, GET_VIDEO_DETAILS, TRENDING_FEED, GET_AUTHOR_VIDEOS } from
 import { useQuery } from '@apollo/client';
 import BarLoader from '../components/Loader/BarLoader';
 import { useAppStore } from '../lib/store';
-import { recordWatch } from '../utils/watchHistory';
+import { recordWatch, batchCheckWatched } from '../utils/watchHistory';
 import { Client } from '@hiveio/dhive';
 import { HIVE_API_NODES, PLAYER_URL } from '../utils/config';
 import ReactionPlayer from '../components/ReactionPlayer/ReactionPlayer';
 import { MdVideocam, MdChatBubble } from 'react-icons/md';
 import { batchGetReputations, LOW_REP_THRESHOLD } from '../utils/reputation';
 import { usePlayer } from '@mantequilla-soft/3speak-player/react';
+import AmbientGlow, { useAmbientGlow } from '../components/AmbientGlow/AmbientGlow';
 
 const hiveClient = new Client(HIVE_API_NODES);
 
@@ -36,7 +37,6 @@ const getRenderer = async () => {
 // Number of author videos to show at the top of recommendations
 const AUTHOR_VIDEOS_COUNT = 4;
 const QUALITY_STORAGE_KEY = '3speak-quality-pref';
-const GLOW_STORAGE_KEY = '3speak-ambient-glow';
 
 // Filter out videos older than December 2023 (old videos may not exist on CDN)
 const MIN_VIDEO_DATE = new Date('2023-12-01T00:00:00.000Z');
@@ -70,6 +70,14 @@ function Watch() {
 
   // Track which videos we've recorded to avoid duplicate API calls
   const recordedWatchRef = useRef(new Set());
+
+  // Track videos played in this autoplay session to avoid loops
+  const playedVideosRef = useRef(new Set());
+
+  // Watched status from backend (Map of "author/permlink" → watch data)
+  const [watchedMap, setWatchedMap] = useState(new Map());
+  const watchedMapRef = useRef(watchedMap);
+  watchedMapRef.current = watchedMap;
 
   // Get playlist data from location state (passed from PlaylistView)
   const [playlistData, setPlaylistData] = useState(null);
@@ -109,21 +117,28 @@ function Watch() {
   const [controlsVisible, setControlsVisible] = useState(false);
   const hideTimerRef = useRef(null);
   const [videoEnded, setVideoEnded] = useState(false);
+  const [autoplayBlocked, setAutoplayBlocked] = useState(false);
 
-  // Ambient glow mode: 'off' | 'page'
-  const [glowMode, setGlowMode] = useState(() => {
-    const stored = localStorage.getItem(GLOW_STORAGE_KEY);
-    if (stored === 'page' || stored === '1' || stored === 'card') return 'page';
-    return 'off';
-  });
-
-  const toggleGlow = useCallback(() => {
-    setGlowMode(prev => {
-      const next = prev === 'off' ? 'page' : 'off';
-      localStorage.setItem(GLOW_STORAGE_KEY, next);
+  // Autoplay next video preference
+  const AUTOPLAY_STORAGE_KEY = '3speak-autoplay';
+  const [autoplayNext, setAutoplayNext] = useState(() => localStorage.getItem('3speak-autoplay') !== '0');
+  const autoplayNextRef = useRef(autoplayNext);
+  autoplayNextRef.current = autoplayNext;
+  const toggleAutoplayNext = useCallback(() => {
+    setAutoplayNext(prev => {
+      const next = !prev;
+      localStorage.setItem(AUTOPLAY_STORAGE_KEY, next ? '1' : '0');
       return next;
     });
   }, []);
+
+  const { glowMode, toggleGlow } = useAmbientGlow();
+
+  // Persist mute/volume preference across video navigations
+  const MUTE_STORAGE_KEY = '3speak-muted';
+  const VOLUME_STORAGE_KEY = '3speak-volume';
+  const storedMuted = localStorage.getItem(MUTE_STORAGE_KEY) === '1';
+  const storedVolume = parseFloat(localStorage.getItem(VOLUME_STORAGE_KEY)) || 1;
 
   // Quality levels state
   const [qualityLevels, setQualityLevels] = useState([]);
@@ -137,12 +152,13 @@ function Watch() {
     pause,
     togglePlay,
     seek,
-    setMuted,
+    setMuted: sdkSetMuted,
+    setVolume: sdkSetVolume,
     togglePip,
     setQuality: sdkSetQuality,
   } = usePlayer({
     apiBase: PLAYER_URL,
-    muted: false,
+    muted: storedMuted,
     loop: false,
     poster: true,
     resume: false,
@@ -153,10 +169,26 @@ function Watch() {
     },
   });
 
+  // Wrap setMuted/setVolume to persist to localStorage
+  const setMuted = useCallback((muted) => {
+    sdkSetMuted(muted);
+    localStorage.setItem(MUTE_STORAGE_KEY, muted ? '1' : '0');
+  }, [sdkSetMuted]);
+
+  const setVolume = useCallback((vol) => {
+    sdkSetVolume(vol);
+    localStorage.setItem(VOLUME_STORAGE_KEY, String(vol));
+  }, [sdkSetVolume]);
+
   // Track when the <video> element is mounted and attached to the Player
   const [videoAttached, setVideoAttached] = useState(false);
   const videoRef = useCallback((element) => {
     sdkVideoRef(element); // pass to usePlayer's internal attach
+    if (element) {
+      // Apply stored volume immediately after attach (SDK has no volume config option)
+      const savedVol = parseFloat(localStorage.getItem('3speak-volume'));
+      if (!isNaN(savedVol)) element.volume = savedVol;
+    }
     setVideoAttached(!!element);
   }, [sdkVideoRef]);
 
@@ -191,26 +223,60 @@ function Watch() {
   useEffect(() => {
     if (!author || !permlink || author === 'unknown' || !player || !videoAttached) return;
     setVideoEnded(false);
+    // Record this video as played in the current session
+    playedVideosRef.current.add(`${author}/${permlink}`);
+    // Reset playhead to 0 immediately so the UI doesn't show the old video's position
+    seek(0);
     loadVideo(`${author}/${permlink}`).catch(err => {
       console.error('[Watch] Failed to load video:', err);
     });
-  }, [author, permlink, player, loadVideo, videoAttached]);
+  }, [author, permlink, player, loadVideo, videoAttached, seek]);
 
   // Subscribe to player events (stable effect — uses refs for mutable values)
   useEffect(() => {
     if (!player) return;
 
+    let canPlayCleanup = null;
+
     const unsubReady = player.on('ready', ({ isVertical }) => {
       videoIsVerticalRef.current = isVertical;
       wrapperRef.current?.classList.toggle('vertical-video', isVertical);
-
-      // Auto-play
-      player.play().catch(() => {});
 
       // Seek to timestamp if ?t= parameter is present
       const startTime = parseInt(new URLSearchParams(window.location.search).get('t'), 10);
       if (startTime > 0) {
         setTimeout(() => player.seek(startTime), 200);
+      }
+
+      // Restore persisted mute/volume preference on each video load
+      const shouldMute = localStorage.getItem('3speak-muted') === '1';
+      player.setMuted(shouldMute);
+      const savedVol = parseFloat(localStorage.getItem('3speak-volume'));
+      if (!isNaN(savedVol)) player.setVolume(savedVol);
+
+      // Autoplay: wait for canplay (enough data buffered) instead of playing
+      // immediately on metadata load, which fails on slow connections.
+      const videoEl = player.element;
+      const tryAutoplay = () => {
+        player.play().then(() => {
+          setAutoplayBlocked(false);
+        }).catch((err) => {
+          if (err?.name === 'NotAllowedError') {
+            setAutoplayBlocked(true);
+          }
+        });
+      };
+      if (videoEl) {
+        // Clean up any previous canplay listener
+        if (canPlayCleanup) { canPlayCleanup(); canPlayCleanup = null; }
+
+        if (videoEl.readyState >= 3) {
+          tryAutoplay();
+        } else {
+          const onCanPlay = () => tryAutoplay();
+          videoEl.addEventListener('canplay', onCanPlay, { once: true });
+          canPlayCleanup = () => videoEl.removeEventListener('canplay', onCanPlay);
+        }
       }
 
       // Fetch quality levels and apply stored preference
@@ -249,6 +315,20 @@ function Watch() {
     const unsubEnded = player.on('ended', () => {
       if (playlistDataRef.current && showPlaylistRef.current) {
         navigateToNextVideoRef.current();
+      } else if (autoplayNextRef.current && suggestedVideosRef.current?.length > 0) {
+        // Find the first suggested video not already watched (backend) or played (session)
+        const next = suggestedVideosRef.current.find(v => {
+          const a = v?.author?.username || v?.author?.id || v?.author || v?.owner;
+          if (!a || !v.permlink) return false;
+          const key = `${a}/${v.permlink}`;
+          return !playedVideosRef.current.has(key) && !watchedMapRef.current.has(key);
+        });
+        if (next) {
+          const nextAuthor = next?.author?.username || next?.author?.id || next?.author || next?.owner;
+          navigate(`/watch?v=${nextAuthor}/${next.permlink}`);
+        } else {
+          setVideoEnded(true);
+        }
       } else {
         setVideoEnded(true);
       }
@@ -256,6 +336,7 @@ function Watch() {
 
     const unsubPlay = player.on('play', () => {
       setVideoEnded(false);
+      setAutoplayBlocked(false);
     });
 
     return () => {
@@ -263,47 +344,9 @@ function Watch() {
       unsubQuality();
       unsubEnded();
       unsubPlay();
+      if (canPlayCleanup) canPlayCleanup();
     };
   }, [player]);
-
-  // Ambient glow: draw video frames to a tiny canvas, CSS blur does the rest
-  const pageGlowRef = useRef(null);
-
-  useEffect(() => {
-    const canvas = pageGlowRef.current;
-    if (!canvas) return;
-
-    if (glowMode === 'off') {
-      const ctx = canvas.getContext('2d');
-      if (ctx) ctx.clearRect(0, 0, canvas.width, canvas.height);
-      return;
-    }
-
-    const video = player?.element;
-    if (!video) return;
-
-    const ctx = canvas.getContext('2d', { willReadFrequently: false });
-    if (!ctx) return;
-
-    canvas.width = 32;
-    canvas.height = 18;
-
-    let rafId = null;
-    let lastDraw = 0;
-    const FPS_INTERVAL = 1000 / 4;
-
-    const draw = (now) => {
-      rafId = requestAnimationFrame(draw);
-      if (now - lastDraw < FPS_INTERVAL) return;
-      lastDraw = now;
-      if (video.readyState >= 2 && !video.paused) {
-        ctx.drawImage(video, 0, 0, 32, 18);
-      }
-    };
-
-    rafId = requestAnimationFrame(draw);
-    return () => cancelAnimationFrame(rafId);
-  }, [player, videoAttached, glowMode]);
 
   // Handle quality change with optimistic UI update + persist preference
   const handleQualityChange = useCallback((level) => {
@@ -429,7 +472,10 @@ function Watch() {
     return localStorage.getItem('3speak-reactions-visible') !== 'false';
   });
   const [reactionSize, setReactionSize] = useState(() => {
-    return localStorage.getItem('3speak-reaction-size') || 'standard';
+    const stored = localStorage.getItem('3speak-reaction-size');
+    // Migrate legacy 'large' → 'big'
+    if (stored === 'large') return 'big';
+    return stored || 'standard';
   });
 
   const setReactionsVisible = useCallback((visible) => {
@@ -467,8 +513,8 @@ function Watch() {
     }, 100);
   }, []);
 
-  const REACTION_SIZES = ['medium', 'standard', 'large'];
-  const REACTION_SIZE_LABELS = { medium: 'Medium', standard: 'Standard', large: 'Cinema' };
+  const REACTION_SIZES = ['medium', 'standard', 'big', 'cinema'];
+  const REACTION_SIZE_LABELS = { medium: 'Medium', standard: 'Standard', big: 'Big', cinema: 'Cinema' };
   const cycleReactionSize = useCallback(() => {
     setReactionSize(prev => {
       const idx = REACTION_SIZES.indexOf(prev);
@@ -638,7 +684,6 @@ function Watch() {
   }, [videoLoading, videoData, author, permlink]);
 
   const videoDetails = videoData?.socialPost || hiveFallback;
-
   // Record watch history when video loads (if tracking is enabled)
   useEffect(() => {
     if (!user || !author || !permlink || author === 'unknown' || watchHistoryEnabled === false) {
@@ -714,6 +759,28 @@ function Watch() {
     // Combine: author videos first, then recommendations
     return [...authorVideos, ...recommendations];
   }, [authorVideosData, suggestionsData, trendingData, author, permlink]);
+
+  const suggestedVideosRef = useRef(suggestedVideos);
+  suggestedVideosRef.current = suggestedVideos;
+
+  // Batch-check which suggested videos the user has already watched
+  useEffect(() => {
+    if (!user || suggestedVideos.length === 0) {
+      setWatchedMap(new Map());
+      return;
+    }
+    let cancelled = false;
+    const videos = suggestedVideos.map(v => ({
+      author: v?.author?.username || v?.author?.id || v?.author || v?.owner,
+      permlink: v.permlink,
+    })).filter(v => v.author && v.permlink);
+
+    batchCheckWatched(user, videos).then(result => {
+      if (!cancelled) setWatchedMap(result);
+    }).catch(() => {});
+
+    return () => { cancelled = true; };
+  }, [user, suggestedVideos]);
 
   // Build reactions from comment markers: video reactions use the embed URL from metadata
   const reactions = useMemo(() => {
@@ -811,8 +878,7 @@ function Watch() {
 
   return (
     <div className={`play-container${isReactionPlayerVisible && reactions.length > 0 ? ` reaction-${reactionSize}` : ''}`}>
-      {/* Page-level ambient glow canvas — lives outside .play-video so it can cover the full page background */}
-      <canvas className={`page-glow-canvas${glowMode === 'page' ? ' active' : ''}`} ref={pageGlowRef} aria-hidden="true" />
+      <AmbientGlow getVideoEl={() => player?.element} glowMode={glowMode} />
       <PlayVideo
         videoDetails={videoDetails}
         author={author}
@@ -827,10 +893,19 @@ function Watch() {
           buffered: playerState.buffered,
           isPlaying: !playerState.paused,
           isMuted: playerState.muted,
+          volume: playerState.volume,
           isFullscreen,
           isVisible: controlsVisible,
           onTogglePlay: togglePlay,
           onToggleMute: () => setMuted(!playerState.muted),
+          onVolumeChange: (val) => {
+            setVolume(val);
+            if (val === 0) {
+              setMuted(true);
+            } else if (playerState.muted) {
+              setMuted(false);
+            }
+          },
           onSeekBackward: () => seek(Math.max(0, playerState.currentTime - 10)),
           onSeekForward: () => seek(Math.min(playerState.duration, playerState.currentTime + 10)),
           onSeek: seek,
@@ -847,6 +922,17 @@ function Watch() {
           onTogglePip: handleTogglePip,
           videoEnded,
           onReplay: handleReplay,
+          autoplayBlocked,
+          onAutoplayTap: togglePlay,
+          autoplayNext,
+          onToggleAutoplay: toggleAutoplayNext,
+          endSuggestions: suggestedVideos
+            .filter(v => {
+              const a = v?.author?.username || v?.author?.id || v?.author || v?.owner;
+              const key = `${a}/${v.permlink}`;
+              return !playedVideosRef.current.has(key) && !watchedMap.has(key);
+            })
+            .slice(0, 5),
           qualityLevels,
           currentQuality,
           onQualityChange: handleQualityChange,
@@ -882,6 +968,34 @@ function Watch() {
             )}
           </>
         }
+        cinemaReactionPanel={reactionSize === 'cinema' ? (
+          <>
+            {isReactionPlayerVisible && reactions.length > 0 && (
+              <ReactionPlayer
+                reactions={reactions}
+                selectedIndex={selectedReactionIndex}
+                onSelectReaction={handleSelectReaction}
+                onClose={() => setReactionsVisible(false)}
+                size={reactionSize}
+                onCycleSize={cycleReactionSize}
+                currentTime={playerState.currentTime}
+                duration={playerState.duration}
+                mainIsPlaying={!playerState.paused}
+                onReactionPlay={pause}
+              />
+            )}
+            {!isReactionPlayerVisible && reactions.length > 0 && (
+              <button className="show-reactions-btn" onClick={() => setReactionsVisible(true)}>
+                Show Reactions ({reactionCountLabel})
+              </button>
+            )}
+            {reactions.length === 0 && (
+              <button className="show-reactions-btn" onClick={handleAddReaction}>
+                Add Reaction
+              </button>
+            )}
+          </>
+        ) : null}
       />
 
       {/* Right column: Reaction Player + Recommended */}

--- a/src/page/Watch.scss
+++ b/src/page/Watch.scss
@@ -103,7 +103,7 @@
 
       // standard = default (69/30), no override needed
 
-      &.reaction-large {
+      &.reaction-big {
         .play-video {
           flex-basis: 80%;
           max-width: 80%;
@@ -111,6 +111,16 @@
         .right-column {
           flex-basis: 18%;
           max-width: 18%;
+        }
+      }
+
+      &.reaction-cinema {
+        .play-video {
+          flex-basis: 100%;
+          max-width: 100%;
+        }
+        .right-column {
+          display: none;
         }
       }
     }
@@ -175,34 +185,3 @@
     }
 }
 
-// Page-level ambient glow canvas — covers the full viewport behind all content
-.page-glow-canvas {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  // Dark theme
-  filter: blur(90px) saturate(3) brightness(0.6);
-  opacity: 0;
-  z-index: 5;
-  pointer-events: none;
-  image-rendering: auto;
-  transition: opacity 0.6s ease;
-
-  &.active {
-    opacity: 0.8;
-  }
-
-  // Light theme: boost saturation + brightness so only vivid colors come through
-  :root:not([data-theme="dark"]) & {
-    filter: blur(90px) saturate(6) brightness(1.8) contrast(0.6);
-    &.active {
-      opacity: 0.5;
-    }
-  }
-
-  @include respond(phone) {
-    display: none;
-  }
-}

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -14,7 +14,31 @@ const PLAYLISTS_API_URL = import.meta.env.VITE_PLAYLISTS_API_URL || 'https://3sp
 const TRENDING_SORTED_URL = import.meta.env.VITE_TRENDING_SORTED_URL || 'https://tags.3speak.tv/feeds/trendingSorted';
 const FOLLOW_FEED_URL = import.meta.env.VITE_FOLLOW_FEED_URL || 'https://tags.3speak.tv/feed';
 
-const EDITOR_URL = import.meta.env.VITE_EDITOR_URL || 'https://editor.3speak.tv';
+// Editor URLs — comma-separated list; a random reachable one is selected at runtime
+const EDITOR_URLS = (import.meta.env.VITE_EDITOR_URLS || import.meta.env.VITE_EDITOR_URL || 'https://editor.3speak.tv')
+  .split(',')
+  .map(u => u.trim())
+  .filter(Boolean);
+
+/**
+ * Pick a random reachable editor URL from the configured list.
+ * Shuffles the list, then HEAD-requests each until one responds non-404.
+ * Returns the first working URL, or null if none are reachable.
+ */
+async function getEditorUrl() {
+  const shuffled = [...EDITOR_URLS].sort(() => Math.random() - 0.5);
+  for (const url of shuffled) {
+    try {
+      const res = await fetch(url, { method: 'HEAD', mode: 'no-cors', cache: 'no-store' });
+      // mode: 'no-cors' returns opaque response (status 0) which is fine —
+      // it means the server responded. A network error would throw instead.
+      return url;
+    } catch {
+      // Network error — server unreachable, try next
+    }
+  }
+  return null;
+}
 
 // Feature flags
 const FEATURE_EDITOR = import.meta.env.VITE_FEATURE_EDITOR === 'true';
@@ -23,6 +47,9 @@ const FEATURE_EDITOR = import.meta.env.VITE_FEATURE_EDITOR === 'true';
 const EMBED_UPLOAD_URL = import.meta.env.VITE_EMBED_UPLOAD_URL || 'https://embed.3speak.tv/uploads';
 const EMBED_API_URL = import.meta.env.VITE_EMBED_API_URL || 'https://embed.3speak.tv';
 const EMBED_API_KEY = import.meta.env.VITE_EMBED_API_KEY || '';
+
+// Translation API (LibreTranslate)
+const TRANSLATE_API_URL = import.meta.env.VITE_TRANSLATE_API_URL || 'https://3speak-translator.okinoko.io';
 
 // Watch history threshold - number of days to show unwatched indicator
 const WATCH_HISTORY_THRESHOLD_DAYS = parseInt(import.meta.env.VITE_WATCH_HISTORY_THRESHOLD_DAYS || '14', 10);
@@ -50,8 +77,10 @@ export {
   EMBED_UPLOAD_URL,
   EMBED_API_URL,
   EMBED_API_KEY,
+  TRANSLATE_API_URL,
   TRENDING_SORTED_URL,
   FOLLOW_FEED_URL,
-  EDITOR_URL,
+  EDITOR_URLS,
+  getEditorUrl,
   FEATURE_EDITOR,
 };

--- a/src/utils/translate.js
+++ b/src/utils/translate.js
@@ -1,0 +1,92 @@
+import axios from 'axios';
+import { TRANSLATE_API_URL } from './config';
+
+const STORAGE_KEY = '3speak-translate-lang';
+
+export const SUPPORTED_LANGUAGES = [
+  { code: 'en', name: 'English', native: 'English' },
+  { code: 'zh', name: 'Chinese', native: '中文' },
+  { code: 'hi', name: 'Hindi', native: 'हिन्दी' },
+  { code: 'es', name: 'Spanish', native: 'Español' },
+  { code: 'fr', name: 'French', native: 'Français' },
+  { code: 'ar', name: 'Arabic', native: 'العربية' },
+  { code: 'bn', name: 'Bengali', native: 'বাংলা' },
+  { code: 'pt', name: 'Portuguese', native: 'Português' },
+  { code: 'ru', name: 'Russian', native: 'Русский' },
+  { code: 'ja', name: 'Japanese', native: '日本語' },
+  { code: 'de', name: 'German', native: 'Deutsch' },
+  { code: 'ko', name: 'Korean', native: '한국어' },
+  { code: 'it', name: 'Italian', native: 'Italiano' },
+  { code: 'nl', name: 'Dutch', native: 'Nederlands' },
+  { code: 'pl', name: 'Polish', native: 'Polski' },
+  { code: 'tr', name: 'Turkish', native: 'Türkçe' },
+  { code: 'vi', name: 'Vietnamese', native: 'Tiếng Việt' },
+  { code: 'th', name: 'Thai', native: 'ไทย' },
+  { code: 'id', name: 'Indonesian', native: 'Bahasa Indonesia' },
+  { code: 'uk', name: 'Ukrainian', native: 'Українська' },
+  { code: 'sv', name: 'Swedish', native: 'Svenska' },
+  { code: 'cs', name: 'Czech', native: 'Čeština' },
+  { code: 'el', name: 'Greek', native: 'Ελληνικά' },
+  { code: 'hu', name: 'Hungarian', native: 'Magyar' },
+  { code: 'fi', name: 'Finnish', native: 'Suomi' },
+  { code: 'da', name: 'Danish', native: 'Dansk' },
+  { code: 'ro', name: 'Romanian', native: 'Română' },
+  { code: 'he', name: 'Hebrew', native: 'עברית' },
+  { code: 'fa', name: 'Persian', native: 'فارسی' },
+  { code: 'tl', name: 'Tagalog', native: 'Tagalog' },
+  { code: 'ms', name: 'Malay', native: 'Bahasa Melayu' },
+  { code: 'bg', name: 'Bulgarian', native: 'Български' },
+  { code: 'nb', name: 'Norwegian', native: 'Norsk' },
+  { code: 'ur', name: 'Urdu', native: 'اردو' },
+];
+
+export function getTargetLanguage() {
+  return localStorage.getItem(STORAGE_KEY) || 'en';
+}
+
+export function setTargetLanguage(code) {
+  localStorage.setItem(STORAGE_KEY, code);
+}
+
+function stripMarkdownAndHtml(text) {
+  let s = text;
+  // Remove "replied to [timestamp](link) on [host](url)" footers
+  s = s.replace(/\n?<br\s*\/?>\s*<sup>\s*replied to.*?<\/sup>/gi, '');
+  s = s.replace(/\n?\*?\*?replied to \[.*?\]\([^)]*\).*$/gim, '');
+  // Remove HTML tags
+  s = s.replace(/<[^>]+>/g, '');
+  // Markdown images ![alt](url)
+  s = s.replace(/!\[[^\]]*\]\([^)]*\)/g, '');
+  // Markdown links [text](url) → text
+  s = s.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1');
+  // Fenced code blocks
+  s = s.replace(/```[\s\S]*?```/g, '');
+  // Inline code
+  s = s.replace(/`([^`]*)`/g, '$1');
+  // Bold/italic markers
+  s = s.replace(/(\*{1,3}|_{1,3})(.*?)\1/g, '$2');
+  // Headings
+  s = s.replace(/^#{1,6}\s+/gm, '');
+  // Blockquotes
+  s = s.replace(/^>\s?/gm, '');
+  // Horizontal rules
+  s = s.replace(/^[-*_]{3,}\s*$/gm, '');
+  // List markers
+  s = s.replace(/^[\s]*[-*+]\s+/gm, '');
+  s = s.replace(/^[\s]*\d+\.\s+/gm, '');
+  // Collapse multiple newlines / whitespace
+  s = s.replace(/\n{3,}/g, '\n\n').trim();
+  return s;
+}
+
+export async function translateText(text, target, source = 'auto') {
+  const cleaned = stripMarkdownAndHtml(text);
+  if (!cleaned) return '';
+  const { data } = await axios.post(`${TRANSLATE_API_URL}/translate`, {
+    q: cleaned,
+    source,
+    target,
+    format: 'text',
+  });
+  return data.translatedText;
+}


### PR DESCRIPTION
Features:
- Add comment translation via LibreTranslate API with language picker dropdown (portal-based, auto-flip, scroll-isolated, preselected language on top), shared across watch page, shorts, and reactions panel
- Add autoplay-next video control: persisted toggle in localStorage, auto-navigates to next unwatched recommended video on end, skips already-watched videos via backend watch history API
- Add end-of-video overlay with replay button and top 5 unwatched recommendation cards (staggered fade/zoom animation)
- Add ambient glow effect on watch page and shorts
- Add multi-URL fallback and health checking for video editor iframe

Bugfixes:
- Fix browser autoplay blocked on first video load (detect NotAllowedError, show play button overlay)
- Fix shorts play/pause not working when comment panel is open
- Fix vote popup clicks intercepted by video player overlay
- Fix glow effect z-index too high on shorts
- Change remix button icon from Tornado to WandSparkles