### PR TITLE
fix: defer HangoutsRoom mount to prevent 401 race on join

### DIFF
--- a/src/components/OpenPod/OpenPodModal.jsx
+++ b/src/components/OpenPod/OpenPodModal.jsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { HangoutsProvider, HangoutsRoom } from '@snapie/hangouts-react';
 import '@snapie/hangouts-react/src/styles/hangouts.css';
 import { useNavigate } from 'react-router-dom';
@@ -12,20 +13,17 @@ export default function OpenPodModal({ isOpen, onClose, roomName, sessionToken, 
   const navigate = useNavigate();
   useWakeLock(isOpen);
 
-  if (!isOpen || !roomName) return null;
+  // React fires child effects before parent effects. Without this flag,
+  // HangoutsRoom.useEffect (join) fires before HangoutsProvider.useEffect
+  // (setSessionToken on apiClient) — causing a 401 on every first join attempt.
+  // By deferring HangoutsRoom's mount to the render AFTER HangoutsProvider's
+  // effects have run, the token is guaranteed to be set before join() is called.
+  const [roomReady, setRoomReady] = useState(false);
+  useEffect(() => {
+    setRoomReady(!!sessionToken && isOpen && !!roomName);
+  }, [sessionToken, isOpen, roomName]);
 
-  // Don't mount HangoutsRoom until we have a session token — joining without
-  // auth causes an immediate 401 because the server requires Authorization.
-  if (!sessionToken) {
-    return (
-      <div className="openpod-modal-overlay">
-        <div className="openpod-modal" data-hh-theme="dark">
-          <button className="openpod-modal-close" onClick={onClose} aria-label="Close OpenPod">✕</button>
-          <div className="openpod-connecting">Authenticating with OpenPods…</div>
-        </div>
-      </div>
-    );
-  }
+  if (!isOpen || !roomName) return null;
 
   const handleRecordingUploaded = (result) => {
     onClose();
@@ -45,17 +43,23 @@ export default function OpenPodModal({ isOpen, onClose, roomName, sessionToken, 
           apiBaseUrl={API_URL}
           livekitServerUrl={LK_URL}
           imageServerApiKey={IMAGE_KEY || undefined}
-          sessionToken={sessionToken || undefined}
+          sessionToken={sessionToken}
           username={username || undefined}
         >
-          <HangoutsRoom
-            roomName={roomName}
-            onLeave={onClose}
-            onRecordingUploaded={handleRecordingUploaded}
-            video
-            embedded
-            maxHeight="78vh"
-          />
+          {roomReady ? (
+            <HangoutsRoom
+              roomName={roomName}
+              onLeave={onClose}
+              onRecordingUploaded={handleRecordingUploaded}
+              video
+              embedded
+              maxHeight="78vh"
+            />
+          ) : (
+            <div className="openpod-connecting">
+              {sessionToken ? 'Connecting to OpenPods…' : 'Authenticating with OpenPods…'}
+            </div>
+          )}
         </HangoutsProvider>
       </div>
     </div>


### PR DESCRIPTION
## Problem

The OpenPods room join was failing with 401 on every first attempt in production (but not locally).

**Root cause:** React fires child component effects before parent effects. In the existing code:
1. `HangoutsProvider` (parent) sets `apiClient.sessionToken` in its `useEffect`
2. `HangoutsRoom` (child) calls `apiClient.joinRoom()` in its `useEffect`

Since child effects fire first, `join()` was called before the token was set on `apiClient` → 401.

**Why it worked locally:** React StrictMode (dev only) runs every effect twice. The first join failed silently; the second succeeded because the token was set by then.

## Fix

Added a `roomReady` state flag to `OpenPodModal`. On first render, `HangoutsRoom` is not mounted. After `HangoutsProvider`'s effects have fired (setting the token), `OpenPodModal`'s own `useEffect` sets `roomReady=true` → `HangoutsRoom` mounts for the first time with the token already in place → join succeeds.

This is a frontend-only fix with no SDK dependency.

## Test plan
- [ ] Open the OpenPods modal and join a room — no 401 in console
- [ ] Verify brief "Connecting to OpenPods…" message appears before the room loads
- [ ] Close and reopen the modal — still works on second join

🤖 Generated with [Claude Code](https://claude.com/claude-code)