### PR TITLE
feat: embed-studio post order/size cap + embed view counts

### DIFF
--- a/src/components/Cards/Card3.jsx
+++ b/src/components/Cards/Card3.jsx
@@ -139,13 +139,23 @@ function Card3({ videos = [], loading = false, error = null, getContentForVideo 
                 noLink
                 compact
               />
-              {getViewCount && getViewCount(video.author?.username || video.author || video.owner, video.permlink) !== null && (
-                <ViewCount
-                  views={getViewCount(video.author?.username || video.author || video.owner, video.permlink)}
-                  watched={isWatched?.(video.author?.username || video.author || video.owner, video.permlink) === true}
-                  formatViews={formatViewCount}
-                />
-              )}
+              {(() => {
+                const vcAuthor = video.author?.username || video.author || video.owner;
+                // Prefer the count already in the feed payload (the only source that
+                // resolves embed videos — /views can't look them up by hive permlink).
+                // Fall back to the batched /views fetch for legacy videos.
+                const feedViews = video.views ?? video.stats?.num_views;
+                const fetchedViews = getViewCount?.(vcAuthor, video.permlink);
+                const resolvedViews = feedViews != null ? feedViews : fetchedViews;
+                if (resolvedViews == null) return null;
+                return (
+                  <ViewCount
+                    views={resolvedViews}
+                    watched={isWatched?.(vcAuthor, video.permlink) === true}
+                    formatViews={formatViewCount}
+                  />
+                );
+              })()}
             </div>
 
             {/* Bottom actions */}

--- a/src/components/ViewCount/ViewCount.jsx
+++ b/src/components/ViewCount/ViewCount.jsx
@@ -37,7 +37,7 @@ function ViewCount({ views, watched, formatViews, author, permlink, size }) {
   }, [author, permlink, views]);
 
   const isWatched = watched ?? selfWatched;
-  const displayViews = views || selfViews;
+  const displayViews = views ?? selfViews;
   const display = formatViews ? formatViews(displayViews) : displayViews?.toLocaleString() ?? '0';
   const iconSize = size ? Math.round(size * 1.15) : undefined;
 

--- a/src/components/embed-studio/EmbedVideoUploadStep1.jsx
+++ b/src/components/embed-studio/EmbedVideoUploadStep1.jsx
@@ -61,6 +61,13 @@ function EmbedVideoUploadStep1() {
       return;
     }
 
+    // Embed uploads are capped at 5GB (enforced server-side too).
+    const MAX_FILE_SIZE = 5 * 1024 * 1024 * 1024; // 5GB
+    if (file.size > MAX_FILE_SIZE) {
+      toast.error("Video is too large. Maximum allowed size is 5GB.");
+      return;
+    }
+
     setLoading(true);
 
     try {
@@ -139,6 +146,9 @@ function EmbedVideoUploadStep1() {
               {videoFile && (
                 <div className='isselected-wrap'>
                   <span>Video Selected. Proceed to upload thumbnail</span>
+                  <div className="upload-info-note">
+                    Info: Your video will get uploaded after finalizing the last step.
+                  </div>
                   <img className="arrow-in" src={Arrow} alt="" />
                 </div>
               )}

--- a/src/components/legacy-studio/VideoUploadStep1.scss
+++ b/src/components/legacy-studio/VideoUploadStep1.scss
@@ -125,6 +125,15 @@
       span{
         margin-bottom: 4px;
       }
+      .upload-info-note {
+        margin: 8px 0 12px;
+        padding: 8px 12px;
+        border: 1px solid var(--border-color, rgba(128, 128, 128, 0.3));
+        border-radius: 8px;
+        font-size: 0.75rem;
+        color: var(--text-secondary);
+        max-width: 320px;
+      }
       img{
         @include mix.respond(phone) {
         width: 40px;

--- a/src/context/EmbedUploadContext.jsx
+++ b/src/context/EmbedUploadContext.jsx
@@ -287,8 +287,8 @@ export function EmbedUploadProvider({ children }) {
       const hivePermlink = `3speak-${Date.now()}`;
       const communityTag = typeof community === 'string' ? community : community?.name || 'hive-181335';
 
-      // Build body: description + embed URL + credit to original author
-      let postBody = `${description}\n\n${capturedEmbedUrl}`;
+      // Build body: embed URL (video first) + description + credit to original author
+      let postBody = `${capturedEmbedUrl}\n\n${description}`;
       if (originalAuthor && originalPermlink) {
         // Use shorts link format when remix comes from a short
         const shortPl = originalShortPermlink || originalPermlink;


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to video upload and view count handling in the embed studio and video components. The changes enhance user feedback during the upload process, enforce file size limits for video uploads, improve the logic for displaying view counts, and update the order of information in post bodies.

**Embed Studio Enhancements:**

* Added a 5GB maximum file size check for video uploads, with user feedback if the limit is exceeded (`src/components/embed-studio/EmbedVideoUploadStep1.jsx`).
* Added an informational note to the UI, clarifying that the video will be uploaded after the final step (`src/components/embed-studio/EmbedVideoUploadStep1.jsx`, `src/components/legacy-studio/VideoUploadStep1.scss`). [[1]](diffhunk://#diff-53735a493d200f68f173a1929fdfac6394ad58b8be8b454a931ca6b4a33b11e0R149-R151) [[2]](diffhunk://#diff-ae97a6f63bf9cc3e892ad5e6b3bf67473e48a50bd53b0c8f192d994ea2197006R128-R136)

**View Count Display Improvements:**

* Improved view count resolution logic in `Card3`, preferring view counts from the feed payload and falling back to fetched counts only if necessary (`src/components/Cards/Card3.jsx`).
* Fixed a bug in `ViewCount` where a view count of zero would incorrectly display as the fallback value, by switching from `||` to `??` (`src/components/ViewCount/ViewCount.jsx`).

**Post Body Formatting:**

* Changed the order of information in the embed post body so that the embed URL appears before the description (`src/context/EmbedUploadContext.jsx`).