### PR TITLE
fix: use redirect instead of rewrite for RSS feeds

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,11 @@
 {
+  "redirects": [
+    { "source": "/rss/:path*", "destination": "https://legacy.3speak.tv/rss/:path*", "statusCode": 301 }
+  ],
   "rewrites": [
     { "source": "/sitemap-videos.xml", "destination": "/api/sitemap-videos.xml" },
     { "source": "/sitemap-channels.xml", "destination": "/api/sitemap-channels.xml" },
     { "source": "/hivesigner.html", "destination": "/hivesigner.html" },
-    { "source": "/rss/:path*", "destination": "https://legacy.3speak.tv/rss/:path*" },
     { "source": "/api/og-debug", "destination": "/api/og-debug" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]


### PR DESCRIPTION
## Summary

- RSS feed URLs (`/rss/theycallmedan.xml`, etc.) were intermittently failing with timeouts
- Changed the Vercel routing for `/rss/:path*` from a **rewrite** to a **301 redirect**

## The problem

The previous config used a Vercel **rewrite** to proxy `/rss/` requests to `legacy.3speak.tv`:

```json
{ "source": "/rss/:path*", "destination": "https://legacy.3speak.tv/rss/:path*" }
```

When Vercel rewrites to an external URL, it acts as a **reverse proxy** — Vercel's edge fetches the response from `legacy.3speak.tv` and forwards it back to the client. This is subject to Vercel's function execution timeout limits (10s on Hobby, 60s on Pro).

## Why it only worked sometimes

The legacy server (`legacy.3speak.tv`) itself responds correctly every time — the RSS feed is valid and available. The intermittent failures were caused by **Vercel's proxy layer timing out** while waiting for the response. Depending on network latency between Vercel's edge node and the legacy server at any given moment, the proxy would sometimes complete within the timeout window and sometimes not.

## The fix

Changed `/rss/:path*` from a `rewrite` to a `redirect` (301). Instead of Vercel proxying the request, the client is sent directly to `legacy.3speak.tv/rss/...`. This eliminates the proxy timeout entirely since there's no middleman.

Additionally, Vercel processes `redirects` **before** `rewrites` in its routing pipeline, so there's no risk of the catch-all SPA rewrite (`/(.*) → /index.html`) intercepting RSS requests.

## Test plan

- [ ] Verify `https://3speak.tv/rss/theycallmedan.xml` redirects to `https://legacy.3speak.tv/rss/theycallmedan.xml` and returns valid RSS
- [ ] Verify RSS readers can follow the 301 redirect and parse the feed
- [ ] Verify other routes (watch pages, profile pages, sitemaps) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)