### PR TITLE
fix: hide carousel gradient fades when at scroll boundary

### DIFF
--- a/src/page/HomeGrouped.jsx
+++ b/src/page/HomeGrouped.jsx
@@ -120,7 +120,7 @@ const VideoRow = ({ title, videos, linkTo, isLoading, getContentForVideo, isWatc
         )}
       </div>
 
-      <div className="scroll-wrapper">
+      <div className={`scroll-wrapper${showLeftBtn ? ' has-left-fade' : ''}${showRightBtn ? ' has-right-fade' : ''}`}>
         {showLeftBtn && (
           <button className="scroll-btn left" onClick={() => scroll("left")}>
             <FaChevronLeft />

--- a/src/page/HomeGrouped.scss
+++ b/src/page/HomeGrouped.scss
@@ -95,7 +95,7 @@
     position: relative;
     overflow: hidden;
 
-    // Gradient fade hints on left/right edges
+    // Gradient fade hints — only visible when scrolling in that direction is possible
     &::before,
     &::after {
       content: '';
@@ -105,6 +105,7 @@
       width: 80px;
       pointer-events: none;
       z-index: 4;
+      opacity: 0;
       transition: opacity 0.2s ease;
     }
 
@@ -116,6 +117,14 @@
     &::after {
       right: 0;
       background: linear-gradient(to left, var(--bg-primary, #0d0d0d), transparent);
+    }
+
+    &.has-left-fade::before {
+      opacity: 1;
+    }
+
+    &.has-right-fade::after {
+      opacity: 1;
     }
 
     .scroll-btn {


### PR DESCRIPTION
## Summary

- Left gradient fade now only renders when the user can still scroll left (`has-left-fade` class)
- Right gradient fade now only renders when the user can still scroll right (`has-right-fade` class)
- Fades and arrows are now fully in sync — both appear and disappear together as scroll position changes, with the existing 0.2s opacity transition

## Behaviour before
Both fades were always visible, obscuring the first column of videos at the start of the carousel and the last column at the end — even when the corresponding arrow was hidden and no scrolling was possible.

## Behaviour after
At position 0: no left fade, no left arrow — first videos fully visible.  
Scrolled to end: no right fade, no right arrow — last videos fully visible.  
Mid-scroll: both fades and both arrows shown as before.

## Test plan
- [ ] Load home page, confirm left fade is absent on initial load
- [ ] Scroll right — confirm left fade appears alongside the left arrow
- [ ] Scroll to end — confirm right fade disappears alongside the right arrow
- [ ] Confirm smooth 0.2s transition on fade appearance/disappearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)