### PR TITLE
fix: bump @snapie/hangouts-react to 0.3.11 — fix 401 on room join

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,9 +24,12 @@
         "@hiveio/dhive": "^1.3.2",
         "@hiveio/hive-js": "^2.0.8",
         "@jwplayer/jwplayer-react": "^1.1.3",
+        "@livekit/components-react": "^2.9.20",
         "@mantequilla-soft/3speak-player": "^0.3.2",
         "@rajesh896/video-thumbnails-generator": "^2.3.9",
         "@reduxjs/toolkit": "^2.6.1",
+        "@snapie/hangouts-core": "^0.3.2",
+        "@snapie/hangouts-react": "^0.3.11",
         "@snapie/renderer": "^0.1.1",
         "@tanstack/react-query": "^5.90.2",
         "@tiptap/core": "^3.11.1",
@@ -69,6 +72,7 @@
         "jwt-decode": "^4.0.0",
         "keychain-sdk": "^0.8.5",
         "ldrs": "^1.1.6",
+        "livekit-client": "^2.18.8",
         "lodash.debounce": "^4.0.8",
         "lowlight": "^3.3.0",
         "lucide-react": "^0.503.0",
@@ -2013,6 +2017,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
     "node_modules/@capacitor/android": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-8.1.0.tgz",
@@ -2937,7 +2947,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
       "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@floating-ui/utils": "^0.2.11"
       }
@@ -2957,8 +2966,7 @@
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@fortawesome/fontawesome-free": {
       "version": "6.7.2",
@@ -3693,6 +3701,77 @@
       "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.13.0.tgz",
       "integrity": "sha512-4+qRW2Pc8V+btL0QEmdB2X+uyx0kOWMWE1/LWsq5sZy3Q5tpi4eItJS6mB0XL3wGW59RQ+8bchNQQ1OW/va8Og==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/components-core": {
+      "version": "0.12.13",
+      "resolved": "https://registry.npmjs.org/@livekit/components-core/-/components-core-0.12.13.tgz",
+      "integrity": "sha512-DQmi84afHoHjZ62wm8y+XPNIDHTwFHAltjd3lmyXj8UZHOY7wcza4vFt1xnghJOD5wLRY58L1dkAgAw59MgWvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@floating-ui/dom": "1.7.4",
+        "loglevel": "1.9.1",
+        "rxjs": "7.8.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "livekit-client": "^2.17.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@livekit/components-core/node_modules/@floating-ui/dom": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@livekit/components-react": {
+      "version": "2.9.20",
+      "resolved": "https://registry.npmjs.org/@livekit/components-react/-/components-react-2.9.20.tgz",
+      "integrity": "sha512-hjkYOsJj9Jbghb7wM5cI8HoVisKeL6Zcy1VnRWTLm0sqVbto8GJp/17T4Udx85mCPY6Jgh8I1Cv0yVzgz7CQtg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/components-core": "0.12.13",
+        "clsx": "2.1.1",
+        "events": "^3.3.0",
+        "jose": "^6.0.12",
+        "usehooks-ts": "3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@livekit/krisp-noise-filter": "^0.2.12 || ^0.3.0",
+        "livekit-client": "^2.17.2",
+        "react": ">=18",
+        "react-dom": ">=18",
+        "tslib": "^2.6.2"
+      },
+      "peerDependenciesMeta": {
+        "@livekit/krisp-noise-filter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@livekit/mutex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
+      "integrity": "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.45.3",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.45.3.tgz",
+      "integrity": "sha512-WmMxBTsy4dRBqcrswFwUUlgq3Z0nnhOqKR6tX749Rb/PcB1yBMUtrHxZvcsS6qi3/5+86zHeVG+exmu1sZqfJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
     },
     "node_modules/@mantequilla-soft/3speak-player": {
       "version": "0.3.2",
@@ -4707,6 +4786,26 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@snapie/hangouts-core": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@snapie/hangouts-core/-/hangouts-core-0.3.2.tgz",
+      "integrity": "sha512-odDBptvcY+CbGiOGgu/003EaAcROzCagTD40PDdSf0YRkyTkKxl8SxnwmDHhl+Bx1BhP3/QbFYFfOijHyHcnZg==",
+      "license": "MIT"
+    },
+    "node_modules/@snapie/hangouts-react": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@snapie/hangouts-react/-/hangouts-react-0.3.11.tgz",
+      "integrity": "sha512-z2LHTPYtVofexZeWLut0/HZWoTICPVyZSjCrMA63jklnkSFLkJIz50q2gFs+nIN6inWaVJnpZH1HV0AxgIsOfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@snapie/hangouts-core": "^0.3.0"
+      },
+      "peerDependencies": {
+        "@livekit/components-react": "^2.0.0",
+        "livekit-client": "^2.0.0",
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@snapie/renderer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@snapie/renderer/-/renderer-0.1.1.tgz",
@@ -5461,6 +5560,13 @@
       "resolved": "https://registry.npmjs.org/@types/deep-freeze-strict/-/deep-freeze-strict-1.1.2.tgz",
       "integrity": "sha512-VvMETBojHvhX4f+ocYTySQlXMZfxKV3Jyb7iCWlWaC+exbedkv6Iv2bZZqI736qXjVguH6IH7bzwMBMfTT+zuQ==",
       "license": "MIT"
+    },
+    "node_modules/@types/dom-mediacapture-record": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
+      "integrity": "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.7",
@@ -9964,6 +10070,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-base64": {
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
@@ -10286,6 +10401,39 @@
       "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
       "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA=="
     },
+    "node_modules/livekit-client": {
+      "version": "2.18.8",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.18.8.tgz",
+      "integrity": "sha512-E+bSpnBVng/1xG4RfL1Q51dHUpBwL14Wix4sR5bS0djEzKMEtrxcUyhWLltdwQ0USf1t0PaxW6WL4oVb2s4Fsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/mutex": "1.1.1",
+        "@livekit/protocol": "1.45.3",
+        "events": "^3.3.0",
+        "jose": "^6.1.0",
+        "loglevel": "^1.9.2",
+        "sdp-transform": "^2.15.0",
+        "tslib": "2.8.1",
+        "typed-emitter": "^2.1.0",
+        "webrtc-adapter": "9.0.5"
+      },
+      "peerDependencies": {
+        "@types/dom-mediacapture-record": "^1"
+      }
+    },
+    "node_modules/livekit-client/node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -10413,6 +10561,19 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
+      "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
     },
     "node_modules/lolight": {
       "version": "1.4.1",
@@ -13616,6 +13777,21 @@
       "integrity": "sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg==",
       "license": "MIT"
     },
+    "node_modules/sdp": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz",
+      "integrity": "sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==",
+      "license": "MIT"
+    },
+    "node_modules/sdp-transform": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz",
+      "integrity": "sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==",
+      "license": "MIT",
+      "bin": {
+        "sdp-verify": "checker.js"
+      }
+    },
     "node_modules/secp256k1": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.1.tgz",
@@ -14690,6 +14866,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "rxjs": "*"
+      }
+    },
     "node_modules/typescript-chained-error": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/typescript-chained-error/-/typescript-chained-error-1.6.0.tgz",
@@ -15003,6 +15188,21 @@
       "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/usehooks-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.1.tgz",
+      "integrity": "sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.debounce": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=16.15.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/util": {
@@ -15405,6 +15605,19 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.5.tgz",
+      "integrity": "sha512-U9vjByy/sK2OMXu5mmfuZFKTMIUQe34c0JXRO+oDrxJTsntdYT2iIFwYMOV7HhMTuktcZLGf2W1N/OcSf9ssWg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
+      }
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@rajesh896/video-thumbnails-generator": "^2.3.9",
     "@reduxjs/toolkit": "^2.6.1",
     "@snapie/hangouts-core": "^0.3.2",
-    "@snapie/hangouts-react": "^0.3.10",
+    "@snapie/hangouts-react": "^0.3.11",
     "@snapie/renderer": "^0.1.1",
     "@tanstack/react-query": "^5.90.2",
     "@tiptap/core": "^3.11.1",


### PR DESCRIPTION
## What

Updates `@snapie/hangouts-react` from 0.3.10 → 0.3.11.

## Why

Room joins were failing with 401 even after the modal/lobby guards landed in the previous PR. The real root cause was inside the SDK itself:

`HangoutsProvider` created `apiClient` in `useMemo` (no token), then set the token in `useEffect`. React fires child effects before parent effects, so `HangoutsRoom.join()` always fired before the token was on `apiClient` — every join went out unauthenticated.

## SDK fix (0.3.11)

- `HangoutsProvider`: set session token **synchronously** inside `useMemo` so the client has auth before any child effect can run
- `HangoutsRoom`: gate `join()` on `isAuthenticated` as defense-in-depth

## Why it worked on SnapieIO / locally but not on preview

- **SnapieIO**: uses the SDK's internal Keychain auth — `HangoutsRoom` only renders after login completes, so the token is always set first. No race.
- **Local dev**: React StrictMode runs effects twice. First join fails silently, second succeeds (token is set by then). Production has no StrictMode, so there's no retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)