### PR TITLE
fix: OpenPods light mode visibility and sidebar badge

### DIFF
--- a/src/components/OpenPod/OpenPodModal.scss
+++ b/src/components/OpenPod/OpenPodModal.scss
@@ -29,24 +29,24 @@
   box-shadow: 0 24px 64px rgba(0, 0, 0, 0.6);
   animation: openpod-slide-up 0.2s ease;
 
-  // Map SDK CSS variables onto 3speak TV theme tokens
-  --hh-bg:               var(--bg-primary, #0d0d0d);
-  --hh-bg-secondary:     var(--bg-secondary, #1a1a1a);
-  --hh-bg-hover:         rgba(255, 255, 255, 0.07);
-  --hh-text:             var(--text-primary, #ffffff);
-  --hh-text-secondary:   rgba(255, 255, 255, 0.6);
-  --hh-text-muted:       rgba(255, 255, 255, 0.35);
-  --hh-border:           rgba(255, 255, 255, 0.1);
-  --hh-border-light:     rgba(255, 255, 255, 0.06);
-  --hh-input-border:     rgba(255, 255, 255, 0.15);
+  // Map SDK CSS variables onto 3speak TV theme tokens (theme-aware)
+  --hh-bg:               var(--bg-primary);
+  --hh-bg-secondary:     var(--card-bg);
+  --hh-bg-hover:         var(--bg-hover);
+  --hh-text:             var(--text-primary);
+  --hh-text-secondary:   var(--text-secondary);
+  --hh-text-muted:       var(--text-muted, var(--text-secondary));
+  --hh-border:           var(--border-color);
+  --hh-border-light:     var(--border-light);
+  --hh-input-border:     var(--border-color);
   --hh-primary:          var(--accent-primary, #e53935);
   --hh-primary-hover:    #c62828;
   --hh-danger:           #e53935;
   --hh-success:          #43a047;
-  --hh-btn-secondary-bg: rgba(255, 255, 255, 0.08);
-  --hh-btn-secondary-text: var(--text-primary, #ffffff);
-  --hh-btn-secondary-hover: rgba(255, 255, 255, 0.13);
-  --hh-shadow:           0 4px 16px rgba(0, 0, 0, 0.4);
+  --hh-btn-secondary-bg: var(--bg-tertiary);
+  --hh-btn-secondary-text: var(--text-primary);
+  --hh-btn-secondary-hover: var(--bg-hover);
+  --hh-shadow:           var(--card-shadow, 0 4px 16px rgba(0, 0, 0, 0.4));
 }
 
 @keyframes openpod-slide-up {

--- a/src/components/Sidebar/Sidebar.scss
+++ b/src/components/Sidebar/Sidebar.scss
@@ -1,4 +1,21 @@
 @use "../../mixins.scss" as mix;
+
+// Applies in both expanded and collapsed sidebar states
+.sidebar-live-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 6px;
+    background: var(--accent-primary, #e53935);
+    color: #fff;
+    font-size: 10px;
+    font-weight: 700;
+    border-radius: 10px;
+    padding: 1px 6px;
+    line-height: 16px;
+    min-width: 18px;
+}
+
 .sidebar{
     background: var(--sidebar-bg);
     width: 12%;
@@ -224,14 +241,4 @@ hr{
         }
     }
 
-    .sidebar-live-badge {
-        margin-left: 6px;
-        background: var(--accent-primary, #e53935);
-        color: #fff;
-        font-size: 10px;
-        font-weight: 700;
-        border-radius: 10px;
-        padding: 1px 6px;
-        line-height: 16px;
-    }
 }

--- a/src/page/OpenPods.scss
+++ b/src/page/OpenPods.scss
@@ -2,24 +2,24 @@
   padding: 24px;
   min-height: calc(100vh - 80px);
 
-  // Map SDK CSS vars to 3speak TV theme
-  --hh-bg:               var(--bg-primary, #0d0d0d);
-  --hh-bg-secondary:     var(--bg-secondary, #1a1a1a);
-  --hh-bg-hover:         rgba(255, 255, 255, 0.07);
-  --hh-text:             var(--text-primary, #ffffff);
-  --hh-text-secondary:   rgba(255, 255, 255, 0.6);
-  --hh-text-muted:       rgba(255, 255, 255, 0.35);
-  --hh-border:           rgba(255, 255, 255, 0.1);
-  --hh-border-light:     rgba(255, 255, 255, 0.06);
-  --hh-input-border:     rgba(255, 255, 255, 0.15);
+  // Map SDK CSS vars to 3speak TV theme (theme-aware — works in light and dark)
+  --hh-bg:               var(--bg-primary);
+  --hh-bg-secondary:     var(--card-bg);
+  --hh-bg-hover:         var(--bg-hover);
+  --hh-text:             var(--text-primary);
+  --hh-text-secondary:   var(--text-secondary);
+  --hh-text-muted:       var(--text-muted, var(--text-secondary));
+  --hh-border:           var(--border-color);
+  --hh-border-light:     var(--border-light);
+  --hh-input-border:     var(--border-color);
   --hh-primary:          var(--accent-primary, #e53935);
   --hh-primary-hover:    #c62828;
   --hh-danger:           #e53935;
   --hh-success:          #43a047;
-  --hh-btn-secondary-bg: rgba(255, 255, 255, 0.08);
-  --hh-btn-secondary-text: var(--text-primary, #ffffff);
-  --hh-btn-secondary-hover: rgba(255, 255, 255, 0.13);
-  --hh-shadow:           0 4px 16px rgba(0, 0, 0, 0.4);
+  --hh-btn-secondary-bg: var(--bg-tertiary);
+  --hh-btn-secondary-text: var(--text-primary);
+  --hh-btn-secondary-hover: var(--bg-hover);
+  --hh-shadow:           var(--card-shadow, 0 4px 16px rgba(0, 0, 0, 0.2));
 }
 
 .openpods-connecting {


### PR DESCRIPTION
## What

Two styling fixes for the OpenPods feature in light mode.

## Fixes

**1. Sidebar "OpenPods1" → "OpenPods 🔴1"**
The `.sidebar-live-badge` CSS was nested inside `.small-sidebar` (collapsed state only), so it had no styles when the sidebar was expanded — the count rendered as plain text directly after the label.

**2. OpenPods invisible in light mode**
All `--hh-*` CSS variable mappings were hardcoded to dark-mode rgba values:
- `--hh-border: rgba(255,255,255,0.1)` → invisible on white background → room cards had no visible border
- `--hh-input-border: rgba(255,255,255,0.15)` → invisible → "Add background image" button border invisible
- `--hh-text-secondary: rgba(255,255,255,0.6)` → white text → "Add background image" label invisible
- etc.

Replaced all of these with 3speak.tv's own theme-aware CSS variables (`--border-color`, `--card-bg`, `--text-secondary`, `--bg-hover`, etc.) which flip correctly between light and dark mode automatically. Applies to both the OpenPods lobby page and the room modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)