### PR TITLE
feat: embed-studio post order/size cap + embed view counts

### DIFF
--- a/preview-3speak-dev.service
+++ b/preview-3speak-dev.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=preview.3speak.tv Vite dev server (HMR, proxied by nginx)
+After=network.target
+
+[Service]
+Type=simple
+User=prodops
+Group=prodops
+WorkingDirectory=/mnt/HC_Volume_103240961/prodops/services/preview-3speak
+Environment=PATH=/mnt/HC_Volume_103240961/prodops/.nvm/versions/node/v22.22.3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ExecStart=/mnt/HC_Volume_103240961/prodops/.nvm/versions/node/v22.22.3/bin/node /mnt/HC_Volume_103240961/prodops/services/preview-3speak/node_modules/vite/bin/vite.js --host 0.0.0.0
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/preview.3speak.tv.nginx
+++ b/preview.3speak.tv.nginx
@@ -1,0 +1,83 @@
+# Preview / staging 3Speak SPA — proxied to the Vite dev server
+# (services/preview-3speak, `npm run dev` on :5173) so source edits show live
+# with HMR and no rebuild. API routes are still proxied to their backends.
+server {
+    server_name preview.3speak.tv;
+
+    client_max_body_size 0;
+
+    location /api {
+        proxy_pass http://localhost:4020;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /upload-api/ {
+        proxy_pass https://video.3speak.tv/;
+        proxy_http_version 1.1;
+        proxy_set_header Host video.3speak.tv;
+        proxy_set_header Origin "";
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_request_buffering off;
+        proxy_buffering off;
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_redirect https://video.3speak.tv /upload-api;
+    }
+
+    location /image-api/ {
+        proxy_pass https://images.3speak.tv/;
+        proxy_http_version 1.1;
+        proxy_set_header Host images.3speak.tv;
+        proxy_set_header Origin "";
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /hive-image-api/ {
+        proxy_pass https://images.hive.blog/;
+        proxy_http_version 1.1;
+        proxy_ssl_server_name on;
+        proxy_set_header Host images.hive.blog;
+        proxy_set_header Origin "";
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        client_max_body_size 0;
+    }
+
+    # Everything else → Vite dev server. The Upgrade/Connection headers are
+    # required for Vite's HMR websocket to work through the proxy.
+    location / {
+        proxy_pass http://127.0.0.1:5173;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+    }
+
+    listen [::]:443 ssl; # managed by Certbot
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/3speak.tv/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/3speak.tv/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+}
+
+server {
+    if ($host = preview.3speak.tv) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+    listen 80;
+    listen [::]:80;
+    server_name preview.3speak.tv;
+    return 404; # managed by Certbot
+}

--- a/src/components/Cards/Card3.jsx
+++ b/src/components/Cards/Card3.jsx
@@ -139,13 +139,23 @@ function Card3({ videos = [], loading = false, error = null, getContentForVideo 
                 noLink
                 compact
               />
-              {getViewCount && getViewCount(video.author?.username || video.author || video.owner, video.permlink) !== null && (
-                <ViewCount
-                  views={getViewCount(video.author?.username || video.author || video.owner, video.permlink)}
-                  watched={isWatched?.(video.author?.username || video.author || video.owner, video.permlink) === true}
-                  formatViews={formatViewCount}
-                />
-              )}
+              {(() => {
+                const vcAuthor = video.author?.username || video.author || video.owner;
+                // Prefer the count already in the feed payload (the only source that
+                // resolves embed videos — /views can't look them up by hive permlink).
+                // Fall back to the batched /views fetch for legacy videos.
+                const feedViews = video.views ?? video.stats?.num_views;
+                const fetchedViews = getViewCount?.(vcAuthor, video.permlink);
+                const resolvedViews = feedViews != null ? feedViews : fetchedViews;
+                if (resolvedViews == null) return null;
+                return (
+                  <ViewCount
+                    views={resolvedViews}
+                    watched={isWatched?.(vcAuthor, video.permlink) === true}
+                    formatViews={formatViewCount}
+                  />
+                );
+              })()}
             </div>
 
             {/* Bottom actions */}

--- a/src/components/ViewCount/ViewCount.jsx
+++ b/src/components/ViewCount/ViewCount.jsx
@@ -37,7 +37,7 @@ function ViewCount({ views, watched, formatViews, author, permlink, size }) {
   }, [author, permlink, views]);
 
   const isWatched = watched ?? selfWatched;
-  const displayViews = views || selfViews;
+  const displayViews = views ?? selfViews;
   const display = formatViews ? formatViews(displayViews) : displayViews?.toLocaleString() ?? '0';
   const iconSize = size ? Math.round(size * 1.15) : undefined;
 

--- a/src/components/embed-studio/EmbedVideoUploadStep1.jsx
+++ b/src/components/embed-studio/EmbedVideoUploadStep1.jsx
@@ -61,6 +61,13 @@ function EmbedVideoUploadStep1() {
       return;
     }
 
+    // Embed uploads are capped at 5GB (enforced server-side too).
+    const MAX_FILE_SIZE = 5 * 1024 * 1024 * 1024; // 5GB
+    if (file.size > MAX_FILE_SIZE) {
+      toast.error("Video is too large. Maximum allowed size is 5GB.");
+      return;
+    }
+
     setLoading(true);
 
     try {
@@ -139,6 +146,9 @@ function EmbedVideoUploadStep1() {
               {videoFile && (
                 <div className='isselected-wrap'>
                   <span>Video Selected. Proceed to upload thumbnail</span>
+                  <div className="upload-info-note">
+                    Info: Your video will get uploaded after finalizing the last step.
+                  </div>
                   <img className="arrow-in" src={Arrow} alt="" />
                 </div>
               )}

--- a/src/components/legacy-studio/VideoUploadStep1.scss
+++ b/src/components/legacy-studio/VideoUploadStep1.scss
@@ -125,6 +125,15 @@
       span{
         margin-bottom: 4px;
       }
+      .upload-info-note {
+        margin: 8px 0 12px;
+        padding: 8px 12px;
+        border: 1px solid var(--border-color, rgba(128, 128, 128, 0.3));
+        border-radius: 8px;
+        font-size: 0.75rem;
+        color: var(--text-secondary);
+        max-width: 320px;
+      }
       img{
         @include mix.respond(phone) {
         width: 40px;

--- a/src/context/EmbedUploadContext.jsx
+++ b/src/context/EmbedUploadContext.jsx
@@ -356,8 +356,8 @@ export function EmbedUploadProvider({ children }) {
       const hivePermlink = generatedPermlink;
       const communityTag = typeof community === 'string' ? community : community?.name || 'hive-181335';
 
-      // Build body: description + embed URL + credit to original author
-      let postBody = `${description}\n\n${capturedEmbedUrl}`;
+      // Build body: embed URL (video first) + description + credit to original author
+      let postBody = `${capturedEmbedUrl}\n\n${description}`;
       if (originalAuthor && originalPermlink) {
         // Use shorts link format when remix comes from a short
         const shortPl = originalShortPermlink || originalPermlink;


### PR DESCRIPTION
embed-studio:
- Hive post body now leads with the video embed, then the description
- reject >5GB videos at file-select (matches new server-side cap)
- show an info note under 'Video Selected' that upload happens at the final step

view counts:
- Card3 prefers the feed payload's view count (only source that resolves embed videos) and falls back to the batched /views fetch
- ViewCount uses ?? so a real 0 isn't replaced by the self-fetched value

Also add preview deployment files (preview-3speak-dev.service Vite-dev unit, preview.3speak.tv nginx vhost).