### PR TITLE
fix(openpods): kill join 401 race + bump hangouts-react to 0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@rajesh896/video-thumbnails-generator": "^2.3.9",
         "@reduxjs/toolkit": "^2.6.1",
         "@snapie/hangouts-core": "^0.4.0",
-        "@snapie/hangouts-react": "^0.4.0",
+        "@snapie/hangouts-react": "^0.4.1",
         "@snapie/renderer": "^0.1.1",
         "@tanstack/react-query": "^5.90.2",
         "@tiptap/core": "^3.11.1",
@@ -4729,9 +4729,9 @@
       "license": "MIT"
     },
     "node_modules/@snapie/hangouts-react": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@snapie/hangouts-react/-/hangouts-react-0.4.0.tgz",
-      "integrity": "sha512-xLlvmbEsk4ZGgHiaTjijFTbio6jTuvq80zzMjoQDWDZ+jiOUC5guNEEB5vJxHs1P+JgLHcFvwKEmwEmrQN9kpQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@snapie/hangouts-react/-/hangouts-react-0.4.1.tgz",
+      "integrity": "sha512-GOBkCwV2WFQ/9fzcKeewJLj0jKL3tQIAEu5DaobGvSyx8dxiz/ZemO+b0l6zO5h2PzptRhrtcIQWLCvZWWNyBQ==",
       "license": "MIT",
       "dependencies": {
         "@snapie/hangouts-core": "^0.4.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@rajesh896/video-thumbnails-generator": "^2.3.9",
     "@reduxjs/toolkit": "^2.6.1",
     "@snapie/hangouts-core": "^0.4.0",
-    "@snapie/hangouts-react": "^0.4.0",
+    "@snapie/hangouts-react": "^0.4.1",
     "@snapie/renderer": "^0.1.1",
     "@tanstack/react-query": "^5.90.2",
     "@tiptap/core": "^3.11.1",

--- a/src/components/OpenPod/OpenPodModal.jsx
+++ b/src/components/OpenPod/OpenPodModal.jsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from 'react';
 import { HangoutsProvider, HangoutsRoom } from '@snapie/hangouts-react';
 import '@snapie/hangouts-react/src/styles/hangouts.css';
 import { useWakeLock } from '../../hooks/useWakeLock';
@@ -23,25 +22,17 @@ function buildOpenPodShareUrl(roomName, origin) {
 export default function OpenPodModal({ isOpen, onClose, roomName, sessionToken, username, isAuthenticated }) {
   useWakeLock(isOpen);
 
-  // React fires child effects before parent effects. Without this flag,
-  // HangoutsRoom.useEffect (join) fires before HangoutsProvider.useEffect
-  // (setSessionToken on apiClient) — causing a 401 on every first join attempt.
-  // By deferring HangoutsRoom's mount to the render AFTER HangoutsProvider's
-  // effects have run, the token is guaranteed to be set before join() is called.
-  // Guests don't need a session token, so they're ready as soon as the
-  // modal opens.
-  const [roomReady, setRoomReady] = useState(false);
-  useEffect(() => {
-    if (!isOpen || !roomName) {
-      setRoomReady(false);
-      return;
-    }
-    // Authenticated user → wait for the hangouts session token first.
-    // Unauthenticated visitor → guest path; nothing to wait for.
-    setRoomReady(isAuthenticated ? !!sessionToken : true);
-  }, [sessionToken, isOpen, roomName, isAuthenticated]);
-
   if (!isOpen || !roomName) return null;
+
+  // Authenticated users must have a hangouts session token before we mount
+  // HangoutsProvider. The provider's apiClient is created via useMemo on its
+  // first render and only re-syncs the token via a follow-up useEffect — if
+  // HangoutsRoom (a child) calls join() before that effect runs, the request
+  // goes out with no Authorization header and the server replies "Missing or
+  // invalid Authorization header". Mirroring the gate from OpenPods.jsx, we
+  // simply don't mount the provider until the token is on hand. Guests bypass
+  // the gate since the SDK's guestFallback uses the public /listen endpoint.
+  const needsTokenWait = isAuthenticated && !sessionToken;
 
   // Audio recordings: close the OpenPods modal and forward the blob to
   // the AudioUploadModal at App level, pre-typed as a podcast. App.jsx
@@ -92,14 +83,18 @@ export default function OpenPodModal({ isOpen, onClose, roomName, sessionToken, 
       }}
     >
       <div className="openpod-modal" data-hh-theme="dark">
-        <HangoutsProvider
-          apiBaseUrl={API_URL}
-          livekitServerUrl={LK_URL}
-          imageServerApiKey={IMAGE_KEY || undefined}
-          sessionToken={sessionToken}
-          username={username || undefined}
-        >
-          {roomReady ? (
+        {needsTokenWait ? (
+          <div className="openpod-connecting">
+            Authenticating with OpenPods…
+          </div>
+        ) : (
+          <HangoutsProvider
+            apiBaseUrl={API_URL}
+            livekitServerUrl={LK_URL}
+            imageServerApiKey={IMAGE_KEY || undefined}
+            sessionToken={sessionToken}
+            username={username || undefined}
+          >
             <HangoutsRoom
               roomName={roomName}
               onLeave={onClose}
@@ -110,12 +105,8 @@ export default function OpenPodModal({ isOpen, onClose, roomName, sessionToken, 
               guestFallback
               getShareUrl={buildOpenPodShareUrl}
             />
-          ) : (
-            <div className="openpod-connecting">
-              {sessionToken ? 'Connecting to OpenPods…' : 'Authenticating with OpenPods…'}
-            </div>
-          )}
-        </HangoutsProvider>
+          </HangoutsProvider>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Follow-up to #269 — those two commits got pushed after the merge so they didn't make it in. Re-opening here so they can be merged to preview.

## Summary
- **Bug fix: `OpenPodModal` join 401 race.** The modal mounted `<HangoutsProvider sessionToken={null}>` while waiting on the wallet signature, then flipped `sessionToken` truthy later. `HangoutsProvider`'s apiClient is memoized on `apiBaseUrl` only — sessionToken updates land via a follow-up `useEffect`. When `HangoutsRoom` mounted on the render where the token first arrived, its child `room.join()` `useEffect` fired before the parent's `setSessionToken()` `useEffect`, so `POST /rooms/:name/join` went out with **no `Authorization` header at all** and the server replied `401 "Missing or invalid Authorization header"`.

  Verified server behavior with curl:
  - No header → `"Missing or invalid Authorization header"`
  - Bad token → `"Invalid or expired session token"`
  
  The user reported the first one, confirming the header was absent.

  The previous `roomReady` flag tried to defer `HangoutsRoom` by one render but the apiClient's useMemo had already captured a null `sessionToken` closure-side and the effect-driven sync was racing the child join. The fix mirrors the gate `OpenPods.jsx` already uses: don't mount `HangoutsProvider` until the session token is in hand, so the useMemo path sets it synchronously on the very first render. Guests skip the gate — `guestFallback` uses the public `/listen` endpoint.

- **SDK bump: `@snapie/hangouts-react` `^0.4.0` → `^0.4.1`.** Unlocks guest audio: LiveKit's per-track `<audio>` elements were blocked from playing for guests landing via `/listen` because they never got a user-gesture + `room.startAudio()`. The SDK now renders `<StartAudio>` as a top-center pill when LiveKit reports playback is blocked.

## Test plan
- [x] `npm install` resolves react at 0.4.1
- [x] `npm run build` succeeds clean (incl. PWA service worker emit)
- [x] `eslint` clean on the edited file
- [ ] Smoke-test as authenticated user: deep-link to `/openpods/:name` and click a live pod from the home strip; modal shows "Authenticating with OpenPods…" until the sign completes, then joins without the 401 in the console
- [ ] Smoke-test as guest: open a shared room link unauthenticated, confirm the "Tap to start audio" pill appears and unlocks room audio on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)