### PR TITLE
fix: 401 on room join — sync session token init in HangoutsProvider

### DIFF
--- a/src/components/OpenPod/OpenPodModal.jsx
+++ b/src/components/OpenPod/OpenPodModal.jsx
@@ -14,6 +14,19 @@ export default function OpenPodModal({ isOpen, onClose, roomName, sessionToken, 
 
   if (!isOpen || !roomName) return null;
 
+  // Don't mount HangoutsRoom until we have a session token — joining without
+  // auth causes an immediate 401 because the server requires Authorization.
+  if (!sessionToken) {
+    return (
+      <div className="openpod-modal-overlay">
+        <div className="openpod-modal" data-hh-theme="dark">
+          <button className="openpod-modal-close" onClick={onClose} aria-label="Close OpenPod">✕</button>
+          <div className="openpod-connecting">Authenticating with OpenPods…</div>
+        </div>
+      </div>
+    );
+  }
+
   const handleRecordingUploaded = (result) => {
     onClose();
     navigate(

--- a/src/components/OpenPod/OpenPodModal.scss
+++ b/src/components/OpenPod/OpenPodModal.scss
@@ -54,6 +54,15 @@
   to   { transform: translateY(0);    opacity: 1; }
 }
 
+.openpod-connecting {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 160px;
+  color: var(--text-secondary, rgba(255,255,255,0.5));
+  font-size: 14px;
+}
+
 .openpod-modal-close {
   position: absolute;
   top: 12px;

--- a/src/page/OpenPods.jsx
+++ b/src/page/OpenPods.jsx
@@ -19,7 +19,7 @@ const IMAGE_KEY = import.meta.env.VITE_IMAGE_SERVER_API_KEY;
 const HANGOUT_BASE_URL = 'https://hangout.3speak.tv/room';
 
 export default function OpenPods() {
-  const { openRoom, sessionToken, hangoutsUser } = useHangout();
+  const { openRoom, sessionToken, sessionLoading, hangoutsUser } = useHangout();
   const { authenticated, user } = useAppStore();
   const navigate = useNavigate();
 
@@ -70,13 +70,25 @@ export default function OpenPods() {
     );
   }
 
+  // Wait for the Hangouts session token — without it HangoutsProvider would
+  // show its own internal login form (wrong UX) and any join call would 401.
+  if (sessionLoading || !sessionToken) {
+    return (
+      <div className="openpods-page">
+        <div className="openpods-connecting">
+          <span>Connecting to OpenPods…</span>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="openpods-page" data-hh-theme="dark">
       <HangoutsProvider
         apiBaseUrl={API_URL}
         livekitServerUrl={LK_URL}
         imageServerApiKey={IMAGE_KEY || undefined}
-        sessionToken={sessionToken || undefined}
+        sessionToken={sessionToken}
         username={hangoutsUser || undefined}
       >
         <RoomLobby

--- a/src/page/OpenPods.scss
+++ b/src/page/OpenPods.scss
@@ -22,6 +22,15 @@
   --hh-shadow:           0 4px 16px rgba(0, 0, 0, 0.4);
 }
 
+.openpods-connecting {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40vh;
+  color: var(--text-secondary, rgba(255,255,255,0.5));
+  font-size: 15px;
+}
+
 .openpods-login-gate {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Problem

Every room join was failing with 401 `HangoutsApiError: Missing or invalid Authorization header`, even when a valid session token existed.

**Root cause — React effect ordering:**
React fires child component effects *before* parent effects. `HangoutsProvider` created `apiClient` in `useMemo` (no token) and set the token in a `useEffect`. But `HangoutsRoom` (a child) also has a `useEffect` that calls `room.join()` → `apiClient.joinRoom()`. The child effect fires first, so `joinRoom` was always called before the token landed on `apiClient`.

## Fix

**SDK `@snapie/hangouts-react` 0.3.11:**
- `HangoutsProvider`: set session token synchronously inside `useMemo` so `apiClient` has auth before any child effect can fire
- `HangoutsRoom`: gate `join()` on `isAuthenticated` as defense-in-depth

**3speak.tv:** updated dependency to `^0.3.11`

## Commits

1. `0cd71ad` — frontend modal/lobby guards from PR #262 (already merged)
2. `1cb1da0` — SDK 0.3.11 + package.json update (this commit, the real fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)