### PR TITLE
Polish OpenPod audio player and post interactions

### DIFF
--- a/src/components/AudioPlayerInline/AudioPlayerInline.jsx
+++ b/src/components/AudioPlayerInline/AudioPlayerInline.jsx
@@ -1,11 +1,19 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import './AudioPlayerInline.scss';
 
 const SPEEDS = [1, 1.5, 2];
 
-export default function AudioPlayerInline({ src }) {
+export default function AudioPlayerInline({
+  src,
+  variant = 'inline',
+  title = 'OpenPod Recording',
+  subtitle = 'Recorded live on 3Speak OpenPods',
+  artworkUrl = '',
+  externalUrl = '',
+}) {
   const [audioUrl, setAudioUrl]       = useState(null);
   const [fallbackUrl, setFallbackUrl] = useState(null);
+  const [resolvedArtwork, setResolvedArtwork] = useState('');
   const [loading, setLoading]         = useState(true);
   const [failed, setFailed]           = useState(false);
   const [playing, setPlaying]         = useState(false);
@@ -28,6 +36,7 @@ export default function AudioPlayerInline({ src }) {
           if (!data?.audioUrl) throw new Error('no url');
           setAudioUrl(data.audioUrl);
           if (data.audioUrlFallback) setFallbackUrl(data.audioUrlFallback);
+          if (data.thumbnail_url) setResolvedArtwork(data.thumbnail_url);
           if (data.duration && !isNaN(data.duration)) setDuration(data.duration);
         })
         .catch(() => setFailed(true))
@@ -56,19 +65,19 @@ export default function AudioPlayerInline({ src }) {
     }
   };
 
-  const getRatio = (clientX) => {
+  const getRatio = useCallback((clientX) => {
     const bar = progressRef.current;
     if (!bar || !duration) return null;
     const rect = bar.getBoundingClientRect();
     return Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
-  };
+  }, [duration]);
 
-  const seekTo = (ratio) => {
+  const seekTo = useCallback((ratio) => {
     const a = audioRef.current;
     if (!a || ratio === null) return;
     a.currentTime = ratio * duration;
     setCurrentTime(ratio * duration);
-  };
+  }, [duration]);
 
   const handleProgressClick = (e) => seekTo(getRatio(e.clientX));
 
@@ -87,7 +96,7 @@ export default function AudioPlayerInline({ src }) {
       window.removeEventListener('mousemove', onMove);
       window.removeEventListener('mouseup', onUp);
     };
-  }, [dragging, duration]);
+  }, [dragging, duration, getRatio, seekTo]);
 
   const cycleSpeed = () => {
     const next = (speedIdx + 1) % SPEEDS.length;
@@ -102,11 +111,14 @@ export default function AudioPlayerInline({ src }) {
   };
 
   const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
+  const displayArtwork = artworkUrl || resolvedArtwork;
+  const hasMediaHeader = variant === 'preview' || displayArtwork || title || subtitle;
+  const kicker = variant === 'preview' ? 'Audio preview' : 'OpenPod';
 
   if (failed) return null;
 
   return (
-    <div className="apin">
+    <div className={`apin apin--${variant}`}>
       {audioUrl && (
         <audio
           ref={audioRef}
@@ -124,7 +136,25 @@ export default function AudioPlayerInline({ src }) {
         />
       )}
 
+      {hasMediaHeader && (
+        <div className="apin__media">
+          <div className="apin__art" aria-hidden="true">
+            {displayArtwork ? (
+              <img src={displayArtwork} alt="" />
+            ) : (
+              <span>OP</span>
+            )}
+          </div>
+          <div className="apin__meta">
+            <span className="apin__kicker">{kicker}</span>
+            <span className="apin__title">{title}</span>
+            {subtitle && <span className="apin__subtitle">{subtitle}</span>}
+          </div>
+        </div>
+      )}
+
       <button
+        type="button"
         className="apin__play"
         onClick={togglePlay}
         disabled={loading || !audioUrl}
@@ -160,9 +190,15 @@ export default function AudioPlayerInline({ src }) {
         {fmt(currentTime)}<span className="apin__sep"> / </span>{fmt(duration)}
       </span>
 
-      <button className="apin__speed" onClick={cycleSpeed}>
+      <button type="button" className="apin__speed" onClick={cycleSpeed}>
         {SPEEDS[speedIdx]}x
       </button>
+
+      {externalUrl && (
+        <a className="apin__external" href={externalUrl} target="_blank" rel="noopener noreferrer">
+          Open
+        </a>
+      )}
     </div>
   );
 }

--- a/src/components/AudioPlayerInline/AudioPlayerInline.scss
+++ b/src/components/AudioPlayerInline/AudioPlayerInline.scss
@@ -1,23 +1,109 @@
 .apin {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 14px;
-  background: var(--bg-tertiary);
+  gap: 12px;
+  padding: 12px;
+  background:
+    linear-gradient(135deg, rgba(229, 57, 53, 0.08), transparent 38%),
+    var(--bg-secondary);
   border: 1px solid var(--border-light);
-  border-radius: 10px;
+  border-radius: 14px;
   margin: 10px 0;
   width: 100%;
   box-sizing: border-box;
   user-select: none;
+  box-shadow: var(--shadow-sm);
+
+  &--preview {
+    align-items: stretch;
+    gap: 14px;
+    padding: 14px;
+    margin: 0;
+    background:
+      radial-gradient(circle at 0% 0%, rgba(229, 57, 53, 0.22), transparent 34%),
+      linear-gradient(135deg, var(--bg-secondary), var(--bg-tertiary));
+    border-color: color-mix(in srgb, var(--accent-primary, #e53935) 24%, var(--border-light));
+    box-shadow: 0 18px 44px rgba(0, 0, 0, 0.16);
+  }
+
+  &__media {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 190px;
+    flex: 0 0 auto;
+  }
+
+  &__art {
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    overflow: hidden;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background:
+      linear-gradient(145deg, rgba(229, 57, 53, 0.95), rgba(116, 22, 20, 0.95));
+    color: #fff;
+    font-size: 12px;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.22);
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      cursor: default;
+    }
+  }
+
+  &__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  &__kicker {
+    color: var(--accent-primary, #e53935);
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    line-height: 1;
+    text-transform: uppercase;
+  }
+
+  &__title {
+    color: var(--text-primary);
+    font-size: 13px;
+    font-weight: 700;
+    line-height: 1.25;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 220px;
+  }
+
+  &__subtitle {
+    color: var(--text-secondary);
+    font-size: 11px;
+    line-height: 1.25;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 220px;
+  }
 
   &__play {
     flex-shrink: 0;
-    width: 34px;
-    height: 34px;
+    width: 38px;
+    height: 38px;
     border-radius: 50%;
     border: none;
-    background: var(--accent-primary);
+    background:
+      linear-gradient(145deg, var(--accent-primary), var(--accent-hover, #c62828));
     color: #fff;
     display: flex;
     align-items: center;
@@ -43,14 +129,14 @@
   &__progress {
     flex: 1;
     position: relative;
-    padding: 10px 0;
+    padding: 14px 0;
     min-width: 0;
   }
 
   &__track {
-    height: 4px;
-    background: var(--border-light);
-    border-radius: 2px;
+    height: 6px;
+    background: color-mix(in srgb, var(--border-light) 75%, transparent);
+    border-radius: 999px;
     overflow: hidden;
   }
 
@@ -67,13 +153,15 @@
   &__thumb {
     position: absolute;
     top: 50%;
-    width: 12px;
-    height: 12px;
+    width: 14px;
+    height: 14px;
     background: var(--accent-primary);
+    border: 2px solid var(--bg-secondary);
     border-radius: 50%;
-    transform: translate(-50%, -50%) scale(0);
+    transform: translate(-50%, -50%) scale(0.85);
     transition: transform 0.15s;
     pointer-events: none;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.24);
   }
 
   &__progress:hover &__thumb {
@@ -86,6 +174,8 @@
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
     flex-shrink: 0;
+    min-width: 74px;
+    text-align: right;
   }
 
   &__sep {
@@ -109,6 +199,63 @@
       background: var(--accent-primary);
       color: #fff;
       border-color: transparent;
+    }
+  }
+
+  &__external {
+    align-self: center;
+    flex-shrink: 0;
+    border: 1px solid var(--border-light);
+    border-radius: 999px;
+    color: var(--text-secondary);
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1;
+    padding: 7px 10px;
+    text-decoration: none;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+
+    &:hover {
+      background: var(--bg-hover);
+      border-color: var(--accent-primary, #e53935);
+      color: var(--accent-primary, #e53935);
+      text-decoration: none;
+    }
+  }
+}
+
+@media (max-width: 720px) {
+  .apin {
+    flex-wrap: wrap;
+
+    &__media {
+      width: 100%;
+      min-width: 0;
+    }
+
+    &__progress {
+      flex-basis: calc(100% - 150px);
+    }
+  }
+}
+
+@media (max-width: 480px) {
+  .apin {
+    gap: 10px;
+
+    &__title,
+    &__subtitle {
+      max-width: 100%;
+    }
+
+    &__progress {
+      order: 4;
+      flex-basis: 100%;
+      padding: 6px 0 4px;
+    }
+
+    &__time {
+      margin-left: auto;
     }
   }
 }

--- a/src/components/OpenPod/OpenPodsLiveStrip.jsx
+++ b/src/components/OpenPod/OpenPodsLiveStrip.jsx
@@ -1,7 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 import { HangoutsApiClient } from '@snapie/hangouts-core';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useHangout } from '../../context/HangoutContext';
+import { useAppStore } from '../../lib/store';
 import { MdMic } from 'react-icons/md';
 import './OpenPodsLiveStrip.scss';
 
@@ -11,6 +12,8 @@ const client = new HangoutsApiClient({
 
 export default function OpenPodsLiveStrip() {
   const { openRoom } = useHangout();
+  const { authenticated } = useAppStore();
+  const navigate = useNavigate();
 
   const { data: rooms = [] } = useQuery({
     queryKey: ['openpods-live-rooms'],
@@ -20,6 +23,14 @@ export default function OpenPodsLiveStrip() {
   });
 
   if (rooms.length === 0) return null;
+
+  const handleJoinRoom = (roomName) => {
+    if (!authenticated) {
+      navigate('/login');
+      return;
+    }
+    openRoom(roomName);
+  };
 
   return (
     <div className="openpods-live-strip">
@@ -37,7 +48,7 @@ export default function OpenPodsLiveStrip() {
           <button
             key={room.name}
             className="strip-card"
-            onClick={() => openRoom(room.name)}
+            onClick={() => handleJoinRoom(room.name)}
             aria-label={`Join OpenPod: ${room.title}`}
           >
             <img

--- a/src/components/modal/ReportModal.jsx
+++ b/src/components/modal/ReportModal.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import { createPortal } from 'react-dom';
 import { IoClose } from 'react-icons/io5';
 import { toast } from 'sonner';
@@ -16,6 +16,16 @@ export function isReported(objectType, objectId) {
 }
 
 const REPORT_REASONS = {
+  post: [
+    { value: 'spam', label: 'Spam or misleading' },
+    { value: 'harassment', label: 'Harassment or bullying' },
+    { value: 'hate_speech', label: 'Hate speech' },
+    { value: 'violence', label: 'Violent or graphic content' },
+    { value: 'sexual', label: 'Sexual content' },
+    { value: 'copyright', label: 'Copyright infringement' },
+    { value: 'scam', label: 'Scam or fraud' },
+    { value: 'other', label: 'Other' },
+  ],
   video: [
     { value: 'spam', label: 'Spam or misleading' },
     { value: 'harassment', label: 'Harassment or bullying' },
@@ -48,7 +58,7 @@ const REPORT_REASONS = {
  *
  * @param {boolean} isOpen
  * @param {() => void} onClose
- * @param {'video' | 'comment' | 'user'} type
+ * @param {'post' | 'video' | 'comment' | 'user'} type
  * @param {{ author: string, permlink?: string }} target - what is being reported
  */
 export default function ReportModal({ isOpen, onClose, type = 'video', target }) {
@@ -99,7 +109,11 @@ export default function ReportModal({ isOpen, onClose, type = 'video', target })
 
       // Remember this report in localStorage
       const reportKey = `reported_${objectType}_${objectId}`;
-      try { localStorage.setItem(reportKey, '1'); } catch {}
+      try {
+        localStorage.setItem(reportKey, '1');
+      } catch {
+        // Ignore storage failures; the report itself was accepted.
+      }
 
       toast.success('Report submitted. Thank you.');
       handleClose();
@@ -119,7 +133,7 @@ export default function ReportModal({ isOpen, onClose, type = 'video', target })
 
   if (!isOpen) return null;
 
-  const typeLabel = type === 'user' ? 'User' : type === 'comment' ? 'Comment' : type === 'short' ? 'Short' : 'Video';
+  const typeLabel = type === 'user' ? 'User' : type === 'comment' ? 'Comment' : type === 'short' ? 'Short' : type === 'post' ? 'Post' : 'Video';
 
   return createPortal(
     <div className="report-modal-overlay" onClick={handleClose}>

--- a/src/context/HangoutContext.jsx
+++ b/src/context/HangoutContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import { HangoutsApiClient, loginWithSignFn } from '@snapie/hangouts-core';
 import { useAppStore } from '../lib/store';
 import aioha, { KeyTypes } from '../hive-api/aioha';
@@ -20,24 +20,42 @@ export function HangoutContextProvider({ children }) {
 
   const { authenticated, user } = useAppStore();
 
-  const loginToHangouts = async () => {
-    if (!authenticated || !user) return;
+  const loginToHangouts = useCallback(async (requestedUser = user) => {
+    if (!authenticated || !requestedUser) return null;
+
+    const isStillCurrentUser = () => {
+      const state = useAppStore.getState();
+      return state.authenticated && state.user === requestedUser;
+    };
 
     // Return cached token immediately
-    const cached = sessionCache.get(user);
+    const cached = sessionCache.get(requestedUser);
     if (cached) {
-      hangoutsClient.setSessionToken(cached);
-      setSessionToken(cached);
-      return;
+      if (isStillCurrentUser()) {
+        hangoutsClient.setSessionToken(cached);
+        setSessionToken(cached);
+      }
+      return cached;
     }
 
     // Deduplicate: if a login is already in-flight, await it
-    if (pendingLogin) {
+    if (pendingLogin?.user === requestedUser) {
       try {
-        const token = await pendingLogin;
-        setSessionToken(token);
+        const token = await pendingLogin.promise;
+        if (isStillCurrentUser()) setSessionToken(token);
+        return token;
       } catch { /* error already logged by the initiating call */ }
-      return;
+      return null;
+    }
+
+    // If another account is mid-signature, don't apply that token to this user.
+    // Wait for it to settle, then retry only if this account is still current.
+    if (pendingLogin) {
+      setSessionLoading(true);
+      try {
+        await pendingLogin.promise;
+      } catch { /* error already logged by the initiating call */ }
+      return isStillCurrentUser() ? loginToHangouts(requestedUser) : null;
     }
 
     setSessionLoading(true);
@@ -48,42 +66,68 @@ export function HangoutContextProvider({ children }) {
       return res.result;
     };
 
-    pendingLogin = loginWithSignFn(hangoutsClient, user, signFn)
+    const loginPromise = loginWithSignFn(hangoutsClient, requestedUser, signFn)
       .then(session => {
-        sessionCache.set(user, session.token);
-        hangoutsClient.setSessionToken(session.token);
+        sessionCache.set(session.username || requestedUser, session.token);
+        if (isStillCurrentUser()) {
+          hangoutsClient.setSessionToken(session.token);
+        } else {
+          hangoutsClient.clearSessionToken();
+        }
         return session.token;
       })
       .catch(err => {
         console.error('[OpenPods] Session auth failed:', err);
         throw err;
       })
-      .finally(() => { pendingLogin = null; });
+      .finally(() => {
+        if (pendingLogin?.user === requestedUser) pendingLogin = null;
+      });
+
+    pendingLogin = { user: requestedUser, promise: loginPromise };
 
     try {
-      const token = await pendingLogin;
-      setSessionToken(token);
+      const token = await loginPromise;
+      if (isStillCurrentUser()) setSessionToken(token);
+      return token;
     } catch {
-      setSessionToken(null);
+      if (isStillCurrentUser()) setSessionToken(null);
+      return null;
     } finally {
-      setSessionLoading(false);
+      if (isStillCurrentUser()) setSessionLoading(false);
     }
-  };
+  }, [authenticated, user]);
+
+  const openRoom = useCallback((roomName) => {
+    if (!roomName || !authenticated || !user) return false;
+
+    if (!sessionToken && !sessionLoading) {
+      loginToHangouts(user);
+    }
+
+    setActiveRoom(roomName);
+    return true;
+  }, [authenticated, user, sessionToken, sessionLoading, loginToHangouts]);
 
   useEffect(() => {
     if (authenticated && user) {
-      loginToHangouts();
-    } else {
+      setActiveRoom(null);
       setSessionToken(null);
+      hangoutsClient.clearSessionToken();
+      loginToHangouts(user);
+    } else {
+      setActiveRoom(null);
+      setSessionToken(null);
+      setSessionLoading(false);
       sessionCache.clear();
       hangoutsClient.clearSessionToken();
     }
-  }, [authenticated, user]);
+  }, [authenticated, user, loginToHangouts]);
 
   return (
     <HangoutContext.Provider value={{
       activeRoom,
-      openRoom:       setActiveRoom,
+      openRoom,
       closeRoom:      () => setActiveRoom(null),
       sessionToken,
       sessionLoading,

--- a/src/page/OpenPodPublish.jsx
+++ b/src/page/OpenPodPublish.jsx
@@ -10,6 +10,7 @@ import { commentWithAioha } from '../hive-api/aioha';
 import MarkdownComposer from '../components/studio/MarkdownComposer';
 import Community_modal from '../components/modal/Community_modal';
 import Beneficiary_modal from '../components/modal/Beneficiary_modal';
+import AudioPlayerInline from '../components/AudioPlayerInline/AudioPlayerInline';
 import './OpenPodPublish.scss';
 
 const HIVE_API = 'https://api.hive.blog';
@@ -37,7 +38,7 @@ export default function OpenPodPublish() {
   const [communityModalOpen, setCommunityModalOpen] = useState(false);
   const [beneModalOpen,      setBeneModalOpen]      = useState(false);
   const [beneList,   setBeneList]     = useState([]);
-  const [beneCount,  setBeneCount]    = useState(2);
+  const [_beneCount, setBeneCount]    = useState(2);
   const [remaining,  setRemaining]    = useState(89);
   const [publishing, setPublishing]   = useState(false);
   const [thumbnailUrl, setThumbnailUrl] = useState('');
@@ -202,18 +203,17 @@ export default function OpenPodPublish() {
       {/* Audio preview */}
       {audioUrl && (
         <div className="publish-audio-preview">
-          <span className="preview-label">Recording preview</span>
-          <iframe
-            src={`${audioUrl}&mode=compact&iframe=1`}
-            className="publish-audio-player"
-            height="65"
-            frameBorder="0"
-            allow="autoplay"
-            title="OpenPod Recording"
+          <div className="preview-copy">
+            <span className="preview-label">Recording preview</span>
+            <p>Review the audio before publishing. This is the same player readers will see on the post.</p>
+          </div>
+          <AudioPlayerInline
+            src={audioUrl}
+            variant="preview"
+            title={title || roomTitle || 'OpenPod Recording'}
+            artworkUrl={thumbnailUrl}
+            externalUrl={audioUrl}
           />
-          <a href={audioUrl} target="_blank" rel="noopener noreferrer" className="preview-link">
-            Open in new tab
-          </a>
         </div>
       )}
 

--- a/src/page/OpenPodPublish.scss
+++ b/src/page/OpenPodPublish.scss
@@ -32,19 +32,44 @@
 
 // ── Audio preview ─────────────────────────────────────────────
 .publish-audio-preview {
-  display: flex;
-  align-items: center;
+  display: grid;
   gap: 14px;
-  background: var(--bg-secondary, rgba(255,255,255,0.04));
-  border: 1px solid rgba(255,255,255,0.08);
-  border-radius: 10px;
-  padding: 14px 18px;
+  background:
+    linear-gradient(135deg, rgba(229, 57, 53, 0.08), transparent 42%),
+    var(--bg-secondary, rgba(255,255,255,0.04));
+  border: 1px solid var(--border-light, rgba(255,255,255,0.08));
+  border-radius: 16px;
+  padding: 16px;
   margin-bottom: 28px;
-  flex-wrap: wrap;
+  box-shadow: var(--shadow-sm);
 
   @include mix.respond(phone) {
-    flex-direction: column;
+    padding: 14px;
+  }
+}
+
+.preview-copy {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+
+  p {
+    margin: 0;
+    color: var(--text-secondary, rgba(255,255,255,0.5));
+    font-size: 13px;
+    line-height: 1.4;
+    text-align: right;
+  }
+
+  @include mix.respond(phone) {
     align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
+
+    p {
+      text-align: left;
+    }
   }
 }
 
@@ -55,24 +80,6 @@
   text-transform: uppercase;
   letter-spacing: 0.04em;
   white-space: nowrap;
-}
-
-.publish-audio-player {
-  flex: 1;
-  min-width: 200px;
-  height: 65px;
-  border: none;
-  border-radius: 6px;
-  background: transparent;
-}
-
-.preview-link {
-  font-size: 12px;
-  color: var(--text-secondary, rgba(255,255,255,0.5));
-  text-decoration: none;
-  white-space: nowrap;
-
-  &:hover { color: var(--text-primary); text-decoration: underline; }
 }
 
 // ── Form ──────────────────────────────────────────────────────

--- a/src/page/PostView.jsx
+++ b/src/page/PostView.jsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useParams, Navigate, Link, useLocation } from 'react-router-dom';
 import axios from 'axios';
+import { toast } from 'sonner';
 import { useAppStore } from '../lib/store';
 import BlogContent from '../components/playVideo/BlogContent';
 import CommentSection from '../components/playVideo/CommentSection';
@@ -9,9 +10,15 @@ import CommentVoteTooltip from '../components/tooltip/CommentVoteTooltip';
 import BarLoader from '../components/Loader/BarLoader';
 import AuthorBadge from '../components/AuthorBadge/AuthorBadge';
 import PayoutAmount from '../components/PayoutAmount/PayoutAmount';
+import TipModal from '../components/tip-reward/TipModal';
+import ReportModal, { isReported } from '../components/modal/ReportModal';
 import { HIVE_API_URL } from '../utils/config';
 import { resolveRootPost, ensure3SpeakStatus } from '../utils/threeSpeakDetection';
+import { recordReshare, getResharesForVideo } from '../utils/reshares';
+import { isLoggedIn } from '../hive-api/aioha';
 import { LuTimer } from 'react-icons/lu';
+import { Repeat2 } from 'lucide-react';
+import { MdAttachMoney, MdComment, MdFlag, MdShare } from 'react-icons/md';
 import './PostView.scss';
 
 function parseAudioPermlink(audioUrl) {
@@ -72,6 +79,10 @@ function PostView() {
   const [weight, setWeight]           = useState(100);
   const [voteValue, setVoteValue]     = useState(0);
   const [accountData, setAccountData] = useState(null);
+  const [reshareCount, setReshareCount] = useState(0);
+  const [hasReshared, setHasReshared] = useState(false);
+  const [isTipModalOpen, setIsTipModalOpen] = useState(false);
+  const [isReportOpen, setIsReportOpen] = useState(false);
 
   // Fetch the post via bridge.get_post (unless prefilled from navigation state)
   useEffect(() => {
@@ -120,6 +131,91 @@ function PostView() {
 
     return () => { cancelled = true; };
   }, [author, permlink]);
+
+  useEffect(() => {
+    if (!author || !permlink) return;
+    let cancelled = false;
+    setReshareCount(0);
+    setHasReshared(false);
+
+    (async () => {
+      try {
+        const { reshares, count } = await getResharesForVideo(author, permlink);
+        if (cancelled) return;
+        setReshareCount(count);
+        if (currentUser) {
+          setHasReshared(reshares.some(r => r.username === currentUser));
+        }
+      } catch (err) {
+        console.warn('Failed to fetch post reshares:', err);
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [author, permlink, currentUser]);
+
+  const requireLogin = useCallback((action) => {
+    if (authenticated && currentUser && isLoggedIn()) return true;
+    toast.error(`Log in to ${action}`);
+    return false;
+  }, [authenticated, currentUser]);
+
+  const toggleVoteTooltip = useCallback(() => {
+    if (!requireLogin('vote')) return;
+    setShowTooltip(prev => !prev);
+  }, [requireLogin]);
+
+  const handleShare = useCallback(async () => {
+    const shareUrl = `${window.location.origin}/post/${author}/${permlink}`;
+    const shareData = { title: post?.title || '3Speak Post', url: shareUrl };
+    try {
+      if (navigator.share && navigator.canShare?.(shareData)) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(shareUrl);
+        toast.success('Link copied to clipboard!');
+      }
+    } catch (err) {
+      if (err.name !== 'AbortError') {
+        try {
+          await navigator.clipboard.writeText(shareUrl);
+          toast.success('Link copied to clipboard!');
+        } catch {
+          toast.error('Failed to share');
+        }
+      }
+    }
+  }, [author, permlink, post?.title]);
+
+  const handleReshare = useCallback(async () => {
+    if (!requireLogin('reblog')) return;
+    if (hasReshared) {
+      toast.info('Already reblogged');
+      return;
+    }
+
+    const result = await recordReshare(currentUser, author, permlink);
+    if (result) {
+      setHasReshared(true);
+      setReshareCount(prev => prev + 1);
+      toast.success('Reblogged!');
+    } else {
+      toast.error('Failed to reblog');
+    }
+  }, [requireLogin, hasReshared, currentUser, author, permlink]);
+
+  const handleReply = useCallback(() => {
+    const commentBox = document.querySelector('.post-view-comments .add-comment-wrap .textarea-box');
+    if (commentBox) {
+      commentBox.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      setTimeout(() => commentBox.focus(), 350);
+    }
+  }, []);
+
+  const handleTip = useCallback(() => {
+    if (!requireLogin('tip')) return;
+    setIsTipModalOpen(true);
+  }, [requireLogin]);
 
   // Fetch thumbnail from audio backend for OpenPod posts
   useEffect(() => {
@@ -351,12 +447,54 @@ function PostView() {
         </div>
 
         <div className="post-view-actions">
-          <UpvoteCount
-            count={voteCount}
-            voted={isVoted}
-            onClick={() => setShowTooltip(v => !v)}
-            size={16}
-          />
+          <div className="post-view-actions-primary">
+            <button
+              type="button"
+              className={`post-action-btn post-action-btn-vote${isVoted ? ' active' : ''}`}
+              onClick={toggleVoteTooltip}
+              title={isVoted ? 'Adjust vote' : 'Upvote'}
+            >
+              <UpvoteCount
+                count={voteCount}
+                voted={isVoted}
+                size={15}
+              />
+            </button>
+            <button type="button" className="post-action-btn" onClick={handleReply} title="Reply">
+              <MdComment size={17} />
+              <span>Reply</span>
+            </button>
+          </div>
+
+          <div className="post-view-actions-secondary">
+            <button type="button" className="post-icon-action" onClick={handleShare} title="Share">
+              <MdShare size={17} />
+            </button>
+            <button
+              type="button"
+              className={`post-icon-action post-reshare-action${hasReshared ? ' active' : ''}`}
+              onClick={handleReshare}
+              disabled={!authenticated || !isLoggedIn()}
+              title={!authenticated ? 'Log in to reblog' : hasReshared ? 'Reblogged' : 'Reblog'}
+            >
+              <Repeat2 size={16} />
+              {reshareCount > 0 && <span>{reshareCount}</span>}
+            </button>
+            {authenticated && currentUser !== post.author && (
+              <button type="button" className="post-icon-action post-tip-action" onClick={handleTip} title="Tip creator">
+                <MdAttachMoney size={17} />
+              </button>
+            )}
+            <button
+              type="button"
+              className={`post-icon-action post-report-action${isReported('post', `${author}/${permlink}`) ? ' reported' : ''}`}
+              onClick={() => setIsReportOpen(true)}
+              title="Report post"
+            >
+              <MdFlag size={17} />
+            </button>
+          </div>
+
           {authenticated && showTooltip && (
             <CommentVoteTooltip
               showTooltip={showTooltip}
@@ -388,6 +526,21 @@ function PostView() {
           />
         </div>
       </div>
+
+      {isTipModalOpen && (
+        <TipModal
+          recipient={post.author}
+          isOpen={isTipModalOpen}
+          onClose={() => setIsTipModalOpen(false)}
+        />
+      )}
+
+      <ReportModal
+        isOpen={isReportOpen}
+        onClose={() => setIsReportOpen(false)}
+        type="post"
+        target={{ author, permlink }}
+      />
     </div>
   );
 }

--- a/src/page/PostView.scss
+++ b/src/page/PostView.scss
@@ -136,12 +136,119 @@
 .post-view-actions {
   display: flex;
   align-items: center;
-  gap: 16px;
-  padding: 10px 0;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 0;
   border-top: 1px solid var(--border-light);
   border-bottom: 1px solid var(--border-light);
   margin-bottom: 20px;
   position: relative;
+  flex-wrap: wrap;
+}
+
+.post-view-actions-primary,
+.post-view-actions-secondary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.post-action-btn,
+.post-icon-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 1px solid var(--border-light);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  min-height: 34px;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, transform 0.12s ease;
+
+  &:hover:not(:disabled) {
+    background: var(--bg-hover);
+    border-color: var(--accent-primary, #e53935);
+    color: var(--accent-primary, #e53935);
+    transform: translateY(-1px);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+  }
+}
+
+.post-action-btn {
+  padding: 7px 13px;
+}
+
+.post-action-btn-vote {
+  .upvote-count-badge {
+    color: inherit;
+  }
+
+  &.active {
+    border-color: color-mix(in srgb, var(--accent-primary, #e53935) 40%, var(--border-light));
+    color: var(--accent-primary, #e53935);
+    background: color-mix(in srgb, var(--accent-primary, #e53935) 10%, transparent);
+  }
+}
+
+.post-icon-action {
+  min-width: 34px;
+  padding: 7px 10px;
+}
+
+.post-reshare-action {
+  &.active {
+    border-color: rgba(34, 197, 94, 0.38);
+    color: #22c55e;
+    background: rgba(34, 197, 94, 0.12);
+  }
+
+  span {
+    font-size: 12px;
+    font-weight: 700;
+  }
+}
+
+.post-tip-action:hover:not(:disabled) {
+  color: #f59e0b;
+  border-color: rgba(245, 158, 11, 0.45);
+}
+
+.post-report-action {
+  &.reported {
+    color: #e31337;
+    background: rgba(227, 19, 55, 0.12);
+    border-color: rgba(227, 19, 55, 0.25);
+  }
+}
+
+@include mix.respond(phone) {
+  .post-view-actions {
+    align-items: stretch;
+  }
+
+  .post-view-actions-primary,
+  .post-view-actions-secondary {
+    width: 100%;
+  }
+
+  .post-view-actions-primary {
+    .post-action-btn {
+      flex: 1;
+    }
+  }
+
+  .post-view-actions-secondary {
+    justify-content: space-between;
+  }
 }
 
 .post-view-comments {


### PR DESCRIPTION
## Summary
- Replace the OpenPod publish iframe preview with the shared React audio player and add a polished preview variant.
- Harden Aioha/Hangouts session handling so stale or cross-account tokens cannot be applied during room joins.
- Add post-level actions for OpenPod posts: vote, reply jump, share, reblog, tip, and report.

## Test plan
- `npx eslint src/components/AudioPlayerInline/AudioPlayerInline.jsx src/page/OpenPodPublish.jsx`
- `npx eslint src/context/HangoutContext.jsx src/components/OpenPod/OpenPodsLiveStrip.jsx src/components/AudioPlayerInline/AudioPlayerInline.jsx src/page/OpenPodPublish.jsx`
- `npx eslint src/page/PostView.jsx src/page/PostView.scss src/components/modal/ReportModal.jsx` (warnings only)
- `npm run build`

Notes: full repo lint still has existing unrelated failures/noise outside this change.

Made with [Cursor](https://cursor.com)