### PR TITLE
feat(watch): author can edit title, tags, description, and thumbnail

### DIFF
--- a/src/components/playVideo/EditVideoModal.jsx
+++ b/src/components/playVideo/EditVideoModal.jsx
@@ -1,0 +1,463 @@
+import { useState, useEffect, useMemo, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { IoClose } from 'react-icons/io5';
+import { MdImage, MdUpload } from 'react-icons/md';
+import { toast } from 'sonner';
+import { Client } from '@hiveio/dhive';
+import { HIVE_API_NODES } from '../../utils/config';
+import { commentWithAioha } from '../../hive-api/aioha';
+import { uploadThumbnail } from '../../utils/uploadThumbnail';
+import './EditVideoModal.scss';
+
+const hiveClient = new Client(HIVE_API_NODES);
+
+const TITLE_MIN = 5;
+const TITLE_MAX = 250;
+const MAX_TAGS = 10;
+
+/**
+ * Split a 3Speak post body into three parts:
+ *   header  — thumbnail image link + "▶️ Watch on 3Speak" + separator
+ *   middle  — the user's actual description (what we let them edit)
+ *   footer  — trailing separator + "▶️ [3Speak]" link
+ *
+ * If the body doesn't match the expected shape, we treat the whole thing as
+ * editable middle with empty header/footer — editing then preserves everything.
+ */
+function splitPostBody(body) {
+  if (typeof body !== 'string' || !body) {
+    return { header: '', middle: '', footer: '' };
+  }
+
+  const src = body.replace(/\r\n/g, '\n');
+
+  // Header pattern:
+  //   [![](thumbUrl)](watchUrl)\n\n
+  //   ▶️ [Watch on 3Speak](watchUrl)\n\n
+  //   ---\n
+  // We match leniently: any whitespace between the three pieces, "▶️" optional
+  // variants, optional surrounding whitespace.
+  const headerRe = new RegExp(
+    '^\\s*' +
+    // thumbnail image link: [![alt](thumb)](watch)
+    '(?:\\[\\s*!\\[[^\\]]*\\]\\([^)]*\\)\\s*\\]\\([^)]*\\)\\s*\\n+)?' +
+    // "Watch on 3Speak" line
+    '(?:(?:▶️|â–¶ï¸|▶)?\\s*\\[\\s*Watch on 3Speak\\s*\\]\\([^)]*\\)\\s*\\n+)?' +
+    // horizontal rule
+    '(?:-{3,}\\s*\\n+)?',
+    ''
+  );
+
+  // Footer pattern (at end of body):
+  //   \n---\n\n▶️ [3Speak](watchUrl)\n
+  const footerRe = new RegExp(
+    '(?:\\n+-{3,}\\s*)?' +
+    '\\n+(?:▶️|â–¶ï¸|▶)?\\s*\\[\\s*3Speak\\s*\\]\\([^)]*\\)\\s*$',
+    ''
+  );
+
+  const headerMatch = src.match(headerRe);
+  const header = headerMatch ? headerMatch[0] : '';
+  const afterHeader = src.slice(header.length);
+
+  const footerMatch = afterHeader.match(footerRe);
+  const footer = footerMatch ? footerMatch[0] : '';
+  const middle = footerMatch
+    ? afterHeader.slice(0, afterHeader.length - footer.length)
+    : afterHeader;
+
+  // If neither header nor footer matched, expose the full body so the author
+  // doesn't lose anything on save.
+  if (!header && !footer) {
+    return { header: '', middle: src, footer: '' };
+  }
+
+  return { header, middle: middle.trim(), footer };
+}
+
+function recombinePostBody(header, middle, footer) {
+  const parts = [];
+  if (header) parts.push(header.replace(/\s+$/, ''));
+  parts.push((middle ?? '').trim());
+  if (footer) parts.push(footer.replace(/^\s+/, ''));
+  return parts.filter(Boolean).join('\n\n') + '\n';
+}
+
+/**
+ * Modal for editing a video post on Hive.
+ * Broadcasts a `comment` operation with the same author/permlink to replace
+ * on-chain title, body and json_metadata. Video file itself is never touched.
+ *
+ * @param {boolean} isOpen
+ * @param {() => void} onClose
+ * @param {string} author          - video author (must equal logged-in user)
+ * @param {string} permlink
+ * @param {(changes: { title, body, tags, thumbnail }) => void} onSaved
+ */
+export default function EditVideoModal({ isOpen, onClose, author, permlink, onSaved }) {
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [loadError, setLoadError] = useState(null);
+
+  // Original on-chain post — source of truth for round-trip fidelity.
+  const [original, setOriginal] = useState(null);
+
+  // Editable fields
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState(''); // middle section only — what the user edits
+  const [bodyHeader, setBodyHeader] = useState(''); // 3Speak thumb+link header, rewrite thumb on save
+  const [bodyFooter, setBodyFooter] = useState(''); // trailing 3Speak link
+  const [tagsInput, setTagsInput] = useState('');
+  const [thumbnailUrl, setThumbnailUrl] = useState('');
+  const [thumbUploading, setThumbUploading] = useState(false);
+  const thumbInputRef = useRef(null);
+
+  // Fetch original post when modal opens
+  useEffect(() => {
+    if (!isOpen || !author || !permlink) return;
+
+    let cancelled = false;
+    setLoading(true);
+    setLoadError(null);
+
+    (async () => {
+      try {
+        const post = await hiveClient.call('condenser_api', 'get_content', [author, permlink]);
+        if (cancelled) return;
+        if (!post || !post.author) {
+          setLoadError('Could not find this post on Hive.');
+          setLoading(false);
+          return;
+        }
+
+        let meta = {};
+        try { meta = JSON.parse(post.json_metadata || '{}'); } catch (_) {}
+
+        // Extract current thumbnail
+        let currentThumb = '';
+        const sourceMap = meta.video?.info?.sourceMap;
+        if (Array.isArray(sourceMap)) {
+          const thumbEntry = sourceMap.find((s) => s.type === 'thumbnail');
+          if (thumbEntry?.url) currentThumb = thumbEntry.url;
+        }
+        if (!currentThumb && Array.isArray(meta.image) && meta.image[0]) {
+          currentThumb = meta.image[0];
+        }
+
+        // Tags: prefer json_metadata.tags (that's what publishers use),
+        // fall back to post.category + json_metadata.tags merge minus duplicates
+        const metaTags = Array.isArray(meta.tags) ? meta.tags : [];
+
+        const { header, middle, footer } = splitPostBody(post.body || '');
+
+        setOriginal({ post, meta });
+        setTitle(post.title || '');
+        setBody(middle);
+        setBodyHeader(header);
+        setBodyFooter(footer);
+        setTagsInput(metaTags.join(' '));
+        setThumbnailUrl(currentThumb);
+        setLoading(false);
+      } catch (err) {
+        if (cancelled) return;
+        console.error('Failed to load post for edit:', err);
+        setLoadError('Failed to load post from Hive. Please try again.');
+        setLoading(false);
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [isOpen, author, permlink]);
+
+  // Reset local state when the modal closes
+  useEffect(() => {
+    if (isOpen) return;
+    setOriginal(null);
+    setTitle('');
+    setBody('');
+    setBodyHeader('');
+    setBodyFooter('');
+    setTagsInput('');
+    setThumbnailUrl('');
+    setLoadError(null);
+    setSaving(false);
+  }, [isOpen]);
+
+  // Parse tags input (space/comma separated, lowercased, deduplicated)
+  const parsedTags = useMemo(() => {
+    if (!tagsInput) return [];
+    const raw = tagsInput
+      .toLowerCase()
+      .split(/[\s,]+/)
+      .map((t) => t.trim())
+      .filter(Boolean);
+    return [...new Set(raw)];
+  }, [tagsInput]);
+
+  // Validation
+  const titleLen = title.trim().length;
+  const titleValid = titleLen >= TITLE_MIN && titleLen <= TITLE_MAX;
+  const tagsValid = parsedTags.length > 0 && parsedTags.length <= MAX_TAGS;
+  const bodyValid = body.trim().length > 0;
+  const canSave = titleValid && tagsValid && bodyValid && !!original && !saving;
+
+  // Has anything actually changed?
+  const isDirty = useMemo(() => {
+    if (!original) return false;
+    const origTags = Array.isArray(original.meta.tags) ? original.meta.tags : [];
+    const origThumb = (() => {
+      const sm = original.meta.video?.info?.sourceMap;
+      if (Array.isArray(sm)) {
+        const t = sm.find((s) => s.type === 'thumbnail');
+        if (t?.url) return t.url;
+      }
+      return Array.isArray(original.meta.image) ? (original.meta.image[0] || '') : '';
+    })();
+    const { middle: origMiddle } = splitPostBody(original.post.body || '');
+    return (
+      title.trim() !== (original.post.title || '').trim() ||
+      body !== origMiddle ||
+      parsedTags.join(' ') !== origTags.join(' ') ||
+      thumbnailUrl.trim() !== origThumb
+    );
+  }, [original, title, body, parsedTags, thumbnailUrl]);
+
+  const handleThumbFilePick = async (e) => {
+    const file = e.target.files?.[0];
+    e.target.value = ''; // allow re-picking the same file
+    if (!file) return;
+    if (!file.type.startsWith('image/')) {
+      toast.error('Please select an image file.');
+      return;
+    }
+    // 10 MB cap — same ballpark as the uploader
+    if (file.size > 10 * 1024 * 1024) {
+      toast.error('Image too large (max 10 MB).');
+      return;
+    }
+    setThumbUploading(true);
+    try {
+      const url = await uploadThumbnail(file);
+      setThumbnailUrl(url);
+      toast.success('Thumbnail uploaded.');
+    } catch (err) {
+      console.error('Thumbnail upload failed:', err);
+      toast.error(err?.message || 'Thumbnail upload failed.');
+    } finally {
+      setThumbUploading(false);
+    }
+  };
+
+  const handleSave = async (e) => {
+    e?.preventDefault?.();
+    if (!canSave) return;
+    if (!isDirty) {
+      toast.info('No changes to save.');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const { post, meta } = original;
+
+      // Build new json_metadata preserving the original structure
+      const newMeta = { ...meta };
+      newMeta.tags = parsedTags;
+
+      // Update thumbnail references in both `image` and `video.info.sourceMap`
+      const trimmedThumb = thumbnailUrl.trim();
+      if (trimmedThumb) {
+        newMeta.image = Array.isArray(newMeta.image)
+          ? [trimmedThumb, ...newMeta.image.filter((u) => u !== trimmedThumb)]
+          : [trimmedThumb];
+
+        if (newMeta.video?.info?.sourceMap && Array.isArray(newMeta.video.info.sourceMap)) {
+          const sm = newMeta.video.info.sourceMap.map((s) =>
+            s.type === 'thumbnail' ? { ...s, url: trimmedThumb } : s
+          );
+          // If no existing thumbnail entry, add one
+          if (!sm.some((s) => s.type === 'thumbnail')) {
+            sm.push({ type: 'thumbnail', url: trimmedThumb });
+          }
+          newMeta.video = { ...newMeta.video, info: { ...newMeta.video.info, sourceMap: sm } };
+        }
+      }
+
+      // Rewrite the thumbnail URL inside the header's image-link, if a header
+      // exists and the thumbnail changed. The pattern is [![...](OLD)](watch).
+      let finalHeader = bodyHeader;
+      if (trimmedThumb && finalHeader) {
+        finalHeader = finalHeader.replace(
+          /(\[\s*!\[[^\]]*\]\()[^)]*(\)\s*\]\([^)]*\))/,
+          `$1${trimmedThumb}$2`
+        );
+      }
+
+      // Rebuild the full post body: preserved header + user-edited middle + preserved footer
+      const finalBody = recombinePostBody(finalHeader, body, bodyFooter);
+
+      const result = await commentWithAioha(
+        post.parent_author || '',
+        post.parent_permlink || '',
+        permlink,
+        title.trim(),
+        finalBody,
+        newMeta,
+        null // don't touch comment_options on edit — can't be changed after first broadcast
+      );
+
+      if (!result?.success) {
+        throw new Error(result?.error || 'Broadcast failed');
+      }
+
+      toast.success('Video updated!');
+      onSaved?.({
+        title: title.trim(),
+        body: finalBody,
+        tags: parsedTags,
+        thumbnail: trimmedThumb,
+      });
+      onClose();
+    } catch (err) {
+      console.error('Edit save failed:', err);
+      toast.error(err?.message || 'Failed to save changes.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div className="edit-video-modal-overlay" onClick={onClose}>
+      <div className="edit-video-modal-content" onClick={(e) => e.stopPropagation()}>
+        <button className="edit-video-close-btn" onClick={onClose} aria-label="Close">
+          <IoClose size={22} />
+        </button>
+
+        <h3 className="edit-video-title">Edit Video</h3>
+        <p className="edit-video-subtitle">@{author}/{permlink}</p>
+
+        {loading && (
+          <div className="edit-video-loading">Loading current post…</div>
+        )}
+
+        {loadError && !loading && (
+          <div className="edit-video-error">{loadError}</div>
+        )}
+
+        {!loading && !loadError && original && (
+          <form className="edit-video-form" onSubmit={handleSave}>
+            {/* Thumbnail */}
+            <label className="edit-video-label">Thumbnail</label>
+            <div className="edit-video-thumb-row">
+              {thumbnailUrl ? (
+                <img
+                  className="edit-video-thumb-preview"
+                  src={thumbnailUrl}
+                  alt="Thumbnail preview"
+                  onError={(e) => { e.currentTarget.style.visibility = 'hidden'; }}
+                  onLoad={(e) => { e.currentTarget.style.visibility = 'visible'; }}
+                />
+              ) : (
+                <div className="edit-video-thumb-placeholder"><MdImage size={32} /></div>
+              )}
+              <div className="edit-video-thumb-inputs">
+                <input
+                  type="url"
+                  className="edit-video-input"
+                  value={thumbnailUrl}
+                  onChange={(e) => setThumbnailUrl(e.target.value)}
+                  placeholder="https://..."
+                  disabled={thumbUploading}
+                />
+                <button
+                  type="button"
+                  className="edit-video-upload-btn"
+                  onClick={() => thumbInputRef.current?.click()}
+                  disabled={thumbUploading || saving}
+                  title="Upload an image"
+                >
+                  <MdUpload size={16} />
+                  {thumbUploading ? 'Uploading…' : 'Upload'}
+                </button>
+                <input
+                  ref={thumbInputRef}
+                  type="file"
+                  accept="image/*"
+                  style={{ display: 'none' }}
+                  onChange={handleThumbFilePick}
+                />
+              </div>
+            </div>
+            <span className="edit-video-hint">
+              Upload an image or paste a direct URL. Leave unchanged to keep the current thumbnail.
+            </span>
+
+            {/* Title */}
+            <label className="edit-video-label">Title</label>
+            <input
+              type="text"
+              className="edit-video-input"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              maxLength={TITLE_MAX}
+            />
+            <span className={`edit-video-hint${!titleValid && title ? ' error' : ''}`}>
+              {titleLen}/{TITLE_MAX} · min {TITLE_MIN}
+            </span>
+
+            {/* Tags */}
+            <label className="edit-video-label">Tags</label>
+            <input
+              type="text"
+              className="edit-video-input"
+              value={tagsInput}
+              onChange={(e) => setTagsInput(e.target.value)}
+              placeholder="space-separated"
+            />
+            <div className="edit-video-tags-preview">
+              {parsedTags.map((t) => <span key={t}>#{t}</span>)}
+            </div>
+            <span className={`edit-video-hint${!tagsValid && parsedTags.length ? ' error' : ''}`}>
+              {parsedTags.length}/{MAX_TAGS} tags · at least 1 required
+            </span>
+
+            {/* Body */}
+            <label className="edit-video-label">Description</label>
+            <textarea
+              className="edit-video-textarea"
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              rows={10}
+              placeholder="Tell viewers about your video…"
+            />
+            <span className="edit-video-hint">
+              Supports markdown. The 3Speak video embed at the top and bottom of
+              your post is preserved automatically.
+            </span>
+
+            <div className="edit-video-actions">
+              <button
+                type="button"
+                className="edit-video-btn-secondary"
+                onClick={onClose}
+                disabled={saving}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="edit-video-btn-primary"
+                disabled={!canSave || !isDirty}
+              >
+                {saving ? 'Saving…' : 'Save changes'}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/components/playVideo/EditVideoModal.scss
+++ b/src/components/playVideo/EditVideoModal.scss
@@ -1,0 +1,245 @@
+@use "../../mixins.scss" as mix;
+
+.edit-video-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+
+  @include mix.respond(phone) {
+    align-items: flex-end;
+    padding: 0;
+  }
+}
+
+.edit-video-modal-content {
+  background: var(--card-bg, #fff);
+  color: var(--text-primary, #000);
+  border-radius: 12px;
+  padding: 24px;
+  width: 560px;
+  max-width: 95vw;
+  max-height: 90vh;
+  overflow-y: auto;
+  position: relative;
+
+  @include mix.respond(phone) {
+    width: 100%;
+    max-width: 100%;
+    max-height: 90vh;
+    border-radius: 16px 16px 0 0;
+    padding: 20px 16px;
+    padding-bottom: calc(20px + env(safe-area-inset-bottom, 0px));
+    animation: edit-video-modal-slide-up 0.25s ease forwards;
+  }
+}
+
+.edit-video-close-btn {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-primary, #000);
+  padding: 4px;
+  display: flex;
+  align-items: center;
+}
+
+.edit-video-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0 0 4px;
+}
+
+.edit-video-subtitle {
+  font-size: 12px;
+  color: var(--text-secondary, #888);
+  margin: 0 0 16px;
+  word-break: break-all;
+}
+
+.edit-video-loading,
+.edit-video-error {
+  padding: 24px 0;
+  text-align: center;
+  font-size: 14px;
+  color: var(--text-secondary, #888);
+}
+
+.edit-video-error {
+  color: var(--accent-color, #e31337);
+}
+
+.edit-video-form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-align: left;
+}
+
+.edit-video-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary, #666);
+  margin-top: 10px;
+}
+
+.edit-video-input,
+.edit-video-textarea {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color, #ddd);
+  background: var(--input-bg, #f9f9f9);
+  color: var(--text-primary, #000);
+  font-size: 14px;
+  font-family: inherit;
+  box-sizing: border-box;
+
+  &:focus {
+    outline: none;
+    border-color: var(--accent-color, #e31337);
+  }
+}
+
+.edit-video-textarea {
+  resize: vertical;
+  min-height: 160px;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 13px;
+}
+
+.edit-video-hint {
+  font-size: 11px;
+  color: var(--text-secondary, #888);
+  margin-bottom: 4px;
+
+  &.error {
+    color: var(--accent-color, #e31337);
+  }
+}
+
+.edit-video-thumb-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.edit-video-thumb-inputs {
+  display: flex;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+}
+
+.edit-video-upload-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 12px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color, #ddd);
+  background: var(--input-bg, #f9f9f9);
+  color: var(--text-primary, #000);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+
+  &:hover:not(:disabled) {
+    background: var(--border-color, #e5e5e5);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.edit-video-thumb-preview {
+  width: 96px;
+  height: 54px;
+  object-fit: cover;
+  border-radius: 6px;
+  background: var(--input-bg, #f0f0f0);
+  flex-shrink: 0;
+}
+
+.edit-video-thumb-placeholder {
+  width: 96px;
+  height: 54px;
+  border-radius: 6px;
+  background: var(--input-bg, #f0f0f0);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary, #888);
+}
+
+.edit-video-tags-preview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+
+  span {
+    font-size: 11px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: var(--input-bg, #f0f0f0);
+    color: var(--text-secondary, #666);
+  }
+}
+
+.edit-video-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.edit-video-btn-primary,
+.edit-video-btn-secondary {
+  padding: 10px 18px;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.edit-video-btn-primary {
+  background: var(--accent-color, #e31337);
+  color: #fff;
+
+  &:hover:not(:disabled) { opacity: 0.9; }
+}
+
+.edit-video-btn-secondary {
+  background: transparent;
+  color: var(--text-primary, #000);
+  border: 1px solid var(--border-color, #ddd);
+
+  &:hover:not(:disabled) {
+    background: var(--input-bg, #f0f0f0);
+  }
+}
+
+@keyframes edit-video-modal-slide-up {
+  from { transform: translateY(100%); }
+  to { transform: translateY(0); }
+}

--- a/src/components/playVideo/PlayVideo.jsx
+++ b/src/components/playVideo/PlayVideo.jsx
@@ -47,11 +47,12 @@ import { recordReshare, getResharesForVideo } from '../../utils/reshares';
 import EditorModal from '../modal/EditorModal';
 import SubtitleOverlay from '../SubtitleOverlay/SubtitleOverlay';
 import ReportModal, { isReported } from '../modal/ReportModal';
-import { MdFlag } from 'react-icons/md';
+import EditVideoModal from './EditVideoModal';
+import { MdFlag, MdEdit } from 'react-icons/md';
 
 dayjs.extend(relativeTime);
 
-const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlaylist, videoControls, mobileReactionPanel, cinemaReactionPanel, videoRef, wrapperRef }) => {
+const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlaylist, videoControls, mobileReactionPanel, cinemaReactionPanel, videoRef, wrapperRef, onVideoEdited, overrideBody }) => {
   const { user, authenticated } = useAppStore();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -87,6 +88,7 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
   const [speakData, setSpeakData] = useState(null);
   const [isPlaylistModalOpen, setIsPlaylistModalOpen] = useState(false);
   const [isReportOpen, setIsReportOpen] = useState(false);
+  const [isEditOpen, setIsEditOpen] = useState(false);
   const [isRemovingWatchLater, setIsRemovingWatchLater] = useState(false);
   const [communityData, setCommunityData] = useState(null);
   const [authorReputation, setAuthorReputation] = useState(null);
@@ -914,6 +916,20 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
                   {reshareCount > 0 && <span className="reshare-count">{reshareCount}</span>}
                 </button>
 
+                {authenticated && user === author && (
+                  <button
+                    type="button"
+                    className="edit-video-btn"
+                    onClick={() => {
+                      videoControls?.onPause?.();
+                      setIsEditOpen(true);
+                    }}
+                    title="Edit video details"
+                  >
+                    <MdEdit size={16} />
+                  </button>
+                )}
+
                 <button
                   type="button"
                   className={`report-btn${isReported('post', `${author}/${permlink}`) ? ' reported' : ''}`}
@@ -1027,7 +1043,7 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
         <div className="description-wrap">
           <div className={`description-collapsible${descriptionExpanded ? '' : ' collapsed'}`}>
             <div className="blog-content">
-              <BlogContent author={author} permlink={permlink} />
+              <BlogContent author={author} permlink={permlink} description={overrideBody} />
             </div>
           </div>
           <button
@@ -1101,6 +1117,14 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
         onClose={() => setIsReportOpen(false)}
         type="video"
         target={{ author, permlink }}
+      />
+
+      <EditVideoModal
+        isOpen={isEditOpen}
+        onClose={() => setIsEditOpen(false)}
+        author={author}
+        permlink={permlink}
+        onSaved={(changes) => onVideoEdited?.(changes)}
       />
 
       {/* Mobile FAB — speed-dial for quick actions */}

--- a/src/components/playVideo/PlayVideo.scss
+++ b/src/components/playVideo/PlayVideo.scss
@@ -440,6 +440,24 @@
                 }
             }
 
+            .edit-video-btn {
+                display: inline-flex;
+                align-items: center;
+                padding: 4px 8px;
+                background-color: rgba(255, 255, 255, 0.1);
+                color: var(--text-secondary);
+                border: none;
+                border-radius: 5px;
+                font-size: 13px;
+                cursor: pointer;
+                transition: all 0.2s ease;
+
+                &:hover {
+                  background-color: var(--accent-primary);
+                  color: var(--text-inverse);
+                }
+            }
+
             .report-btn {
                 display: inline-flex;
                 align-items: center;

--- a/src/page/Watch.jsx
+++ b/src/page/Watch.jsx
@@ -740,7 +740,40 @@ function Watch() {
     return () => { cancelled = true; };
   }, [videoLoading, videoData, author, permlink]);
 
-  const videoDetails = videoData?.socialPost || hiveFallback;
+  // Optimistic override populated right after the author saves an edit.
+  // The GraphQL indexer may lag a few minutes behind the Hive blockchain,
+  // so we merge these values onto videoDetails immediately, then let a
+  // scheduled refetch replace them with real server data.
+  const [editOverride, setEditOverride] = useState(null);
+  const baseVideoDetails = videoData?.socialPost || hiveFallback;
+  const videoDetails = useMemo(() => {
+    if (!baseVideoDetails || !editOverride) return baseVideoDetails;
+    const merged = { ...baseVideoDetails, ...editOverride };
+    // Update thumbnail inside nested spkvideo shape as well
+    if (editOverride.thumbnail_url && baseVideoDetails.spkvideo) {
+      merged.spkvideo = { ...baseVideoDetails.spkvideo, thumbnail_url: editOverride.thumbnail_url };
+    }
+    return merged;
+  }, [baseVideoDetails, editOverride]);
+
+  const handleVideoEdited = useCallback((changes) => {
+    if (!changes) return;
+    setEditOverride({
+      title: changes.title,
+      body: changes.body,
+      tags: changes.tags,
+      thumbnail_url: changes.thumbnail || undefined,
+    });
+    // Wipe hive fallback so a fresh fetch can happen, and re-run the GraphQL query.
+    setHiveFallback(null);
+    setHiveFallbackDone(false);
+    // Apollo indexers typically trail chain by ~30-90s; requery a few times.
+    const timers = [8000, 20000, 45000].map((delay) =>
+      setTimeout(() => { refetchVideo().catch(() => {}); }, delay)
+    );
+    return () => timers.forEach(clearTimeout);
+  }, [refetchVideo]);
+
   // Record watch history when video loads (if tracking is enabled)
   useEffect(() => {
     if (!user || !author || !permlink || author === 'unknown' || watchHistoryEnabled === false) {
@@ -983,6 +1016,8 @@ function Watch() {
         wrapperRef={wrapperRef}
         playlistData={showPlaylist ? playlistData : null}
         onClosePlaylist={() => setShowPlaylist(false)}
+        onVideoEdited={handleVideoEdited}
+        overrideBody={editOverride?.body}
         videoControls={{
           currentTime: playerState.currentTime,
           duration: playerState.duration,


### PR DESCRIPTION
#209
Add an edit button to the watch page, visible only to the video's author. Opens a modal that fetches the post fresh from Hive, lets the author change title, tags, description body, and thumbnail (via URL paste or upload through the same image service the studio uploaders use), then rebroadcasts a comment op to update the post.

Preserves the 3Speak-specific body wrapping (thumbnail link, 'Watch on 3Speak' header, footer link) by splitting the body into header+middle+footer - user only edits the middle, and we rewrite the thumbnail inside the header link on save.

Video playback pauses when the modal opens, and Watch.jsx merges the change optimistically so the new values appear immediately, then schedules refetches (8s/20s/45s) to replace them once the GraphQL indexer catches up with the chain.