### PR TITLE
fix: add images.3speak.tv to optimized CDN allowlist

### DIFF
--- a/src/utils/fixThumbnails.js
+++ b/src/utils/fixThumbnails.js
@@ -43,8 +43,10 @@ export function fixVideoThumbnail(video) {
     return thumbnail.replace("https://ipfs-3speak.b-cdn.net", APP_BUNNY_IPFS_CDN);
   }
 
-  // ✅ Already using Hive proxy - return as-is (already optimized)
-  if (thumbnail.includes("images.hive.blog") || thumbnail.includes("files.peakd.com")) {
+  // ✅ Already using optimized CDN - return as-is (no need to re-proxy)
+  if (thumbnail.includes("images.hive.blog") || 
+      thumbnail.includes("files.peakd.com") || 
+      thumbnail.includes("images.3speak.tv")) {
     return thumbnail;
   }
 


### PR DESCRIPTION
Prevents unnecessary double-proxying of WebP thumbnails from images.3speak.tv through images.hive.blog. Now supports all three thumbnail sources:
- images.hive.blog URLs (already proxied)
- images.3speak.tv WebP (optimized CDN)
- IPFS CIDs (ipfs://)

This applies to all feeds: home feed, recommended, drafts, and profile pages.