### PR TITLE
feat: proxy /rss/ requests to legacy.3speak.tv

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,7 @@
     { "source": "/sitemap-videos.xml", "destination": "/api/sitemap-videos.xml" },
     { "source": "/sitemap-channels.xml", "destination": "/api/sitemap-channels.xml" },
     { "source": "/hivesigner.html", "destination": "/hivesigner.html" },
+    { "source": "/rss/:path*", "destination": "https://legacy.3speak.tv/rss/:path*" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- RSS feeds are generated by a bot running on the legacy site (`legacy.3speak.tv`) and stored as XML files
- Since the new 3speak.tv is hosted on Vercel, we can't write/serve static XML files directly
- Added a Vercel rewrite rule to transparently proxy `/rss/*` requests to `legacy.3speak.tv/rss/*`, so existing feed URLs (e.g. `3speak.tv/rss/shiftrox.xml`) keep working

## Test plan
- [ ] Verify `https://3speak.tv/rss/shiftrox.xml` returns the RSS XML content after deployment
- [ ] Confirm the response is served transparently (URL stays as `3speak.tv`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated routing configuration to delegate RSS feed requests to legacy infrastructure while maintaining service availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->