### PR TITLE
fix: pass images.ecency.com thumbnails through without Hive proxy

### DIFF
--- a/src/utils/fixThumbnails.js
+++ b/src/utils/fixThumbnails.js
@@ -9,7 +9,7 @@ const FALLBACK_THUMBNAIL = "/images/speak.jpg"; // Local fallback image
 export { fallbackImg };
 
 export function fixVideoThumbnail(video) {
-  const thumbnail = video?.images?.thumbnail || video?.thumbUrl || video?.spkvideo?.thumbnail_url || video?.thumbnailUrl || video?.thumbnail;
+  const thumbnail = video?.images?.thumbnail || video?.thumbUrl || video?.spkvideo?.thumbnail_url || video?.thumbnailUrl || video?.thumbnail_url || video?.thumbnail;
 
   // Validate thumbnail exists and is not just whitespace
   if (!thumbnail || typeof thumbnail !== 'string' || thumbnail.trim() === '') {
@@ -43,7 +43,7 @@ export function fixVideoThumbnail(video) {
   }
 
   // ✅ Already using Hive proxy or our own image service - return as-is
-  if (cleanThumbnail.includes("images.hive.blog") || cleanThumbnail.includes("files.peakd.com") || cleanThumbnail.includes("images.3speak.tv")) {
+  if (cleanThumbnail.includes("images.hive.blog") || cleanThumbnail.includes("files.peakd.com") || cleanThumbnail.includes("images.3speak.tv") || cleanThumbnail.includes("images.ecency.com")) {
     return cleanThumbnail;
   }
 


### PR DESCRIPTION
## Summary

- `images.ecency.com` was missing from the trusted-domain passthrough list in `fixVideoThumbnail`, causing Ecency-hosted thumbnails to be re-wrapped through `images.hive.blog/p/` — which fails on Ecency's image gateway
- Also adds `video.thumbnail_url` (snake_case) to the field lookup chain so embed-style API responses that don't camelCase the field are not silently skipped

## Root cause

Users who post via Ecency store their thumbnails at `images.ecency.com`. The API returns these as `images.thumbnail` correctly, but `fixVideoThumbnail` only whitelisted `images.hive.blog`, `files.peakd.com`, and `images.3speak.tv` as pass-through domains. Everything else was run through the Hive image proxy, which cannot fetch Ecency's gateway URLs, resulting in blank thumbnails across the profile page.

## Test plan

- [ ] Visit a profile that uploads via Ecency (e.g. `/p/josueelinfame`) and confirm thumbnails render
- [ ] Confirm other profiles with IPFS / Hive-hosted thumbnails are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)