### PR TITLE
Fix/various things

### DIFF
--- a/src/components/LoginModal/LoginModal.jsx
+++ b/src/components/LoginModal/LoginModal.jsx
@@ -24,7 +24,37 @@ function LoginModal({ displayed, onLogin, onClose, loginTitle, loginOptions }) {
       return;
     }
 
+    const replaceHiveAuthQRText = () => {
+      const modal = document.querySelector('#aioha-modal');
+      if (!modal) return;
+      const originalText = 'Scan the QR code using a HiveAuth-compatible mobile app.';
+      const newText = 'Scan the QR code using a hiveauth compatible mobile app. If you have the app on this phone then just tap the qr code.';
+      modal.querySelectorAll('p').forEach((p) => {
+        if (p.textContent.trim() === originalText) {
+          p.textContent = newText;
+        }
+      });
+    };
+
+    const styleHiveAuthQR = () => {
+      const modal = document.querySelector('#aioha-modal');
+      if (!modal) return;
+      // The QR is inside a class-less <a> wrapping a div with w-64/aspect-square
+      modal.querySelectorAll('a:not([class])').forEach((a) => {
+        const inner = a.querySelector('div.aspect-square');
+        if (!inner) return;
+        a.style.display = 'block';
+        a.style.textAlign = 'center';
+        inner.style.width = '256px';
+        inner.style.maxWidth = '100%';
+        inner.style.marginLeft = 'auto';
+        inner.style.marginRight = 'auto';
+      });
+    };
+
     const injectButton = () => {
+      replaceHiveAuthQRText();
+      styleHiveAuthQR();
       const modalContent = document.querySelector('#aioha-modal > div > div');
       if (modalContent) {
         // Only show on provider selection page (check for provider list)

--- a/src/components/LoginModal/LoginModal.scss
+++ b/src/components/LoginModal/LoginModal.scss
@@ -12,6 +12,7 @@
     display: none !important;
   }
 
+
   // Style the injected email button container - matches modal's internal padding
   .email-login-btn-container {
     position: absolute;

--- a/src/hooks/auth/hive.js
+++ b/src/hooks/auth/hive.js
@@ -1,19 +1,27 @@
-import { Aioha, initAioha, KeyTypes, Providers } from "@aioha/aioha";
+import { Aioha, KeyTypes, Providers } from "@aioha/aioha";
 
-const aioha =
-  typeof window === "undefined"
-    ? new Aioha()
-    : initAioha({
-        hiveauth: {
-          name: "3Speak",
-          // description: "Aioha test app",
-        },
-        hivesigner: {
-          app: "3speak.tv",
-          callbackURL: window.location.origin + "/hivesigner.html", // TODO set properly
-          scope: ["login", "vote"],
-        },
-      });
+// Manual Aioha setup instead of initAioha() — we skip registerMetaMaskSnap()
+// because it probes window.ethereum, which triggers the Phantom wallet
+// "Which extension do you want to connect with?" popup for users who have
+// both Phantom and MetaMask installed. We don't offer a MetaMask login,
+// so there's nothing to lose by not registering that provider.
+const buildAioha = () => {
+  const a = new Aioha();
+  if (typeof window === "undefined") return a;
+  a.registerKeychain();
+  a.registerLedger();
+  a.registerPeakVault();
+  a.registerHiveAuth({ name: "3Speak" });
+  a.registerHiveSigner({
+    app: "3speak.tv",
+    callbackURL: window.location.origin + "/hivesigner.html",
+    scope: ["login", "vote"],
+  });
+  a.loadAuth();
+  return a;
+};
+
+const aioha = buildAioha();
 
 function generatePayload(account) {
   const payload = {

--- a/vite.config.js
+++ b/vite.config.js
@@ -40,7 +40,7 @@ export default defineConfig({
       strategies: "injectManifest",
       srcDir: "src",
       filename: "sw.js",
-      devOptions: { enabled: true },
+      devOptions: { enabled: false },
       manifest: {
         name: "3Speak",
         short_name: "3Speak",


### PR DESCRIPTION
- #248: clearer instructions + larger, centered QR code
  (applied via existing MutationObserver, no node_modules patching)
- #241: skip `registerMetaMaskSnap()` in Aioha setup so
  `window.ethereum` isn't probed — we don't offer MetaMask login anyway
- **Dev PWA fix**: disable service worker in dev mode (the injectManifest
  strategy left `self.__WB_MANIFEST` unpopulated, causing SW eval errors
  and minute-long page loads)