### PR TITLE
Add embed studio, speed controls, feed endpoint fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,10 @@ VITE_FEED_URL=
 # Views tracking API endpoint
 VITE_VIEWS_URL=
 
+# My Videos API endpoint (profile page, studio drafts)
+# Default: https://views.3speak.tv
+VITE_MY_VIDEOS_URL=
+
 # 3Speak tag feed URL
 VITE_THREESPEAK_TAG_FEED_URL=
 
@@ -82,6 +86,14 @@ VITE_EMBED_API_KEY=
 # Shorts & Trending API Configuration
 # ===========================================
 
+# New content feed API endpoint
+# Default: https://tags.3speak.tv/feeds/new
+VITE_NEW_CONTENT_URL=
+
+# First uploads feed API endpoint
+# Default: https://tags.3speak.tv/feeds/firstUploads
+VITE_FIRST_UPLOADS_URL=
+
 # Trending sorted API endpoint
 # Default: https://tags.3speak.tv/feeds/trendingSorted
 VITE_TRENDING_SORTED_URL=
@@ -102,7 +114,7 @@ VITE_USER_SHORTS_API_URL=
 # 3Speak Video Editor
 # ===========================================
 
-# Video editor iframe URL
+# Video editor iframe URLs (comma-separated, a random working one will be picked)
 # Use http://localhost:9091 for local development
 # Use https://editor.3speak.tv for production
 VITE_EDITOR_URLS=
@@ -131,17 +143,8 @@ VITE_TRANSLATE_API_URL=
 VITE_WATCH_HISTORY_THRESHOLD_DAYS=14
 
 # ===========================================
-# Hive Image Upload (for editor)
-# ===========================================
-
-# Hive account for image uploads (used by editor's image uploader)
-# WARNING: Be careful with posting keys!
-VITE_HIVE_USER=
-VITE_HIVE_POSTING_KEY=
-
-# ===========================================
 # HiveSigner Configuration
 # ===========================================
 
 # HiveSigner app account name
-VITE_HIVESIGNER_APP=threes
+VITE_HIVESIGNER_APP=threespeak

--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -79,11 +79,12 @@ define(['./workbox-96fc63c4'], (function (workbox) { 'use strict';
    */
   workbox.precacheAndRoute([{
     "url": "/index.html",
-    "revision": "0.5b2kua321co"
+    "revision": "0.eopspov658g"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("/index.html"), {
-    allowlist: [/^\/$/]
+    allowlist: [/^\/$/],
+    denylist: [/^\/hivesigner\.html/]
   }));
   workbox.registerRoute(/\.(?:js|css|woff2?)$/i, new workbox.StaleWhileRevalidate({
     "cacheName": "static-assets",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@hiveio/dhive": "^1.3.2",
         "@hiveio/hive-js": "^2.0.8",
         "@jwplayer/jwplayer-react": "^1.1.3",
-        "@mantequilla-soft/3speak-player": "^0.2.1",
+        "@mantequilla-soft/3speak-player": "^0.3.0",
         "@rajesh896/video-thumbnails-generator": "^2.3.9",
         "@reduxjs/toolkit": "^2.6.1",
         "@snapie/renderer": "^0.1.1",
@@ -3693,9 +3693,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@mantequilla-soft/3speak-player": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@mantequilla-soft/3speak-player/-/3speak-player-0.2.1.tgz",
-      "integrity": "sha512-yQtgexGUGzxZ7Yd3y8Xu0e2voKRVtWb/wUw+Zp8vvC1NCRPXWts5xoB6YZveNAMOZgJt9Z57S6R9ez0n6OPYJw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mantequilla-soft/3speak-player/-/3speak-player-0.3.0.tgz",
+      "integrity": "sha512-ifqk+Fm4E87vBTtnMYtoq9QFVnsNF6mDuebcd+KLFVQrBT9Y9SQ4gcEo5e8oU0m6YsZ28MHRRJ33diuik2uVCQ==",
       "license": "MIT",
       "dependencies": {
         "hls.js": "^1.5.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@hiveio/dhive": "^1.3.2",
     "@hiveio/hive-js": "^2.0.8",
     "@jwplayer/jwplayer-react": "^1.1.3",
-    "@mantequilla-soft/3speak-player": "^0.2.1",
+    "@mantequilla-soft/3speak-player": "^0.3.0",
     "@rajesh896/video-thumbnails-generator": "^2.3.9",
     "@reduxjs/toolkit": "^2.6.1",
     "@snapie/renderer": "^0.1.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -56,7 +56,14 @@ import HiveImageUploader from "./page/HiveImageUploader";
 import PlaylistView from "./page/PlaylistView";
 import WatchedView from "./page/WatchedView";
 import { LegacyUploadProvider } from "./context/LegacyUploadContext";
+import { EmbedUploadProvider } from "./context/EmbedUploadContext";
 import { HiveAuthProvider } from "./context/HiveAuthContext";
+
+// Embed studio pages
+import EmbedStudioPage from "./components/embed-studio/EmbedStudioPage";
+import EmbedThumbnail from "./components/embed-studio/EmbedThumbnail";
+import EmbedDetails from "./components/embed-studio/EmbedDetails";
+import EmbedPreview from "./components/embed-studio/EmbedPreview";
 import { useAioha } from "@aioha/react-ui";
 import LoginModal from "./components/LoginModal/LoginModal";
 import { KeyTypes } from "@aioha/aioha";
@@ -234,6 +241,7 @@ function App() {
   return (
     <HiveAuthProvider>
     <LegacyUploadProvider>
+    <EmbedUploadProvider>
     <div onClick={()=> {setGlobalCloseRender(true)}}>
       <Toaster richColors position="top-right" />
       <ShortsPreloader />
@@ -262,6 +270,11 @@ function App() {
             <Route path="/studio/thumbnail" element={<Thumbnail />} />
             <Route path="/studio/details" element={<Details />} />
             <Route path="/studio/preview" element={<Preview />} />
+            {/* Embed studio (uses embed.okinoko.io upload service) */}
+            <Route path="/embed-studio" element={<EmbedStudioPage />} />
+            <Route path="/embed-studio/thumbnail" element={<EmbedThumbnail />} />
+            <Route path="/embed-studio/details" element={<EmbedDetails />} />
+            <Route path="/embed-studio/preview" element={<EmbedPreview />} />
             {/* <Route path="/studio2" element={<StudioPage2 />} /> */}
             <Route path="/draft" element={<DraftStudio />} />
             <Route path="/editvideo/:d" element={<EditVideo />} />
@@ -302,6 +315,7 @@ function App() {
       </div>
     </div>
 
+    </EmbedUploadProvider>
     </LegacyUploadProvider>
     </HiveAuthProvider>
   );

--- a/src/components/ReactVideoModal/ReactVideoModal.jsx
+++ b/src/components/ReactVideoModal/ReactVideoModal.jsx
@@ -2,7 +2,7 @@ import { useState, useRef, useCallback, useEffect } from 'react';
 import { MdUploadFile, MdVideocam, MdStop, MdFiberManualRecord } from 'react-icons/md';
 import * as tus from 'tus-js-client';
 import { toast } from 'sonner';
-import { EMBED_UPLOAD_URL, EMBED_API_KEY } from '../../utils/config';
+import { EMBED_UPLOAD_URL, EMBED_API_URL, EMBED_API_KEY } from '../../utils/config';
 import { commentWithAioha } from '../../hive-api/aioha';
 import { useAppStore } from '../../lib/store';
 import './ReactVideoModal.scss';
@@ -270,6 +270,31 @@ function ReactVideoTab({ author, permlink, currentTime, formatTime, onPosted, on
       );
 
       if (result.success) {
+        // Link the embed video to the Hive post
+        try {
+          // Extract embed permlink from embedUrl (format: .../embed?v=owner/permlink)
+          const vParam = new URL(embedUrl).searchParams.get('v');
+          const embedPermlink = vParam ? vParam.split('/').pop() : null;
+          if (embedPermlink && EMBED_API_URL) {
+            await fetch(`${EMBED_API_URL}/video/${embedPermlink}/hive`, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                ...(EMBED_API_KEY ? { 'X-API-Key': EMBED_API_KEY } : {}),
+              },
+              body: JSON.stringify({
+                hive_author: user,
+                hive_permlink: newPermlink,
+                hive_title: '',
+                hive_body: commentBody,
+                hive_tags: ['3speak', 'reaction'],
+              }),
+            });
+          }
+        } catch (linkErr) {
+          console.warn('Failed to link embed video to Hive post:', linkErr);
+        }
+
         toast.success('Video reaction posted!');
         setStatusText('Done!');
         if (onPosted) onPosted();

--- a/src/components/Userprofilepage/UserProfilePage.jsx
+++ b/src/components/Userprofilepage/UserProfilePage.jsx
@@ -8,7 +8,7 @@ import { Quantum } from 'ldrs/react'
 import 'ldrs/react/Quantum.css'
 import { useInfiniteQuery, useQueryClient as useReactQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
-import { VIEWS_URL } from '../../utils/config';
+import { MY_VIDEOS_URL } from '../../utils/config';
 import Card3 from '../Cards/Card3';
 import { IoMdShare, IoMdAdd } from 'react-icons/io';
 import { IoLogoRss } from 'react-icons/io5';
@@ -96,7 +96,7 @@ function UserProfilePage() {
  const LIMIT = 20;
 
 const fetchVideos = async ({ pageParam = 0 }) => {
-  const url = `${VIEWS_URL}/api/my-videos?username=${user}&limit=${LIMIT}&offset=${pageParam}&status=published&sort=newest`;
+  const url = `${MY_VIDEOS_URL}/api/my-videos?username=${user}&limit=${LIMIT}&offset=${pageParam}&status=published&sort=newest`;
 
   const res = await axios.get(url);
   return res.data?.data?.videos || [];

--- a/src/components/VideoControls/VideoControls.jsx
+++ b/src/components/VideoControls/VideoControls.jsx
@@ -74,12 +74,17 @@ function VideoControls({
   subtitleLoading,
   subtitleStyle,
   onSubtitleStyleChange,
+  playbackRate,
+  onPlaybackRateChange,
 }) {
   const resolvedMarkers = markers || [];
 
   const [hovering, setHovering] = useState(false);
   const [qualityMenuOpen, setQualityMenuOpen] = useState(false);
   const qualityMenuRef = useRef(null);
+  const [speedMenuOpen, setSpeedMenuOpen] = useState(false);
+  const speedMenuRef = useRef(null);
+  const speedPortalRef = useRef(null);
   const [subtitleMenuOpen, setSubtitleMenuOpen] = useState(false);
   const subtitleMenuRef = useRef(null);
   const isTouchDevice = typeof window !== 'undefined' && 'ontouchstart' in window;
@@ -202,6 +207,20 @@ function VideoControls({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [qualityMenuOpen]);
 
+  // Close speed menu when clicking outside
+  useEffect(() => {
+    if (!speedMenuOpen) return;
+    const handleClickOutside = (e) => {
+      const inWrap = speedMenuRef.current?.contains(e.target);
+      const inPortal = speedPortalRef.current?.contains(e.target);
+      if (!inWrap && !inPortal) {
+        setSpeedMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [speedMenuOpen]);
+
   // Close subtitle menu when clicking outside
   useEffect(() => {
     if (!subtitleMenuOpen) return;
@@ -234,6 +253,7 @@ function VideoControls({
 
   const subtitlePortalStyle = subtitleMenuOpen ? getPortalStyle(subtitleMenuRef) : null;
   const qualityPortalStyle = qualityMenuOpen ? getPortalStyle(qualityMenuRef) : null;
+  const speedPortalStyle = speedMenuOpen ? getPortalStyle(speedMenuRef) : null;
 
   const handleMarkerClick = useCallback((e, time, index) => {
     e.stopPropagation();
@@ -493,6 +513,36 @@ function VideoControls({
                       </div>
                     </div>
                   )}
+                </div>
+                </PortalIf>
+              )}
+            </div>
+          )}
+          {onPlaybackRateChange && (
+            <div className="vc-speed-wrap" ref={speedMenuRef}>
+              <button
+                className={`vc-btn vc-btn--speed${playbackRate !== 1 ? ' active' : ''}`}
+                onClick={() => { setSpeedMenuOpen(o => !o); setQualityMenuOpen(false); setSubtitleMenuOpen(false); }}
+                title="Playback speed"
+              >
+                {playbackRate !== 1 ? `${playbackRate}x` : '1x'}
+              </button>
+              {speedMenuOpen && (
+                <PortalIf condition={!!speedPortalStyle}>
+                <div
+                  className="vc-speed-menu"
+                  ref={speedPortalStyle ? speedPortalRef : undefined}
+                  style={speedPortalStyle || undefined}
+                >
+                  {[0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2].map((rate) => (
+                    <button
+                      key={rate}
+                      className={`vc-speed-item${playbackRate === rate ? ' active' : ''}`}
+                      onClick={() => { onPlaybackRateChange(rate); setSpeedMenuOpen(false); }}
+                    >
+                      {rate === 1 ? 'Normal' : `${rate}x`}
+                    </button>
+                  ))}
                 </div>
                 </PortalIf>
               )}

--- a/src/components/VideoControls/VideoControls.scss
+++ b/src/components/VideoControls/VideoControls.scss
@@ -370,6 +370,59 @@
   }
 }
 
+// Speed picker — mirrors quality picker
+.vc-speed-wrap {
+  position: relative;
+}
+
+.vc-btn--speed {
+  font-size: 11px;
+  font-weight: 600;
+  min-width: 28px;
+  letter-spacing: -0.02em;
+
+  &.active {
+    color: var(--accent-primary, #e53935);
+  }
+}
+
+.vc-speed-menu {
+  position: absolute;
+  bottom: 100%;
+  right: 0;
+  margin-bottom: 6px;
+  background: rgba(20, 20, 20, 0.95);
+  border-radius: 6px;
+  padding: 4px 0;
+  min-width: 100px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  z-index: 20;
+}
+
+.vc-speed-item {
+  display: block;
+  width: 100%;
+  padding: 6px 14px;
+  border: none;
+  background: none;
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 12px;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+  }
+
+  &.active {
+    color: var(--accent-primary, #e53935);
+    font-weight: 700;
+  }
+}
+
 // Subtitle picker — mirrors quality picker
 .vc-subtitle-wrap {
   position: relative;
@@ -698,9 +751,10 @@
       }
     }
 
-    // Subtitle & quality menus — open downward on mobile
+    // Subtitle, quality & speed menus — open downward on mobile
     .vc-subtitle-menu,
-    .vc-quality-menu {
+    .vc-quality-menu,
+    .vc-speed-menu {
       bottom: auto;
       top: 100%;
       margin-bottom: 0;

--- a/src/components/embed-studio/EmbedDetails.jsx
+++ b/src/components/embed-studio/EmbedDetails.jsx
@@ -1,0 +1,250 @@
+import React, { useEffect } from 'react'
+import { toast } from 'sonner'
+import { StepProgress } from '../legacy-studio/StepProgress';
+import { IoIosArrowDropdownCircle } from 'react-icons/io';
+import { MdPeopleAlt } from 'react-icons/md';
+import CommunityModal from "../modal/Community_modal";
+import Beneficiary_modal from '../modal/Beneficiary_modal';
+import { Navigate } from 'react-router-dom';
+import { useEmbedUpload } from '../../context/EmbedUploadContext';
+import MarkdownComposer from '../studio/MarkdownComposer';
+import { getMinMaxDates } from '../../utils/schedulingHelpers';
+
+function EmbedDetails() {
+    const {
+        title, setTitle,
+        description, setDescription,
+        tagsInputValue, setTagsInputValue,
+        tagsPreview, setTagsPreview,
+        community, setCommunity, setBeneficiaries,
+        SetDeclineRewards,
+        setRewardPowerup,
+        communitiesData,
+        navigate,
+        BeneficiaryList, setBeneficiaryList,
+        list, setList,
+        remaingPercent, setRemaingPercent,
+        step, setStep,
+        isOpen, setIsOpen,
+        benficaryOpen, setBeneficiaryOpen,
+        selectedThumbnail,
+        isScheduled, setIsScheduled,
+        scheduleDateTime, setScheduleDateTime
+      } = useEmbedUpload();
+
+
+  useEffect(() => {
+    setStep(3)
+  }, [])
+
+  if (!selectedThumbnail) {
+    return <Navigate to="/embed-studio" replace />;
+  }
+
+    const closeCommunityModal = () => {
+        setIsOpen(false);
+    };
+
+    const toggleBeneficiaryModal = () => {
+        setBeneficiaryOpen((prev) => !prev)
+    }
+    const openCommunityModal = () => {
+        setIsOpen(true);
+    };
+
+    const handleSelect = (e) => {
+        const value = e.target.value;
+        if (value === "powerup") {
+            setRewardPowerup(true)
+            SetDeclineRewards(false)
+        } else if (value === "decline") {
+            SetDeclineRewards(true)
+            setRewardPowerup(false)
+        } else {
+            SetDeclineRewards(false)
+            setRewardPowerup(false)
+        }
+    }
+
+  const process = () => {
+    if (!title?.trim()) {
+      toast.error("Title is required");
+      return;
+    }
+
+    if (!description?.trim()) {
+      toast.error("Description is required");
+      return;
+    }
+
+    if (!tagsPreview || tagsPreview.length === 0) {
+      toast.error("Please add at least one tag");
+      return;
+    }
+
+    navigate("/embed-studio/preview");
+    setStep(4);
+  };
+
+
+const handleTagChange = (e) => {
+  const value = e.target.value.toLowerCase();
+
+  const tags = value
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+
+  const uniqueTags = [...new Set(tags)];
+
+  if (uniqueTags.length > 10) {
+    toast.error("You can add a maximum of 10 tags");
+    return;
+  }
+
+  setTagsInputValue(value);
+  setTagsPreview(uniqueTags);
+};
+
+  return (
+    <>
+    <div className="studio-main-container">
+      <div className="studio-page-header">
+        <h1>Upload Video</h1>
+        <p>Follow the steps below to upload and publish your video</p>
+      </div>
+      <StepProgress step={step} />
+      <div className="studio-page-content">
+
+        <div className="video-detail-wrap">
+        <div className="video-items">
+        <div className="input-group">
+          <label htmlFor="">Title</label>
+          <input type="text" value={title} onChange={(e) => setTitle(e.target.value)} />
+        </div>
+        <div className="input-group">
+          <label htmlFor="">Description</label>
+          <div className="wrap-dec">
+          <MarkdownComposer value={description} onChange={setDescription} placeholder="Write your video description here... Supports markdown formatting!" />
+          </div>
+        </div>
+
+        <div className="input-group">
+          <label htmlFor="">Tag</label>
+          <input type="text" value={tagsInputValue} onChange={handleTagChange}  />
+
+          <div className="wrap">
+          <span>Separate multiple tags with </span> <span>Space</span>
+          </div>
+          {/* Show the tags */}
+        <div className="preview-tags">
+        {tagsPreview &&<span> {tagsPreview.map((item, index) => (
+      <span className="item" key={index} style={{ marginRight: '8px' }}>
+        {item}
+      </span>
+    ))}</span>}
+        </div>
+        </div>
+        <div className="community-box-wrap">
+        <div className="community-wrap" onClick={openCommunityModal}>
+            {community ? <span>{community === "hive-181335" ? <div className="wrap"><img src={`https://images.hive.blog/u/hive-181335/avatar`} alt="" /><span></span>Threespeak</div> : <div className="wrap"><img src={`https://images.hive.blog/u/${community.name}/avatar`} alt="" /><span></span>{community.title}</div> }</span> : <span> Select Community </span> }
+            <IoIosArrowDropdownCircle size={16} />
+          </div>
+          <span>Select Community </span>
+          </div>
+
+        <div className="advance-option">
+          <div className="beneficiary-wrap mb">
+           <div className="wrap">
+           <span>Rewards Distribution</span>
+           <span>Optional "Hive Reward Pool" distribution method.</span>
+           </div>
+           <div className="select-wrap">
+            <select name="" id="" onChange={handleSelect}>
+              <option value="default"> Default 50% 50% </option>
+              <option value="powerup">Power up 100%</option>
+              <option value="decline">Decline Payout</option>
+            </select>
+           </div>
+          </div>
+          <div className="beneficiary-wrap">
+           <div className="wrap">
+           <span>Beneficiaries</span>
+           <span>Other accounts that should get a % of the post rewards.</span>
+           </div>
+           <div className="bene-btn-wrap" onClick={toggleBeneficiaryModal}>
+            {list.length > 0 && <spa>{list.length}</spa>}
+            <span> BENEFICIARIES</span>
+            <MdPeopleAlt />
+           </div>
+          </div>
+        </div>
+
+        <div className="scheduling-wrap">
+          <div className="scheduling-header">
+            <label className="schedule-checkbox-label">
+              <input
+                type="checkbox"
+                checked={isScheduled}
+                onChange={(e) => {
+                  setIsScheduled(e.target.checked);
+                  if (!e.target.checked) {
+                    setScheduleDateTime('');
+                  }
+                }}
+              />
+              <span>Schedule for Later</span>
+            </label>
+            <small>Schedule this post to be published at a specific date and time</small>
+          </div>
+
+          {isScheduled && (
+            <div className="schedule-datetime-group">
+              <label htmlFor="schedule-datetime">Publish Date & Time</label>
+              <input
+                type="datetime-local"
+                id="schedule-datetime"
+                value={scheduleDateTime}
+                onChange={(e) => setScheduleDateTime(e.target.value)}
+                min={getMinMaxDates().minFormatted}
+                max={getMinMaxDates().maxFormatted}
+              />
+              <small>Must be at least 1 hour in future, maximum 90 days</small>
+            </div>
+          )}
+        </div>
+
+        <div className="submit-btn-wrap">
+          <button
+            onClick={() => {
+              process();
+            }}
+          >
+            Proceed
+          </button>
+        </div>
+
+        </div>
+
+      </div>
+
+
+        </div>
+    </div>
+          {isOpen && <CommunityModal isOpen={isOpen} data={communitiesData} close={closeCommunityModal} setCommunity={setCommunity} />}
+          {benficaryOpen && <Beneficiary_modal
+              close={toggleBeneficiaryModal}
+              isOpen={benficaryOpen}
+              setBeneficiaries={setBeneficiaries}
+              setBeneficiaryList={setBeneficiaryList}
+              setList={setList}
+              list={list}
+              setRemaingPercent={setRemaingPercent}
+              remaingPercent={remaingPercent}
+          />}
+
+      </>
+  )
+}
+
+export default EmbedDetails

--- a/src/components/embed-studio/EmbedPreview.jsx
+++ b/src/components/embed-studio/EmbedPreview.jsx
@@ -1,0 +1,176 @@
+import React from "react";
+import "../legacy-studio/Preview.scss";
+import { Navigate, useNavigate } from "react-router-dom";
+import { CheckCircle } from "lucide-react";
+import VideoPreview from "../studio/VideoPreview";
+import { StepProgress } from "../legacy-studio/StepProgress";
+import { useEmbedUpload } from "../../context/EmbedUploadContext";
+import VideoUploadStatus from "../legacy-studio/VideoUploadStatus";
+import EditorPreview from "../Editor/EditorPreview";
+
+function EmbedPreview() {
+  const {
+    step,
+    title,
+    description,
+    tagsPreview,
+    videoFile,
+    prevVideoFile,
+    selectedThumbnail,
+    uploading, setUploading,
+    completed,
+    uploadProgress,
+    statusText,
+    statusMessages,
+    embedUrl,
+    publishToEmbed,
+    resetUploadState,
+    user,
+  } = useEmbedUpload();
+
+  const navigate = useNavigate();
+
+  if (!description || !title) {
+    return <Navigate to="/embed-studio" replace />;
+  }
+
+  const handlePostVideo = () => {
+    publishToEmbed();
+  };
+
+  return (
+    <>
+      {/* PREVIEW & PUBLISH BUTTON */}
+      {!uploading && !completed && (
+        <div className="studio-main-container">
+          <div className="studio-page-header">
+            <h1>Upload Video</h1>
+            <p>Follow the steps below to upload and publish your video</p>
+          </div>
+
+          <StepProgress step={step} />
+
+          <div className="studio-page-content">
+            <div className="preview-container">
+              <div className="preview">
+                <h3>Preview</h3>
+
+                {title && (
+                  <div className="preview-section">
+                    <label className="preview-label">Title</label>
+                    <div className="preview-title">{title}</div>
+                  </div>
+                )}
+
+                <div className="preview-section">
+                  <label className="preview-label">Description</label>
+                  <EditorPreview content={description} />
+                </div>
+
+                {prevVideoFile && (
+                  <div className="preview-section">
+                    <label className="preview-label">Video Preview</label>
+                    <div className="preview-video">
+                      <VideoPreview file={prevVideoFile} />
+                    </div>
+                  </div>
+                )}
+
+                {selectedThumbnail && (
+                  <div className="preview-section">
+                    <label className="preview-label">Thumbnail</label>
+                    <img
+                      className="preview-thumbnail"
+                      src={selectedThumbnail}
+                      alt="Thumbnail"
+                    />
+                  </div>
+                )}
+
+                {tagsPreview && (
+                  <div className="preview-section">
+                    <label className="preview-label">Tags</label>
+                    <div className="preview-tags">
+                      {tagsPreview.map((tag, index) => (
+                        <span className="tag-item" key={index}>
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="submit-btn-wrap">
+                <button
+                  className="edit-btn"
+                  onClick={() => navigate('/embed-studio/details')}
+                >
+                  Edit Post
+                </button>
+                <button onClick={handlePostVideo}>
+                  Post Video
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* STATUS CONTAINER — during upload & Hive posting */}
+      {uploading && (
+        <div className="status-container">
+          <VideoUploadStatus
+            statusMessages={statusMessages}
+            statusText={statusText}
+          />
+          {uploadProgress > 0 && uploadProgress < 100 && (
+            <div className="studio-main-container" style={{ marginTop: '1rem' }}>
+              <div className="progressbar-container">
+                <div className="content-wrap">
+                  <div className="wrap">
+                    <div className="wrap-top"><h3>Uploading Video</h3> <div>{uploadProgress}%</div></div>
+                    <div className="progress-bars">
+                      <div className="progress-bar-fill" style={{ width: `${uploadProgress}%` }} />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* COMPLETED */}
+      {completed && (
+        <div className="success-container">
+          <div className="success-box">
+            <div className="success-icon">
+              <CheckCircle size={34} strokeWidth={2} />
+            </div>
+            <h3>Upload Finished!</h3>
+            <p>Your video has been published on 3Speak.</p>
+            {embedUrl && (
+              <p style={{ fontSize: '0.85rem', color: '#666', wordBreak: 'break-all', marginTop: '0.5rem' }}>
+                Embed URL: {embedUrl}
+              </p>
+            )}
+            <button
+              onClick={() => {
+                navigate("/profile");
+                setTimeout(() => {
+                  resetUploadState();
+                }, 50);
+              }}
+              className="profile-btn"
+            >
+              Go To My Profile →
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+export default EmbedPreview;

--- a/src/components/embed-studio/EmbedStudioPage.jsx
+++ b/src/components/embed-studio/EmbedStudioPage.jsx
@@ -1,0 +1,99 @@
+import React, { useEffect } from "react";
+import "../legacy-studio/StudioPage.scss";
+import { StepProgress } from "../legacy-studio/StepProgress";
+import EmbedVideoUploadStep1 from "./EmbedVideoUploadStep1";
+import Auth_modal from "../modal/Auth_modal";
+import VerifyAuthModal from "../modal/VerifyAuthModal";
+import axios from "axios";
+import { has3SpeakPostAuth } from "../../utils/hiveUtils";
+import 'ldrs/react/LineSpinner.css'
+import { useEmbedUpload } from "../../context/EmbedUploadContext";
+import { HIVE_API_URL } from "../../utils/config";
+import { useNavigate } from "react-router-dom";
+import { useState } from "react";
+
+function EmbedStudioPage() {
+  const navigate = useNavigate();
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [isOpenAuth, setIsOpenAuth] = useState(false);
+
+  const {
+    user,
+    setCommunitiesData,
+    step, setStep,
+  } = useEmbedUpload();
+
+  const checkPostAuth = async (username) => {
+    if (!username) return;
+    const hasAuth = await has3SpeakPostAuth(username);
+    if (!hasAuth) {
+      setIsOpenAuth(true);
+    }
+  };
+
+  useEffect(() => {
+    setStep(1);
+  }, []);
+
+  useEffect(() => {
+    const fetchCommunities = async () => {
+      try {
+        const response = await axios.post(HIVE_API_URL, {
+          jsonrpc: "2.0",
+          method: "bridge.list_communities",
+          params: { last: "", limit: 100 },
+          id: 1,
+        });
+        setCommunitiesData(response.data.result || []);
+      } catch (error) {
+        console.error("Error fetching communities:", error);
+      }
+    };
+    fetchCommunities();
+  }, []);
+
+  useEffect(() => {
+    checkPostAuth(user);
+  }, []);
+
+  const handleAuthSuccess = () => {
+    setIsOpenAuth(false);
+  };
+
+  const toggleUploadModalAuth = async () => {
+    setIsOpenAuth(false);
+    setIsVerifying(true);
+    setTimeout(async () => {
+      try {
+        const hasAuth = await has3SpeakPostAuth(user);
+        setIsVerifying(false);
+        if (!hasAuth) {
+          navigate('/new');
+        }
+      } catch (error) {
+        console.error('Error checking auth:', error);
+        setIsVerifying(false);
+        navigate('/new');
+      }
+    }, 4000);
+  };
+
+  return (
+    <>
+      <div className="studio-main-container">
+        <div className="studio-page-header">
+          <h1>Upload Video</h1>
+          <p>Follow the steps below to upload and publish your video</p>
+        </div>
+        <StepProgress step={step} />
+        <div className="studio-page-content">
+          <EmbedVideoUploadStep1 />
+        </div>
+      </div>
+      {isOpenAuth && <Auth_modal isOpenAuth={isOpenAuth} closeAuth={toggleUploadModalAuth} onSuccess={handleAuthSuccess} />}
+      <VerifyAuthModal isOpen={isVerifying} />
+    </>
+  );
+}
+
+export default EmbedStudioPage;

--- a/src/components/embed-studio/EmbedThumbnail.jsx
+++ b/src/components/embed-studio/EmbedThumbnail.jsx
@@ -1,0 +1,209 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Upload, Check } from "lucide-react";
+import "../legacy-studio/VideoUploadStep2.scss";
+import { toast } from "sonner";
+import { TailChase } from "ldrs/react";
+import "ldrs/react/TailChase.css";
+import { StepProgress } from "../legacy-studio/StepProgress";
+import { Navigate, useNavigate } from "react-router-dom";
+import { useEmbedUpload } from "../../context/EmbedUploadContext";
+
+function EmbedThumbnail() {
+  const {
+    generatedThumbnail,
+    thumbnailFile,
+    setThumbnailFile,
+    setStep,
+    videoFile,
+    step,
+    selectedThumbnail,
+    setSelectedThumbnail,
+    selectedIndex,
+    setSelectedIndex,
+  } = useEmbedUpload();
+
+  const [customfile, setCustomFile] = useState([]);
+  const [customFiles, setCustomFiles] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const thumbnailInputRef = useRef(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    setStep(2);
+  }, []);
+
+  // Auto-select first generated thumbnail
+  useEffect(() => {
+    if (
+      generatedThumbnail.length > 0 &&
+      selectedIndex === null &&
+      customfile.length === 0
+    ) {
+      const first = generatedThumbnail[0];
+      setSelectedIndex(0);
+      setSelectedThumbnail(first);
+
+      const base64 = first;
+      const mime = base64.split(";")[0].split(":")[1];
+      const byteString = atob(base64.split(",")[1]);
+      const ab = new ArrayBuffer(byteString.length);
+      const ia = new Uint8Array(ab);
+      for (let i = 0; i < byteString.length; i++) {
+        ia[i] = byteString.charCodeAt(i);
+      }
+      const blob = new Blob([ab], { type: mime });
+      setThumbnailFile(blob);
+    }
+  }, [generatedThumbnail]);
+
+  // Auto-select newest uploaded thumbnail
+  useEffect(() => {
+    if (customfile.length > 0) {
+      const newestIndex = generatedThumbnail.length + (customfile.length - 1);
+      setSelectedIndex(newestIndex);
+      setSelectedThumbnail(customfile[customfile.length - 1]);
+      setThumbnailFile(customFiles[customFiles.length - 1]);
+    }
+  }, [customfile]);
+
+  if (!videoFile) {
+    return <Navigate to="/embed-studio" replace />;
+  }
+
+  const handleThumbnailUpload = (event) => {
+    const file = event.target.files[0];
+    if (file && file.type.startsWith("image/")) {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        const base64 = e.target?.result;
+        setCustomFile((prev) => [...prev, base64]);
+        setCustomFiles((prev) => [...prev, file]);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const allThumbnails = [...generatedThumbnail, ...customfile];
+
+  const uploadThumbnail = () => {
+    if (!selectedThumbnail || !thumbnailFile) {
+      toast.error("Please select a thumbnail first.");
+      return;
+    }
+
+    navigate("/embed-studio/details");
+    setStep(3);
+  };
+
+  return (
+    <>
+      <div className="studio-main-container">
+        <div className="studio-page-header">
+          <h1>Upload Video</h1>
+          <p>Follow the steps below to upload and publish your video</p>
+        </div>
+
+        <StepProgress step={step} />
+
+        <div className="studio-page-content">
+          <div className="upload-step">
+            <div className="upload-step__header">
+              <h2 className="upload-step__title">Choose Thumbnail</h2>
+              <p className="upload-step__subtitle">
+                Select a thumbnail for your video or upload your own
+              </p>
+            </div>
+
+            <div className="upload-step__content">
+              <div className="upload-step__actions">
+                <button
+                  onClick={uploadThumbnail}
+                  className="button button-primary"
+                >
+                  {loading ? (
+                    <TailChase size="20" speed="1.75" color="white" />
+                  ) : (
+                    "Proceed to Details"
+                  )}
+                </button>
+              </div>
+              <div className="thumbnail-grid">
+                {allThumbnails.map((thumbnail, index) => (
+                  <div
+                    key={index}
+                    className={`thumbnail-card ${
+                      selectedIndex === index ? "thumbnail-card--selected" : ""
+                    }`}
+                    onClick={() => {
+                      setSelectedIndex(index);
+                      setSelectedThumbnail(thumbnail);
+
+                      const customIndex = customfile.indexOf(thumbnail);
+                      if (customIndex !== -1) {
+                        setThumbnailFile(customFiles[customIndex]);
+                        return;
+                      }
+
+                      const base64 = thumbnail;
+                      const mime = base64.split(";")[0].split(":")[1];
+                      const byteString = atob(base64.split(",")[1]);
+                      const ab = new ArrayBuffer(byteString.length);
+                      const ia = new Uint8Array(ab);
+                      for (let i = 0; i < byteString.length; i++)
+                        ia[i] = byteString.charCodeAt(i);
+                      const blob = new Blob([ab], { type: mime });
+                      setThumbnailFile(blob);
+                    }}
+                  >
+                    <div className="content">
+                      <img
+                        src={thumbnail}
+                        alt={`Thumbnail ${index + 1}`}
+                        className="image"
+                      />
+                      {selectedIndex === index && (
+                        <div className="check">
+                          <Check className="w-4 h-4" />
+                        </div>
+                      )}
+                      {index >= generatedThumbnail.length && (
+                        <div className="badge">Custom</div>
+                      )}
+                    </div>
+                  </div>
+                ))}
+
+                <div className="thumbnail-upload">
+                  <div className="thumbnail-upload__content">
+                    <input
+                      type="file"
+                      accept="image/*"
+                      ref={thumbnailInputRef}
+                      onChange={handleThumbnailUpload}
+                      className="thumbnail-upload__input"
+                      id="embed-thumbnail-upload"
+                    />
+                    <label
+                      htmlFor="embed-thumbnail-upload"
+                      className="thumbnail-upload__content"
+                    >
+                      <div className="thumbnail-upload__icon">
+                        <Upload className="w-4 h-4" />
+                      </div>
+                      <span className="thumbnail-upload__label">
+                        Upload Custom
+                      </span>
+                    </label>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default EmbedThumbnail;

--- a/src/components/embed-studio/EmbedVideoUploadStep1.jsx
+++ b/src/components/embed-studio/EmbedVideoUploadStep1.jsx
@@ -1,0 +1,142 @@
+import React, { useRef, useState } from 'react'
+import { Upload } from "lucide-react";
+import "../legacy-studio/VideoUploadStep1.scss"
+import { generateVideoThumbnails } from "@rajesh896/video-thumbnails-generator";
+import { toast } from 'sonner'
+import Arrow from "./../../../public/images/arrow.png"
+import { useEmbedUpload } from '../../context/EmbedUploadContext';
+import { useNavigate } from 'react-router-dom';
+import { TailChase } from 'ldrs/react'
+import 'ldrs/react/TailChase.css'
+
+function EmbedVideoUploadStep1() {
+  const {
+    setVideoDuration,
+    videoFile,
+    setVideoFile,
+    setPrevVideoFile,
+    setGeneratedThumbnail,
+  } = useEmbedUpload()
+
+  const [loading, setLoading] = useState(false)
+  const navigate = useNavigate()
+
+  const videoInputRef = useRef(null);
+
+  const calculateVideoDuration = (file) => {
+    return new Promise((resolve) => {
+      const video = document.createElement("video");
+      video.preload = "metadata";
+
+      video.onloadedmetadata = () => {
+        window.URL.revokeObjectURL(video.src);
+        resolve(video.duration);
+      };
+
+      video.src = URL.createObjectURL(file);
+    });
+  };
+
+  const handleVideoSelect = async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+
+    if (!file.type.startsWith("video/")) {
+      toast.error("Please select a valid video file");
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      // Calculate duration
+      const duration = await calculateVideoDuration(file);
+
+      // Generate Thumbnails
+      const thumbs = await generateVideoThumbnails(file, 2, "url");
+      setGeneratedThumbnail(thumbs);
+
+      // Store video for next step
+      setVideoFile(file);
+      setPrevVideoFile(file);
+      setVideoDuration(duration);
+
+    } catch (err) {
+      console.error(err);
+      toast.error(err.message || "Failed to process video.");
+    }
+
+    setLoading(false);
+  };
+
+  const uploadVideo = () => {
+    if (!videoFile) {
+      toast.error("Please select a video file first.");
+      return;
+    }
+
+    navigate("/embed-studio/thumbnail");
+  };
+
+  return (
+    <div>
+      <div className="upload-step">
+
+        <div className="content">
+          <div className="file-upload">
+            <div className="content">
+              <div
+                className="icon"
+                onClick={() => videoInputRef.current?.click()}
+                style={{ cursor: 'pointer' }}
+                title="Click to select a video file"
+              >
+                <Upload className="w-8 h-8" />
+              </div>
+
+              {!videoFile && (
+                <div className="text">
+                  <h3 className="title">Choose a video file</h3>
+                  <p className="formats">
+                    Supports: MP4, AVI, MOV, WMV (Max size: 5GB)
+                  </p>
+                </div>
+              )}
+
+              {videoFile && (
+                <div className='isselected-wrap'>
+                  <span>Video Selected. Proceed to upload thumbnail</span>
+                  <img className="arrow-in" src={Arrow} alt="" />
+                </div>
+              )}
+
+              <input
+                type="file"
+                accept="video/mp4, video/x-m4v, video/*, .mkv, .flv, .mov, .avi, .wmv"
+                ref={videoInputRef}
+                onChange={handleVideoSelect}
+                className="input"
+                id="embed-video-upload"
+              />
+
+              {loading ? (
+                <TailChase size="30" speed="1.75" color="red" />
+              ) : !videoFile ? (
+                <label htmlFor="embed-video-upload" className="button">
+                  Browse Files
+                </label>
+              ) : (
+                <label onClick={uploadVideo} className="button">
+                  Proceed to Thumbnails
+                </label>
+              )}
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  );
+}
+
+export default EmbedVideoUploadStep1;

--- a/src/components/modal/EditorModal.jsx
+++ b/src/components/modal/EditorModal.jsx
@@ -1,15 +1,20 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { X, Loader2 } from 'lucide-react';
+import { generateVideoThumbnails } from '@rajesh896/video-thumbnails-generator';
 import { getEditorUrl } from '../../utils/config';
 import { useAppStore } from '../../lib/store';
+import { useEmbedUpload } from '../../context/EmbedUploadContext';
 import './EditorModal.scss';
 
-function EditorModal({ isOpen, onClose, videoUrl, videoName, videoType, clipStart, clipEnd }) {
+function EditorModal({ isOpen, onClose, videoUrl, videoName, videoType, clipStart, clipEnd, originalAuthor, originalPermlink }) {
+  const navigate = useNavigate();
+  const { setVideoFile, setPrevVideoFile, setGeneratedThumbnail, setVideoDuration, setOriginalAuthor, setOriginalPermlink } = useEmbedUpload();
   const iframeRef = useRef(null);
   const mediaLoadedRef = useRef(false);
   const [editorReady, setEditorReady] = useState(false);
   const { theme, getEffectiveTheme } = useAppStore();
-  const [renderStatus, setRenderStatus] = useState(null); // null | 'sending' | 'rendering' | 'complete' | 'error'
+  const [renderStatus, setRenderStatus] = useState(null); // null | 'sending' | 'rendering' | 'complete' | 'error' | 'preparing'
   const [renderProgress, setRenderProgress] = useState(0);
   const [renderedVideoUrl, setRenderedVideoUrl] = useState(null);
   const pollIntervalRef = useRef(null);
@@ -46,6 +51,8 @@ function EditorModal({ isOpen, onClose, videoUrl, videoName, videoType, clipStar
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'auto';
     }
     return () => {
       document.body.style.overflow = 'auto';
@@ -88,9 +95,14 @@ function EditorModal({ isOpen, onClose, videoUrl, videoName, videoType, clipStar
           // If we have a video to pre-load (remix mode), send it once
           if (videoUrl && !mediaLoadedRef.current) {
             mediaLoadedRef.current = true;
+            // Convert raw IPFS URLs to HLS playlist URLs for the editor
+            let editorUrl = videoUrl;
+            if (editorUrl.includes('/ipfs/') && !editorUrl.endsWith('.m3u8')) {
+              editorUrl = editorUrl.replace(/\/+$/, '') + '/480p/index.m3u8';
+            }
             const msg = {
               type: 'load-media',
-              url: videoUrl,
+              url: editorUrl,
               name: videoName || 'Short Video',
               mediaType: videoType || 'video'
             };
@@ -104,6 +116,10 @@ function EditorModal({ isOpen, onClose, videoUrl, videoName, videoType, clipStar
           handleRenderRequest(data.timeline);
           break;
 
+        case 'post-to-3speak':
+          handlePostTo3Speak(data.outputUrl);
+          break;
+
         case 'editor-closed':
           handleClose();
           break;
@@ -113,6 +129,45 @@ function EditorModal({ isOpen, onClose, videoUrl, videoName, videoType, clipStar
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
   }, [isOpen, resolvedUrl, videoUrl, videoName, videoType, clipStart, clipEnd, sendToEditor]);
+
+  // Prevent navigation away while the editor is open
+  useEffect(() => {
+    if (!isOpen || !editorReady) return;
+
+    // Block real page unloads (refresh, close tab)
+    const handleBeforeUnload = (e) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+
+    // Intercept internal link clicks (SPA navigation) in capture phase
+    const handleClick = (e) => {
+      const anchor = e.target.closest('a[href]');
+      if (!anchor) return;
+
+      const href = anchor.getAttribute('href');
+      // Only intercept internal SPA links
+      if (!href || href.startsWith('#') || href.startsWith('http') || href.startsWith('mailto:')) return;
+
+      const leave = window.confirm(
+        'The editor is still open. Leaving this page will close the editor and unsaved changes will be lost.\n\nOK = Close editor & leave\nCancel = Stay on this page'
+      );
+
+      if (!leave) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+      // If they confirm, let the click proceed — the component will unmount naturally
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    document.addEventListener('click', handleClick, true);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      document.removeEventListener('click', handleClick, true);
+    };
+  }, [isOpen, editorReady]);
 
   // Handle render request from editor
   const handleRenderRequest = async (timeline) => {
@@ -152,6 +207,78 @@ function EditorModal({ isOpen, onClose, videoUrl, videoName, videoType, clipStar
       console.error('[EditorModal] Render request error:', err);
       console.log('[EditorModal] Timeline state for future render:', JSON.stringify(timeline, null, 2));
       setRenderStatus('error');
+    }
+  };
+
+  // Handle "Post to 3Speak" from editor — fetch rendered video, navigate to embed-studio
+  const handlePostTo3Speak = async (outputUrl) => {
+    if (!outputUrl) return;
+
+    try {
+      setRenderStatus('preparing');
+      console.log('[EditorModal] Post to 3Speak: fetching', outputUrl);
+
+      // Fetch the rendered video as a blob
+      const res = await fetch(outputUrl);
+      if (!res.ok) throw new Error(`Failed to fetch rendered video: ${res.status}`);
+      const contentType = res.headers.get('content-type') || '';
+      if (contentType.startsWith('text/')) {
+        throw new Error(`Expected video file but got ${contentType}`);
+      }
+      const blob = await res.blob();
+      const file = new File([blob], 'rendered-video.mp4', { type: blob.type || 'video/mp4' });
+      console.log('[EditorModal] Post to 3Speak: fetched', file.size, 'bytes, type:', file.type);
+
+      // Calculate video duration
+      try {
+        const video = document.createElement('video');
+        video.preload = 'metadata';
+        const duration = await new Promise((resolve) => {
+          video.onloadedmetadata = () => {
+            URL.revokeObjectURL(video.src);
+            resolve(video.duration);
+          };
+          video.onerror = () => resolve(0);
+          video.src = URL.createObjectURL(file);
+        });
+        setVideoDuration(duration);
+      } catch { /* duration will be 0 */ }
+
+      // Generate thumbnails from the video file (with timeout to avoid hanging)
+      try {
+        const thumbs = await Promise.race([
+          generateVideoThumbnails(file, 2, 'url'),
+          new Promise((_, reject) => setTimeout(() => reject(new Error('Thumbnail timeout')), 10000))
+        ]);
+        setGeneratedThumbnail(thumbs);
+      } catch (thumbErr) {
+        console.warn('[EditorModal] Thumbnail generation failed, continuing without:', thumbErr);
+      }
+
+      // Force-close the editor without confirmation
+      setEditorReady(false);
+      setRenderStatus(null);
+      setRenderProgress(0);
+      setRenderedVideoUrl(null);
+      setResolvedUrl(null);
+      setResolveError(false);
+      mediaLoadedRef.current = false;
+      if (pollIntervalRef.current) clearInterval(pollIntervalRef.current);
+      onClose();
+
+      // Pre-set the file in embed context
+      setVideoFile(file);
+      setPrevVideoFile(file);
+
+      // Set original author/permlink for credit attribution
+      if (originalAuthor) setOriginalAuthor(originalAuthor);
+      if (originalPermlink) setOriginalPermlink(originalPermlink);
+
+      // Navigate to embed-studio thumbnail step (video uploads at publish time)
+      navigate('/embed-studio/thumbnail');
+    } catch (err) {
+      console.error('[EditorModal] Post to 3Speak failed:', err);
+      setRenderStatus('post-error');
     }
   };
 
@@ -213,14 +340,14 @@ function EditorModal({ isOpen, onClose, videoUrl, videoName, videoType, clipStar
 
   return (
     <div className="editor-modal">
-      <div className="editor-modal-overlay" onClick={handleClose}></div>
+      <div className="editor-modal-overlay"></div>
       <div className="editor-modal-content">
         <div className="editor-modal-body">
           {/* Show iframe only after a working URL is resolved */}
           {resolvedUrl && (
             <iframe
               ref={iframeRef}
-              src={resolvedUrl}
+              src={`${resolvedUrl}?compact=true`}
               className="editor-iframe"
               allow="cross-origin-isolated; camera; microphone"
               title="3Speak Video Editor"
@@ -270,9 +397,23 @@ function EditorModal({ isOpen, onClose, videoUrl, videoName, videoType, clipStar
                   </button>
                 </div>
               )}
+              {renderStatus === 'preparing' && (
+                <div className="render-status">
+                  <Loader2 size={32} className="spinner" />
+                  <span>Preparing video for upload...</span>
+                </div>
+              )}
               {renderStatus === 'error' && (
                 <div className="render-status render-error">
                   <span>Render service not available yet. Timeline data logged to console.</span>
+                  <button className="render-btn" onClick={() => setRenderStatus(null)}>
+                    Back to Editor
+                  </button>
+                </div>
+              )}
+              {renderStatus === 'post-error' && (
+                <div className="render-status render-error">
+                  <span>Failed to prepare video for upload. Please try downloading instead.</span>
                   <button className="render-btn" onClick={() => setRenderStatus(null)}>
                     Back to Editor
                   </button>

--- a/src/components/modal/EditorModal.scss
+++ b/src/components/modal/EditorModal.scss
@@ -17,10 +17,22 @@
 
 .editor-modal-content {
   position: absolute;
-  inset: 0;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 50%;
+  height: 90%;
   display: flex;
   flex-direction: column;
   z-index: 1;
+  border-radius: 12px;
+  overflow: hidden;
+
+  @media (max-width: 768px) {
+    width: 100%;
+    height: 100%;
+    border-radius: 0;
+  }
 }
 
 .editor-modal-header {

--- a/src/components/playVideo/PlayVideo.jsx
+++ b/src/components/playVideo/PlayVideo.jsx
@@ -364,12 +364,13 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
       toast.error('Could not resolve video URL for remix');
       return;
     }
+    if (videoControls?.onPause) videoControls.onPause();
     setEditorVideoUrl(videoUrlSelected);
     setEditorVideoName(`${author} - ${videoDetails?.title || permlink}`);
     setEditorClipStart(null);
     setEditorClipEnd(null);
     setShowEditorModal(true);
-  }, [videoUrlSelected, author, permlink, videoDetails?.title]);
+  }, [videoUrlSelected, author, permlink, videoDetails?.title, videoControls]);
 
   // Clip mode helpers
   const formatTime = (seconds) => {
@@ -418,13 +419,14 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
       toast.error('Could not resolve video URL');
       return;
     }
+    if (videoControls?.onPause) videoControls.onPause();
     setEditorVideoUrl(videoUrlSelected);
     setEditorVideoName(`${author} - ${videoDetails?.title || permlink} (clip)`);
     setEditorClipStart(clipStart);
     setEditorClipEnd(clipEnd);
     setShowEditorModal(true);
     setClipMode(false);
-  }, [videoUrlSelected, author, permlink, videoDetails?.title, clipStart, clipEnd]);
+  }, [videoUrlSelected, author, permlink, videoDetails?.title, clipStart, clipEnd, videoControls]);
 
   const handleProfileNavigate = useCallback((userName) => {
     navigate(`/p/${userName}`);
@@ -598,6 +600,8 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
                     subtitleLoading={videoControls.subtitleLoading}
                     subtitleStyle={videoControls.subtitleStyle}
                     onSubtitleStyleChange={videoControls.onSubtitleStyleChange}
+                    playbackRate={videoControls.playbackRate}
+                    onPlaybackRateChange={videoControls.onPlaybackRateChange}
                   />
                 </>
               )}
@@ -695,68 +699,112 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
             </div>
 
             <div className="info-buttons-row">
-              <button
-                className="share-btn"
-                onClick={handleShare}
-                title="Share with timestamp"
-              >
-                <MdShare size={16} />
-              </button>
-
-              <button
-                className={`reshare-btn${hasReshared ? ' reshared' : ''}`}
-                onClick={handleReshare}
-                title={hasReshared ? 'Reshared' : 'Reshare'}
-              >
-                <Repeat2 size={16} />
-                {reshareCount > 0 && <span className="reshare-count">{reshareCount}</span>}
-              </button>
-
-              {isInWatchLater && (
-                <button
-                  className={`watch-later-remove-btn ${isRemovingWatchLater ? 'loading' : ''}`}
-                  onClick={handleRemoveFromWatchLater}
-                  disabled={isRemovingWatchLater}
-                  title="Remove from Watch Later"
-                >
-                  <span className="watch-later-icon-wrap">
-                    <MdWatchLater />
-                    <span className="x-badge">&times;</span>
-                  </span>
-                </button>
-              )}
-
-              {authenticated && isLoggedIn() && (
-                <>
-                  <button className="playlist-btn" onClick={() => setIsPlaylistModalOpen(true)} title="Add to playlist">
-                    <MdPlaylistAdd />
+              {FEATURE_EDITOR && (
+                <div className="info-buttons-left">
+                  <button
+                    className="remix-btn"
+                    onClick={handleRemix}
+                    title={!authenticated ? 'Log in to remix' : !videoUrlSelected || !videoControls?.duration ? 'Loading video...' : videoControls.duration > 60 ? 'Remix only available for videos under 60s' : 'Remix in editor'}
+                    disabled={!authenticated || !videoUrlSelected || !videoControls?.duration || videoControls.duration > 60}
+                  >
+                    <Tornado size={16} />
+                    <span className="tools-row-label">Remix</span>
                   </button>
-                  <Button text="Tip" prominent onClick={() => setIsTipModalOpen(true)} />
-                </>
+                  <button
+                    className={`clip-btn${clipMode ? ' active' : ''}`}
+                    onClick={clipMode ? handleCancelClip : handleStartClipMode}
+                    title={!authenticated ? 'Log in to clip' : clipMode ? 'Cancel clip' : 'Clip video'}
+                    disabled={!authenticated}
+                  >
+                    <Scissors size={16} />
+                    <span className="tools-row-label">Clip</span>
+                  </button>
+                  {clipMode && (
+                    <div className="clip-bar-inline">
+                      <span className="clip-bar-inline-label">
+                        {clipMode === 'start' && 'Seek to start'}
+                        {clipMode === 'end' && `${formatTime(clipStart)} →`}
+                        {clipMode === 'done' && `${formatTime(clipStart)} – ${formatTime(clipEnd)}`}
+                      </span>
+                      {clipMode === 'start' && (
+                        <button className="clip-action-btn" onClick={handleSetClipStart}>Set Start</button>
+                      )}
+                      {clipMode === 'end' && (
+                        <button className="clip-action-btn" onClick={handleSetClipEnd}>Set End</button>
+                      )}
+                      {clipMode === 'done' && (
+                        <button className="clip-action-btn" onClick={handleCreateClip}>Create Clip</button>
+                      )}
+                    </div>
+                  )}
+                </div>
               )}
 
-              <CommentVoteTooltip
-                showTooltip={showTooltip}
-                setShowTooltip={setShowTooltip}
-                author={author}
-                permlink={permlink}
-                weight={weight}
-                setWeight={setWeight}
-                voteValue={voteValue}
-                setVoteValue={setVoteValue}
-                accountData={accountData}
-                setAccountData={setAccountData}
-                compact
-                onVoteSuccess={(a, p, isNewVote) => {
-                  setIsVoted(true);
-                  if (isNewVote) setOptimisticVoteCount(prev => prev + 1);
-                }}
-              />
+              <div className="info-buttons-right">
+                <button
+                  className="share-btn"
+                  onClick={handleShare}
+                  title="Share with timestamp"
+                >
+                  <MdShare size={16} />
+                </button>
+
+                <button
+                  className={`reshare-btn${hasReshared ? ' reshared' : ''}`}
+                  onClick={handleReshare}
+                  title={hasReshared ? 'Reshared' : 'Reshare'}
+                >
+                  <Repeat2 size={16} />
+                  {reshareCount > 0 && <span className="reshare-count">{reshareCount}</span>}
+                </button>
+
+                {isInWatchLater && (
+                  <button
+                    className={`watch-later-remove-btn ${isRemovingWatchLater ? 'loading' : ''}`}
+                    onClick={handleRemoveFromWatchLater}
+                    disabled={isRemovingWatchLater}
+                    title="Remove from Watch Later"
+                  >
+                    <span className="watch-later-icon-wrap">
+                      <MdWatchLater />
+                      <span className="x-badge">&times;</span>
+                    </span>
+                  </button>
+                )}
+
+                {authenticated && isLoggedIn() && (
+                  <>
+                    <button className="playlist-btn" onClick={() => setIsPlaylistModalOpen(true)} title="Add to playlist">
+                      <MdPlaylistAdd />
+                    </button>
+                    <Button text="Tip" prominent onClick={() => setIsTipModalOpen(true)} />
+                  </>
+                )}
+
+                <CommentVoteTooltip
+                  showTooltip={showTooltip}
+                  setShowTooltip={setShowTooltip}
+                  author={author}
+                  permlink={permlink}
+                  weight={weight}
+                  setWeight={setWeight}
+                  voteValue={voteValue}
+                  setVoteValue={setVoteValue}
+                  accountData={accountData}
+                  setAccountData={setAccountData}
+                  compact
+                  onVoteSuccess={(a, p, isNewVote) => {
+                    setIsVoted(true);
+                    if (isNewVote) setOptimisticVoteCount(prev => prev + 1);
+                  }}
+                />
+              </div>
             </div>
           </div>
 
+          {/* Mobile-only tools row (Clip/Remix hidden from info-buttons-left on mobile) */}
           {FEATURE_EDITOR && (
-            <div className="tools-row">
+            <div className="tools-row mobile-only">
               <button
                 className="remix-btn"
                 onClick={handleRemix}
@@ -882,6 +930,8 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
         videoName={editorVideoName}
         clipStart={editorClipStart}
         clipEnd={editorClipEnd}
+        originalAuthor={author}
+        originalPermlink={permlink}
       />
 
       {/* Mobile FAB — speed-dial for quick actions */}

--- a/src/components/playVideo/PlayVideo.scss
+++ b/src/components/playVideo/PlayVideo.scss
@@ -296,10 +296,29 @@
             .info-buttons-row {
                 display: flex;
                 align-items: center;
-                justify-content: flex-end;
+                justify-content: space-between;
                 gap: 7px;
                 @include mix.respond(phone) {
                     gap: 5px;
+                }
+
+                .info-buttons-left {
+                    display: flex;
+                    align-items: center;
+                    gap: 7px;
+
+                    @include mix.respond(phone) {
+                        display: none;
+                    }
+                }
+
+                .info-buttons-right {
+                    display: flex;
+                    align-items: center;
+                    gap: 7px;
+                    @include mix.respond(phone) {
+                        gap: 5px;
+                    }
                 }
             }
 
@@ -428,69 +447,110 @@
 
     }
 
+    .tools-row-label {
+        display: none;
+    }
+
+    .remix-btn,
+    .clip-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 5px;
+        padding: 4px 8px;
+        background-color: rgba(255, 255, 255, 0.1);
+        color: var(--text-secondary);
+        border: none;
+        border-radius: 5px;
+        font-size: 13px;
+        cursor: pointer;
+        transition: all 0.2s ease;
+
+        &:hover {
+          background-color: var(--accent-primary);
+          color: var(--text-inverse);
+        }
+
+        &.active {
+          color: var(--accent-primary);
+          background-color: rgba(var(--accent-primary-rgb, 255, 0, 0), 0.15);
+        }
+
+        &:disabled {
+          opacity: 0.35;
+          cursor: not-allowed;
+          &:hover {
+            background-color: rgba(255, 255, 255, 0.1);
+            color: var(--text-secondary);
+          }
+        }
+
+        @include mix.respond(phone) {
+            flex: 1;
+            padding: 6px 14px;
+            border-radius: 16px;
+            font-size: 13px;
+        }
+    }
+
     .tools-row {
         display: flex;
         align-items: center;
         gap: 7px;
         margin-top: 8px;
 
-        .tools-row-label {
+        &.mobile-only {
             display: none;
-        }
-
-        @include mix.respond(phone) {
-            gap: 8px;
-
-            .tools-row-label {
-                display: inline;
-            }
-        }
-
-        .remix-btn,
-        .clip-btn {
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            gap: 5px;
-            padding: 4px 8px;
-            background-color: rgba(255, 255, 255, 0.1);
-            color: var(--text-secondary);
-            border: none;
-            border-radius: 5px;
-            font-size: 13px;
-            cursor: pointer;
-            transition: all 0.2s ease;
-
-            &:hover {
-              background-color: var(--accent-primary);
-              color: var(--text-inverse);
-            }
-
-            &.active {
-              color: var(--accent-primary);
-              background-color: rgba(var(--accent-primary-rgb, 255, 0, 0), 0.15);
-            }
-
-            &:disabled {
-              opacity: 0.35;
-              cursor: not-allowed;
-              &:hover {
-                background-color: rgba(255, 255, 255, 0.1);
-                color: var(--text-secondary);
-              }
-            }
 
             @include mix.respond(phone) {
-                flex: 1;
-                padding: 6px 14px;
-                border-radius: 16px;
-                font-size: 13px;
+                display: flex;
+                gap: 8px;
+
+                .tools-row-label {
+                    display: inline;
+                }
             }
         }
     }
 
-    .clip-bar {
+    .clip-bar-inline {
       display: flex;
+      align-items: center;
+      gap: 8px;
+
+      .clip-bar-inline-label {
+        font-size: 12px;
+        color: var(--text-secondary);
+        white-space: nowrap;
+      }
+
+      .clip-action-btn {
+        padding: 4px 10px;
+        background-color: var(--accent-primary);
+        color: var(--text-inverse);
+        border: none;
+        border-radius: 5px;
+        font-size: 11px;
+        font-weight: 600;
+        cursor: pointer;
+        white-space: nowrap;
+        transition: opacity 0.2s;
+
+        &:hover { opacity: 0.85; }
+      }
+
+      @include mix.respond(phone) {
+        display: none;
+      }
+    }
+
+    .clip-bar {
+      display: none;
+
+      @include mix.respond(phone) {
+        display: flex;
+      }
+
       align-items: center;
       justify-content: space-between;
       gap: 12px;

--- a/src/components/studio/DraftStudio.jsx
+++ b/src/components/studio/DraftStudio.jsx
@@ -7,6 +7,7 @@ import { useNavigate } from 'react-router-dom';
 import BarLoader from '../Loader/BarLoader';
 import { useAppStore } from '../../lib/store';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { MY_VIDEOS_URL } from '../../utils/config';
 
 const DraftStudio = () => {
   const { user, authenticated } = useAppStore();
@@ -30,7 +31,7 @@ const DraftStudio = () => {
         : filter;
 
     try {
-      const res = await axios.get('https://views.3speak.tv/api/my-videos', {
+      const res = await axios.get(`${MY_VIDEOS_URL}/api/my-videos`, {
         params: {
           username: user,
           limit: pageSize,

--- a/src/context/EmbedUploadContext.jsx
+++ b/src/context/EmbedUploadContext.jsx
@@ -1,0 +1,356 @@
+import React, { createContext, useContext, useState, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as tus from 'tus-js-client';
+import { toast } from 'sonner';
+import { EMBED_UPLOAD_URL, EMBED_API_URL, EMBED_API_KEY } from '../utils/config';
+import { commentWithAioha } from '../hive-api/aioha';
+import { useAppStore } from '../lib/store';
+
+const EmbedUploadContext = createContext(null);
+
+export function useEmbedUpload() {
+  const ctx = useContext(EmbedUploadContext);
+  if (!ctx) throw new Error('useEmbedUpload must be used within EmbedUploadProvider');
+  return ctx;
+}
+
+export function EmbedUploadProvider({ children }) {
+  const { user } = useAppStore();
+  const navigate = useNavigate();
+
+  // Step tracking
+  const [step, setStep] = useState(1);
+
+  // Video file state
+  const [videoFile, setVideoFile] = useState(null);
+  const [prevVideoFile, setPrevVideoFile] = useState(null);
+  const [videoDuration, setVideoDuration] = useState(0);
+
+  // Thumbnail state
+  const [generatedThumbnail, setGeneratedThumbnail] = useState([]);
+  const [selectedThumbnail, setSelectedThumbnail] = useState(null);
+  const [thumbnailFile, setThumbnailFile] = useState(null);
+  const [selectedIndex, setSelectedIndex] = useState(null);
+
+  // Details state
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [tagsInputValue, setTagsInputValue] = useState('');
+  const [tagsPreview, setTagsPreview] = useState([]);
+  const [community, setCommunity] = useState('hive-181335');
+  const [beneficiaries, setBeneficiaries] = useState([]);
+  const [declineRewards, SetDeclineRewards] = useState(false);
+  const [rewardPowerup, setRewardPowerup] = useState(false);
+  const [isScheduled, setIsScheduled] = useState(false);
+  const [scheduleDateTime, setScheduleDateTime] = useState('');
+
+  // Community data
+  const [communitiesData, setCommunitiesData] = useState([]);
+
+  // Modal state
+  const [isOpen, setIsOpen] = useState(false);
+  const [benficaryOpen, setBeneficiaryOpen] = useState(false);
+  const [BeneficiaryList, setBeneficiaryList] = useState([]);
+  const [list, setList] = useState([]);
+  const [remaingPercent, setRemaingPercent] = useState(100);
+
+  // Original video attribution (for remix/clip)
+  const [originalAuthor, setOriginalAuthor] = useState(null);
+  const [originalPermlink, setOriginalPermlink] = useState(null);
+
+  // Publish state
+  const [uploading, setUploading] = useState(false);
+  const [completed, setCompleted] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const [statusText, setStatusText] = useState('');
+  const [statusMessages, setStatusMessages] = useState([]);
+  const [embedUrl, setEmbedUrl] = useState('');
+
+  const tusUploadRef = useRef(null);
+
+  const addMessage = (msg, type = 'info') => {
+    setStatusMessages(prev => [...prev, {
+      time: new Date().toLocaleTimeString(),
+      message: msg,
+      type,
+    }]);
+  };
+
+  const resetUploadState = () => {
+    setStep(1);
+    setVideoFile(null);
+    setPrevVideoFile(null);
+    setVideoDuration(0);
+    setGeneratedThumbnail([]);
+    setSelectedThumbnail(null);
+    setThumbnailFile(null);
+    setSelectedIndex(null);
+    setTitle('');
+    setDescription('');
+    setTagsInputValue('');
+    setTagsPreview([]);
+    setCommunity('hive-181335');
+    setBeneficiaries([]);
+    SetDeclineRewards(false);
+    setRewardPowerup(false);
+    setIsScheduled(false);
+    setScheduleDateTime('');
+    setOriginalAuthor(null);
+    setOriginalPermlink(null);
+    setUploading(false);
+    setCompleted(false);
+    setUploadProgress(0);
+    setStatusText('');
+    setStatusMessages([]);
+    setEmbedUrl('');
+    setBeneficiaryList([]);
+    setList([]);
+    setRemaingPercent(100);
+  };
+
+  /**
+   * publishToEmbed — the 3-step publish:
+   * 1. TUS upload to embed service
+   * 2. Post to Hive via aioha
+   * 3. Link embed video to Hive post
+   */
+  const publishToEmbed = async () => {
+    if (!videoFile || !user) {
+      toast.error('No video file or user not logged in');
+      return;
+    }
+    if (!title?.trim()) {
+      toast.error('Title is required');
+      return;
+    }
+    if (!description?.trim()) {
+      toast.error('Description is required');
+      return;
+    }
+    if (!tagsPreview || tagsPreview.length === 0) {
+      toast.error('Please add at least one tag');
+      return;
+    }
+
+    setUploading(true);
+    setUploadProgress(0);
+    setStatusText('Uploading video...');
+    addMessage('Starting video upload...');
+
+    try {
+      // ─── Step 1: TUS upload to embed service ───
+      let capturedEmbedUrl = '';
+
+      await new Promise((resolve, reject) => {
+        const upload = new tus.Upload(videoFile, {
+          endpoint: EMBED_UPLOAD_URL,
+          chunkSize: 5 * 1024 * 1024,
+          retryDelays: [0, 2000, 5000, 10000],
+          headers: {
+            ...(EMBED_API_KEY ? { 'X-API-Key': EMBED_API_KEY } : {}),
+          },
+          metadata: {
+            filename: videoFile.name,
+            filetype: videoFile.type,
+            frontend_app: '3speak-tv',
+            owner: user,
+            short: 'false',
+            duration: String(Math.round(videoDuration)),
+          },
+          onError: (err) => {
+            console.error('TUS upload error:', err);
+            reject(err);
+          },
+          onProgress: (bytesUploaded, bytesTotal) => {
+            const pct = Math.round((bytesUploaded / bytesTotal) * 100);
+            setUploadProgress(pct);
+            setStatusText(`Uploading video... ${pct}%`);
+          },
+          onSuccess: () => {
+            resolve();
+          },
+          onAfterResponse: (req, res) => {
+            const header = res.getHeader('X-Embed-URL') || res.getHeader('x-embed-url');
+            if (header) capturedEmbedUrl = header;
+          },
+        });
+        tusUploadRef.current = upload;
+        upload.start();
+      });
+
+      // Fallback: if no X-Embed-URL header, warn but don't use the raw TUS URL
+      if (!capturedEmbedUrl) {
+        console.warn('No X-Embed-URL header received from embed service');
+      }
+
+      if (!capturedEmbedUrl) {
+        throw new Error('Upload succeeded but no embed URL was returned');
+      }
+
+      setEmbedUrl(capturedEmbedUrl);
+      addMessage('Video uploaded successfully');
+      setStatusText('Posting to Hive...');
+      addMessage('Publishing to Hive blockchain...');
+
+      // ─── Step 2: Post to Hive via aioha ───
+      const hivePermlink = `3speak-${Date.now()}`;
+      const communityTag = typeof community === 'string' ? community : community?.name || 'hive-181335';
+
+      // Build body: description + embed URL + credit to original author
+      let postBody = `${description}\n\n${capturedEmbedUrl}`;
+      if (originalAuthor && originalPermlink) {
+        postBody += `\n\n---\n*Based on a video by [@${originalAuthor}](${window.location.origin}/@${originalAuthor}/${originalPermlink})*`;
+      }
+
+      const jsonMetadata = {
+        app: '3speak/embed',
+        format: 'markdown',
+        tags: ['3speak', ...tagsPreview],
+        video: {
+          platform: '3speak',
+          url: capturedEmbedUrl,
+          ...(originalAuthor ? { originalAuthor, originalPermlink } : {}),
+        },
+      };
+
+      // Build comment_options with 10% beneficiary to threespeakfund + any user-added beneficiaries
+      let parsedBeneficiaries = beneficiaries;
+      if (typeof parsedBeneficiaries === 'string') {
+        try { parsedBeneficiaries = JSON.parse(parsedBeneficiaries); } catch { parsedBeneficiaries = []; }
+      }
+
+      // Always include threespeakfund at 10% (1000 = 10%)
+      const allBeneficiaries = [
+        { account: 'threespeakfund', weight: 1000 },
+        ...(Array.isArray(parsedBeneficiaries) ? parsedBeneficiaries : [])
+      ];
+
+      // Sort by account name (required by Hive protocol)
+      allBeneficiaries.sort((a, b) => a.account.localeCompare(b.account));
+
+      const commentOptions = {
+        author: user,
+        permlink: hivePermlink,
+        max_accepted_payout: '1000000.000 HBD',
+        percent_hbd: 10000,
+        allow_votes: true,
+        allow_curation_rewards: true,
+        extensions: [[0, { beneficiaries: allBeneficiaries }]],
+      };
+
+      // For a root post: parentAuthor='', parentPermlink=community
+      const result = await commentWithAioha(
+        '',              // parentAuthor (empty = root post)
+        communityTag,    // parentPermlink (community)
+        hivePermlink,    // permlink
+        title,           // title
+        postBody,        // body
+        jsonMetadata,    // json_metadata
+        commentOptions   // comment_options with beneficiaries
+      );
+
+      if (!result.success) {
+        throw new Error('Failed to post to Hive');
+      }
+
+      addMessage('Posted to Hive successfully');
+      setStatusText('Linking embed video...');
+
+      // ─── Step 3: Link embed video to Hive post ───
+      try {
+        const vParam = new URL(capturedEmbedUrl).searchParams.get('v');
+        const embedPermlink = vParam ? vParam.split('/').pop() : null;
+
+        if (embedPermlink && EMBED_API_URL) {
+          await fetch(`${EMBED_API_URL}/video/${embedPermlink}/hive`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              ...(EMBED_API_KEY ? { 'X-API-Key': EMBED_API_KEY } : {}),
+            },
+            body: JSON.stringify({
+              hive_author: user,
+              hive_permlink: hivePermlink,
+              hive_title: title,
+              hive_body: postBody,
+              hive_tags: ['3speak', ...tagsPreview],
+            }),
+          });
+          addMessage('Embed video linked to Hive post');
+        }
+      } catch (linkErr) {
+        console.warn('Failed to link embed video to Hive post:', linkErr);
+        addMessage('Warning: Could not link embed video (non-critical)', 'warning');
+      }
+
+      // ─── Done ───
+      setStatusText('Completed');
+      setCompleted(true);
+      setUploading(false);
+      addMessage('Video successfully published!', 'success');
+      toast.success('Video published successfully!');
+
+    } catch (err) {
+      console.error('Publish error:', err);
+      addMessage('Upload failed: ' + err.message, 'error');
+      toast.error('Upload failed: ' + err.message);
+      setUploading(false);
+      setStatusText('');
+    }
+  };
+
+  const value = {
+    // Step
+    step, setStep,
+    // Video
+    videoFile, setVideoFile,
+    prevVideoFile, setPrevVideoFile,
+    videoDuration, setVideoDuration,
+    // Thumbnail
+    generatedThumbnail, setGeneratedThumbnail,
+    selectedThumbnail, setSelectedThumbnail,
+    thumbnailFile, setThumbnailFile,
+    selectedIndex, setSelectedIndex,
+    // Details
+    title, setTitle,
+    description, setDescription,
+    tagsInputValue, setTagsInputValue,
+    tagsPreview, setTagsPreview,
+    community, setCommunity,
+    beneficiaries, setBeneficiaries,
+    declineRewards, SetDeclineRewards,
+    rewardPowerup, setRewardPowerup,
+    isScheduled, setIsScheduled,
+    scheduleDateTime, setScheduleDateTime,
+    // Community data
+    communitiesData, setCommunitiesData,
+    // Modals
+    isOpen, setIsOpen,
+    benficaryOpen, setBeneficiaryOpen,
+    BeneficiaryList, setBeneficiaryList,
+    list, setList,
+    remaingPercent, setRemaingPercent,
+    // Publish state
+    uploading, setUploading,
+    completed, setCompleted,
+    uploadProgress, setUploadProgress,
+    statusText, setStatusText,
+    statusMessages, setStatusMessages,
+    embedUrl, setEmbedUrl,
+    // Original video attribution
+    originalAuthor, setOriginalAuthor,
+    originalPermlink, setOriginalPermlink,
+    // User
+    user,
+    navigate,
+    // Functions
+    publishToEmbed,
+    resetUploadState,
+  };
+
+  return (
+    <EmbedUploadContext.Provider value={value}>
+      {children}
+    </EmbedUploadContext.Provider>
+  );
+}

--- a/src/context/LegacyUploadContext.jsx
+++ b/src/context/LegacyUploadContext.jsx
@@ -489,7 +489,16 @@ const startTusUpload = async (file) => {
     if (!result.success) throw new Error(result.error || "Upload init failed");
 
     const upload_id = result.data.upload_id;
-    const tus_endpoint = result.data.tus_endpoint;
+    let tus_endpoint = result.data.tus_endpoint;
+
+    // If UPLOAD_URL is a proxy path (starts with /), rewrite the absolute TUS
+    // endpoint to go through the same proxy to avoid CORS issues.
+    if (UPLOAD_URL.startsWith('/') && tus_endpoint.startsWith('http')) {
+      try {
+        const parsed = new URL(tus_endpoint);
+        tus_endpoint = UPLOAD_URL + parsed.pathname;
+      } catch { /* keep original if URL parsing fails */ }
+    }
 
     setUploadId(upload_id);
 

--- a/src/page/HomeGrouped.jsx
+++ b/src/page/HomeGrouped.jsx
@@ -1,14 +1,12 @@
 import { useRef, useState, useEffect, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { useQuery as useApolloQuery } from "@apollo/client";
 import axios from "axios";
 import { FaChevronLeft, FaChevronRight } from "react-icons/fa";
 import { Link } from "react-router-dom";
 import "./HomeGrouped.scss";
-import { NEW_CONTENT } from "../graphql/queries";
 import CardSkeleton from "../components/Cards/CardSkeleton";
 import Card3 from "../components/Cards/Card3";
-import { FEED_URL, TRENDING_SORTED_URL, FOLLOW_FEED_URL } from "../utils/config";
+import { FEED_URL, TRENDING_SORTED_URL, FOLLOW_FEED_URL, NEW_CONTENT_URL, FIRST_UPLOADS_URL } from "../utils/config";
 import { useContentBatch } from "../hooks/useContentBatch";
 import { useWatchHistory } from "../hooks/useWatchHistory";
 import useViewCounts from "../hooks/useViewCounts";
@@ -27,12 +25,17 @@ const fetchFollowFeed = async (username) => {
 };
 
 const fetchFirstUploads = async () => {
-  const res = await axios.get(`${FEED_URL}/apiv2/feeds/firstUploads?page=1`);
-  return Array.isArray(res.data) ? res.data : [];
+  const res = await axios.get(`${FIRST_UPLOADS_URL}?page=1&limit=50`);
+  return res.data?.videos || [];
 };
 
 const fetchTrending = async () => {
   const res = await axios.get(`${TRENDING_SORTED_URL}?page=1&limit=50`);
+  return res.data?.videos || [];
+};
+
+const fetchNewContent = async () => {
+  const res = await axios.get(`${NEW_CONTENT_URL}?page=1&limit=50`);
   return res.data?.videos || [];
 };
 
@@ -203,14 +206,17 @@ const HomeGrouped = () => {
     gcTime: 10 * 60 * 1000,
   });
 
-  const { data: newContentData, loading: newContentLoading } = useApolloQuery(NEW_CONTENT, {
-    variables: { limit: 50, skip: 0 },
+  const { data: newContentData, isLoading: newContentLoading } = useQuery({
+    queryKey: ["newcontent-grouped"],
+    queryFn: fetchNewContent,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
   });
 
   // Combine all videos for batch content loading
   const allVideos = useMemo(() => [
     ...(homeData || []).slice(0, 16),
-    ...deduplicateVideos(newContentData?.socialFeed?.items || []).slice(0, 16),
+    ...deduplicateVideos(newContentData || []).slice(0, 16),
     ...(trendingData || []).slice(0, 16),
     ...(firstUploadsData || []).slice(0, 16),
   ], [homeData, newContentData, trendingData, firstUploadsData]);
@@ -237,7 +243,7 @@ const HomeGrouped = () => {
 
       <VideoRow
         title="New Content"
-        videos={deduplicateVideos(newContentData?.socialFeed?.items || [])}
+        videos={deduplicateVideos(newContentData || [])}
         linkTo="/new"
         isLoading={newContentLoading}
         getContentForVideo={getContentForVideo}

--- a/src/page/ProfilePage.jsx
+++ b/src/page/ProfilePage.jsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 
 import { useAppStore } from "../lib/store";
 import { getFollowers } from "../hive-api/api";
+import { MY_VIDEOS_URL } from "../utils/config";
 
 import Card3 from "../components/Cards/Card3";
 import Follower from "../components/Userprofilepage/Follower";
@@ -194,7 +195,7 @@ function ProfilePage() {
 
     try {
       // Use new reliable API endpoint with server-side pagination
-      const res = await axios.get('https://views.3speak.tv/api/my-videos', {
+      const res = await axios.get(`${MY_VIDEOS_URL}/api/my-videos`, {
         params: {
           username: user,
           limit: pageSize,

--- a/src/page/Short.jsx
+++ b/src/page/Short.jsx
@@ -129,6 +129,8 @@ const VideoShort = () => {
   const [showEditorModal, setShowEditorModal] = useState(false);
   const [editorVideoUrl, setEditorVideoUrl] = useState(null);
   const [editorVideoName, setEditorVideoName] = useState(null);
+  const [editorOriginalAuthor, setEditorOriginalAuthor] = useState(null);
+  const [editorOriginalPermlink, setEditorOriginalPermlink] = useState(null);
 
   // Ambient glow
   const { glowMode, toggleGlow } = useAmbientGlow();
@@ -1438,6 +1440,8 @@ const VideoShort = () => {
       if (directUrl) {
         setEditorVideoUrl(directUrl);
         setEditorVideoName(`${currentVid.author} - ${currentVid.caption || currentVid.permlink}`);
+        setEditorOriginalAuthor(currentVid.author);
+        setEditorOriginalPermlink(currentVid.permlink);
         setShowEditorModal(true);
       } else {
         toast.error('Could not resolve video URL for remix');
@@ -2655,6 +2659,8 @@ const VideoShort = () => {
         videoUrl={editorVideoUrl}
         videoName={editorVideoName}
         videoType="video"
+        originalAuthor={editorOriginalAuthor}
+        originalPermlink={editorOriginalPermlink}
       />
     </main>
   );

--- a/src/page/Watch.jsx
+++ b/src/page/Watch.jsx
@@ -168,6 +168,7 @@ function Watch() {
     setVolume: sdkSetVolume,
     togglePip,
     setQuality: sdkSetQuality,
+    setPlaybackRate,
   } = usePlayer({
     apiBase: PLAYER_URL,
     muted: storedMuted,
@@ -958,6 +959,8 @@ function Watch() {
           subtitleCurrentTime: playerState.currentTime,
           subtitleStyle,
           onSubtitleStyleChange: updateSubtitleStyle,
+          playbackRate: playerState.playbackRate,
+          onPlaybackRateChange: setPlaybackRate,
         }}
         mobileReactionPanel={
           <>

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -8,11 +8,14 @@ const PLAYER_URL = import.meta.env.VITE_PLAYER_URL;
 const HIVE_API_URL = import.meta.env.VITE_HIVE_API_URL || 'https://techcoderx.com';
 const FEED_URL = import.meta.env.VITE_FEED_URL || 'https://legacy.3speak.tv';
 const VIEWS_URL = import.meta.env.VITE_VIEWS_URL || 'https://views.3speak.tv';
+const MY_VIDEOS_URL = import.meta.env.VITE_MY_VIDEOS_URL || 'https://views.3speak.tv';
 const TAG_FEED_URL = import.meta.env.VITE_THREESPEAK_TAG_FEED_URL || 'https://legacy.3speak.tv';
 const PLAYLISTS_API_URL = import.meta.env.VITE_PLAYLISTS_API_URL || 'https://3speak-playlists.okinoko.io/api';
 
 const TRENDING_SORTED_URL = import.meta.env.VITE_TRENDING_SORTED_URL || 'https://tags.3speak.tv/feeds/trendingSorted';
 const FOLLOW_FEED_URL = import.meta.env.VITE_FOLLOW_FEED_URL || 'https://tags.3speak.tv/feed';
+const NEW_CONTENT_URL = import.meta.env.VITE_NEW_CONTENT_URL || 'https://tags.3speak.tv/feeds/new';
+const FIRST_UPLOADS_URL = import.meta.env.VITE_FIRST_UPLOADS_URL || 'https://tags.3speak.tv/feeds/firstUploads';
 
 // Editor URLs — comma-separated list; a random reachable one is selected at runtime
 const EDITOR_URLS = (import.meta.env.VITE_EDITOR_URLS || import.meta.env.VITE_EDITOR_URL || 'https://editor.3speak.tv')
@@ -71,6 +74,7 @@ export {
   TAG_FEED_URL,
   FEED_URL,
   VIEWS_URL,
+  MY_VIDEOS_URL,
   PLAYER_URL,
   PLAYLISTS_API_URL,
   WATCH_HISTORY_THRESHOLD_DAYS,
@@ -80,6 +84,8 @@ export {
   TRANSLATE_API_URL,
   TRENDING_SORTED_URL,
   FOLLOW_FEED_URL,
+  NEW_CONTENT_URL,
+  FIRST_UPLOADS_URL,
   EDITOR_URLS,
   getEditorUrl,
   FEATURE_EDITOR,

--- a/vite.config.js
+++ b/vite.config.js
@@ -146,5 +146,32 @@ export default defineConfig({
 
   server: {
     allowedHosts: ["3speak.okinoko.io"],
+    proxy: {
+      // Proxy upload API calls to video.3speak.tv to avoid CORS issues in dev.
+      // In production, VITE_UPLOAD_URL should point directly to video.3speak.tv.
+      '/upload-api': {
+        target: 'https://video.3speak.tv',
+        changeOrigin: true,
+        secure: true,
+        rewrite: (path) => path.replace(/^\/upload-api/, ''),
+        configure: (proxy) => {
+          // Strip Origin header so video.3speak.tv doesn't reject the request
+          proxy.on('proxyReq', (proxyReq) => {
+            proxyReq.removeHeader('origin');
+          });
+          // Rewrite Location headers (TUS protocol returns absolute URLs)
+          // so the TUS client continues through the proxy
+          proxy.on('proxyRes', (proxyRes) => {
+            const location = proxyRes.headers['location'];
+            if (location && location.includes('video.3speak.tv')) {
+              proxyRes.headers['location'] = location.replace(
+                /https?:\/\/video\.3speak\.tv/,
+                '/upload-api'
+              );
+            }
+          });
+        },
+      },
+    },
   },
 });


### PR DESCRIPTION
### Embed Studio (`/embed-studio`)
- New upload flow using the embed service (TUS upload → Hive post → link to embed)
- `EmbedUploadContext.jsx` — context with `publishToEmbed()` handling the 3-step publish
- Wizard pages: file selection, thumbnail, details, preview/publish
- Reuses existing studio UI components (StepProgress, MarkdownComposer, etc.)

### Playback Speed Controls
- Updated `@mantequilla-soft/3speak-player` to v0.3.0 (adds `playbackRate` state and `ratechange` event)
- Added speed selector dropdown to VideoControls with rates 0.25x–2x

### Feed Endpoint Fixes
- Point all feed URLs to `3speak-checker.okinoko.io` (was hitting production `tags.3speak.tv`)
- Add `MY_VIDEOS_URL` config var — profile page and draft studio now use checker instead of hardcoded `views.3speak.tv`
- Sync `.env.example` with `.env`, remove unused JWPlayer vars

### Other
- Editor modal and Remix/Clip integration updates
- PlayVideo layout and styling improvements
- HomeGrouped feed section updates
