### PR TITLE
fix: add images.3speak.tv to optimized CDN allowlist

### DIFF
--- a/src/utils/fixThumbnails.js
+++ b/src/utils/fixThumbnails.js
@@ -42,8 +42,10 @@ export function fixVideoThumbnail(video) {
     return cleanThumbnail.replace("https://ipfs-3speak.b-cdn.net", APP_BUNNY_IPFS_CDN);
   }
 
-  // ✅ Already using Hive proxy - return as-is (already optimized)
-  if (cleanThumbnail.includes("images.hive.blog") || cleanThumbnail.includes("files.peakd.com")) {
+  // ✅ Already using optimized CDN - return as-is (no need to re-proxy)
+  if (cleanThumbnail.includes("images.hive.blog") || 
+      cleanThumbnail.includes("files.peakd.com") || 
+      cleanThumbnail.includes("images.3speak.tv")) {
     return cleanThumbnail;
   }
 


### PR DESCRIPTION
Prevents unnecessary double-proxying of WebP thumbnails from images.3speak.tv through images.hive.blog. Now supports all three thumbnail sources:
- images.hive.blog URLs (already proxied)
- images.3speak.tv WebP (optimized CDN)
- IPFS CIDs (ipfs://)

This applies to all feeds: home feed, recommended, drafts, and profile pages.