### PR TITLE
Feat/various13

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,8 @@ import Login from "./page/Login/Login";
 import LoginNew from "./page/Login/LoginNew";
 import { useAppStore } from "./lib/store";
 import { useEffect } from "react";
+import { checkAppVersion } from "./utils/appVersion";
+import ChangelogModal from "./components/Changelog/ChangelogModal";
 import ProfileNav from "./components/nav/ProfileNav";
 // Legacy studio is retired: /studio routes now redirect to /embed-studio
 // (the embed-studio uploader in non-short mode is the only video upload flow).
@@ -219,6 +221,15 @@ function App() {
 
   }, []);
 
+  // Record the current app version in browser storage on load. If the user upgraded
+  // from a previously stored version, expose the old version via the store so a
+  // changelog / "what's new" prompt can be shown later. First-time visitors (no stored
+  // version) get the version stored silently and never see a prompt.
+  useEffect(() => {
+    const previous = checkAppVersion();
+    if (previous) useAppStore.getState().setAppUpdatedFrom(previous);
+  }, []);
+
   // Persist the last visited non-login route so the app can return
   // users to the same page after they sign in.
   useEffect(() => {
@@ -331,6 +342,7 @@ function App() {
     <EmbedUploadProvider>
     <div onClick={()=> {setGlobalCloseRender(true)}}>
       <Toaster richColors position="top-right" />
+      <ChangelogModal />
       <ShortsPreloader />
       {!hideNavOnMobile && (
         <Nav setSideBar={setSideBar} toggleProfileNav={toggleProfileNav} globalClose={globalCloseRender} setGlobalClose={setGlobalCloseRender} openLoginModal={openLoginModal} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,7 +19,7 @@ import Login from "./page/Login/Login";
 import LoginNew from "./page/Login/LoginNew";
 import { useAppStore } from "./lib/store";
 import { useEffect } from "react";
-import { checkAppVersion } from "./utils/appVersion";
+import { readAppVersion } from "./utils/appVersion";
 import ChangelogModal from "./components/Changelog/ChangelogModal";
 import ProfileNav from "./components/nav/ProfileNav";
 // Legacy studio is retired: /studio routes now redirect to /embed-studio
@@ -221,13 +221,12 @@ function App() {
 
   }, []);
 
-  // Record the current app version in browser storage on load. If the user upgraded
-  // from a previously stored version, expose the old version via the store so a
-  // changelog / "what's new" prompt can be shown later. First-time visitors (no stored
-  // version) get the version stored silently and never see a prompt.
+  // On load, decide whether to show the "what's new" popup. For an upgrade we expose
+  // the previous version via the store; the stored version is advanced only after the
+  // popup is shown (markVersionSeen on close). First-time visitors never see a prompt.
   useEffect(() => {
-    const previous = checkAppVersion();
-    if (previous) useAppStore.getState().setAppUpdatedFrom(previous);
+    const { previousVersion, shouldPrompt } = readAppVersion();
+    if (shouldPrompt) useAppStore.getState().setAppUpdatedFrom(previousVersion);
   }, []);
 
   // Persist the last visited non-login route so the app can return

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -1,51 +1,93 @@
 // 3Speak changelog (preview). NEWEST FIRST. One entry per commit to preview.
 // Each `version` must line up with the APP_VERSION bumps in version.js.
-// Entry `summary` should be 1–5 sentences, simple and user-facing.
+// Entry `summary` should be 1–5 sentences, simple and user-facing — when a feature
+// changes, name the button/page (and route) so people know where to find it.
 //
-// These are placeholder/dummy entries so we can design the "What's new" popup.
-// Real entries start with the next "commit to preview".
+// NOTE: production users start at the 1.0.0 baseline, so every entry sits ABOVE
+// 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
-    version: '1.0.0',
+    version: '1.9.1',
     date: '2026-06-04',
     summary:
-      "We've started keeping a changelog! From now on you'll get a short note about what changed whenever 3Speak updates.",
+      "3Speak now has a changelog! From now on, whenever we ship an update you'll see a short note like this explaining what's new. It pops up automatically after an update — nothing for you to do.",
   },
   {
-    version: '0.9.0',
+    version: '1.9.0',
     date: '2026-06-03',
     summary:
-      'Community pages now show every video posted to that community, including the newest uploads. Open any community from the Communities page to check it out.',
+      'A big update to make 3Speak faster and more complete. Feeds load quicker, Community pages now show every video posted to that community, and view counts are back on video and audio cards. We also added a screen for scheduled posts and made uploads larger and faster.',
   },
   {
-    version: '0.8.0',
-    date: '2026-06-01',
-    summary:
-      'View counts are back on video cards, so you can see how many times a video has been watched right from the feed.',
-  },
-  {
-    version: '0.7.0',
-    date: '2026-05-28',
-    summary:
-      'You can now edit a video after publishing it. Look for the Edit button on your own video pages.',
-  },
-  {
-    version: '0.6.0',
-    date: '2026-05-24',
-    summary:
-      'Added audio uploads. Share a podcast or music track from the Upload page just like a video.',
-  },
-  {
-    version: '0.5.0',
+    version: '1.8.0',
     date: '2026-05-20',
     summary:
-      'Notifications arrived in the top bar — tap the bell icon to see new comments, follows and rewards.',
+      'Pay-per-listen arrived for audio and Pro members get a news ticker. 3Speak now also picks a fast, reliable Hive connection automatically — you can choose your own in the connection settings.',
   },
   {
-    version: '0.4.0',
-    date: '2026-05-15',
+    version: '1.7.0',
+    date: '2026-05-06',
     summary:
-      'Faster, smoother video uploads with support for much larger files.',
+      'Audio comes to 3Speak. Share a podcast or music track from the upload menu and listen with the new built-in audio player, plus new profile and social links.',
+  },
+  {
+    version: '1.6.0',
+    date: '2026-05-03',
+    summary:
+      'Introducing OpenPods — live audio and video rooms. Start or join a room from the new OpenPods section (/openpods), publish your recordings, invite guests, and share a room link.',
+  },
+  {
+    version: '1.5.0',
+    date: '2026-04-10',
+    summary:
+      '3Speak Pro is here. Subscribe for premium perks and show a Pro badge on your avatar across the site. There is a free trial too — find it on your Wallet page.',
+  },
+  {
+    version: '1.4.0',
+    date: '2026-04-07',
+    summary:
+      'Notifications! A new bell icon in the top bar shows your comments, follows, mentions and rewards. They are grouped together, big votes get a "whale" alert, and there is a full Notifications page.',
+  },
+  {
+    version: '1.3.0',
+    date: '2026-04-06',
+    summary:
+      'You can now edit your own videos. Open one of your videos and use the Edit button to change the title, tags, description, or thumbnail.',
+  },
+  {
+    version: '1.2.1',
+    date: '2026-04-04',
+    summary: 'The Hive login popup (HiveAuth) is clearer, with improved text and layout.',
+  },
+  {
+    version: '1.2.0',
+    date: '2026-04-01',
+    summary:
+      'Playlists got better. You can now search your playlists, collapse result groups, and use quick filter chips to find what you want.',
+  },
+  {
+    version: '1.1.0',
+    date: '2026-03-26',
+    summary:
+      'Easier browsing. Tag pages now have filters for type and date, tabs show how many videos they contain, and specially curated videos get a badge.',
+  },
+  {
+    version: '1.0.3',
+    date: '2026-03-20',
+    summary:
+      'Mobile polish: a smaller tipping popup, a fixed comment box, and better title spacing on phones.',
+  },
+  {
+    version: '1.0.2',
+    date: '2026-03-12',
+    summary:
+      'Cleaner posting. Titles and short descriptions now show a character limit as you type, and new posts use tidier links.',
+  },
+  {
+    version: '1.0.1',
+    date: '2026-03-08',
+    summary:
+      "You can now report content. Use the new Report option in the “⋯” menu on any video, comment, or user profile.",
   },
 ];
 

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -1,0 +1,67 @@
+// 3Speak changelog (preview). NEWEST FIRST. One entry per commit to preview.
+// Each `version` must line up with the APP_VERSION bumps in version.js.
+// Entry `summary` should be 1–5 sentences, simple and user-facing.
+//
+// These are placeholder/dummy entries so we can design the "What's new" popup.
+// Real entries start with the next "commit to preview".
+export const CHANGELOG = [
+  {
+    version: '1.0.0',
+    date: '2026-06-04',
+    summary:
+      "We've started keeping a changelog! From now on you'll get a short note about what changed whenever 3Speak updates.",
+  },
+  {
+    version: '0.9.0',
+    date: '2026-06-03',
+    summary:
+      'Community pages now show every video posted to that community, including the newest uploads. Open any community from the Communities page to check it out.',
+  },
+  {
+    version: '0.8.0',
+    date: '2026-06-01',
+    summary:
+      'View counts are back on video cards, so you can see how many times a video has been watched right from the feed.',
+  },
+  {
+    version: '0.7.0',
+    date: '2026-05-28',
+    summary:
+      'You can now edit a video after publishing it. Look for the Edit button on your own video pages.',
+  },
+  {
+    version: '0.6.0',
+    date: '2026-05-24',
+    summary:
+      'Added audio uploads. Share a podcast or music track from the Upload page just like a video.',
+  },
+  {
+    version: '0.5.0',
+    date: '2026-05-20',
+    summary:
+      'Notifications arrived in the top bar — tap the bell icon to see new comments, follows and rewards.',
+  },
+  {
+    version: '0.4.0',
+    date: '2026-05-15',
+    summary:
+      'Faster, smoother video uploads with support for much larger files.',
+  },
+];
+
+// Semver compare of "x.y.z" — returns >0 if a is newer than b.
+function compareVersions(a, b) {
+  const pa = String(a).split('.').map(Number);
+  const pb = String(b).split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] || 0) - (pb[i] || 0);
+    if (diff !== 0) return diff > 0 ? 1 : -1;
+  }
+  return 0;
+}
+
+// All changelog entries strictly newer than `version` (newest first).
+export function changelogSince(version) {
+  if (!version) return [];
+  return CHANGELOG.filter((e) => compareVersions(e.version, version) > 0);
+}

--- a/src/components/Changelog/ChangelogModal.jsx
+++ b/src/components/Changelog/ChangelogModal.jsx
@@ -1,0 +1,122 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { IoClose } from 'react-icons/io5';
+import { useAppStore } from '../../lib/store';
+import { APP_VERSION } from '../../version';
+import { CHANGELOG, changelogSince } from '../../changelog';
+import logo from '../../assets/image/3S_logo.svg';
+import logoDark from '../../assets/image/3S_logodark.png';
+import './ChangelogModal.scss';
+
+// DUMMY MODE: while we design the popup it opens on every load with the latest
+// entries so we can iterate on styling. To go live, set DUMMY_MODE = false — then
+// it only opens for users who upgraded (store.appUpdatedFrom, set by checkAppVersion).
+const DUMMY_MODE = false;
+
+// Short, friendly relative date e.g. "2 weeks ago".
+function timeAgo(dateStr) {
+  const then = new Date(dateStr).getTime();
+  if (isNaN(then)) return '';
+  const days = Math.floor((Date.now() - then) / 86400000);
+  if (days <= 0) return 'today';
+  if (days === 1) return 'yesterday';
+  if (days < 7) return `${days} days ago`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return weeks === 1 ? '1 week ago' : `${weeks} weeks ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return months === 1 ? '1 month ago' : `${months} months ago`;
+  const years = Math.floor(days / 365);
+  return years === 1 ? '1 year ago' : `${years} years ago`;
+}
+
+export default function ChangelogModal() {
+  const appUpdatedFrom = useAppStore((s) => s.appUpdatedFrom);
+  const setAppUpdatedFrom = useAppStore((s) => s.setAppUpdatedFrom);
+  const theme = useAppStore((s) => s.theme);
+  const [open, setOpen] = useState(false);
+  const [atStart, setAtStart] = useState(true);
+  const [atEnd, setAtEnd] = useState(true);
+  const scrollRef = useRef(null);
+
+  useEffect(() => {
+    if (DUMMY_MODE) {
+      setOpen(true);
+      return;
+    }
+    if (appUpdatedFrom) setOpen(true);
+  }, [appUpdatedFrom]);
+
+  // Lock the page behind the popup so the scroll wheel never scrolls the site.
+  useEffect(() => {
+    if (!open) return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = previous; };
+  }, [open]);
+
+  // Recompute which edge fades should show.
+  const updateFades = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setAtStart(el.scrollLeft <= 1);
+    setAtEnd(el.scrollLeft + el.clientWidth >= el.scrollWidth - 1);
+  }, []);
+
+  // Translate vertical mouse-wheel into horizontal scrolling of the entries row.
+  // Native non-passive listener so we can preventDefault (background stays put).
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || !open) return;
+    updateFades();
+    const onWheel = (e) => {
+      if (e.deltaY === 0) return;
+      e.preventDefault();
+      el.scrollLeft += e.deltaY;
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, [open, updateFades]);
+
+  if (!open) return null;
+
+  const entries = DUMMY_MODE ? CHANGELOG : changelogSince(appUpdatedFrom);
+  if (entries.length === 0) return null;
+
+  const close = () => {
+    setOpen(false);
+    if (!DUMMY_MODE) setAppUpdatedFrom(null);
+  };
+
+  return (
+    <div className="changelog-overlay" onClick={close}>
+      <div className="changelog-modal" onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true">
+        <button className="changelog-close" onClick={close} aria-label="Close">
+          <IoClose />
+        </button>
+
+        <div className="changelog-header">
+          <img className="changelog-logo" src={theme === 'dark' ? logoDark : logo} alt="3Speak" />
+          <h2>We shipped an update!</h2>
+          <p className="changelog-subtitle">Here&apos;s what&apos;s new in v{APP_VERSION}</p>
+        </div>
+
+        <div className={`changelog-scroller${atStart ? ' at-start' : ''}${atEnd ? ' at-end' : ''}`}>
+          <div className="changelog-body" ref={scrollRef} onScroll={updateFades}>
+            {entries.map((entry) => (
+              <div className="changelog-entry" key={entry.version}>
+                <div className="changelog-entry-meta">
+                  <span className="changelog-entry-version">v{entry.version}</span>
+                  {entry.date && <span className="changelog-entry-date">{timeAgo(entry.date)}</span>}
+                </div>
+                <p className="changelog-entry-summary">{entry.summary}</p>
+              </div>
+            ))}
+          </div>
+          <span className="changelog-fade left" aria-hidden="true" />
+          <span className="changelog-fade right" aria-hidden="true" />
+        </div>
+
+        <button className="changelog-cta" onClick={close}>Got it</button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Changelog/ChangelogModal.jsx
+++ b/src/components/Changelog/ChangelogModal.jsx
@@ -3,6 +3,7 @@ import { IoClose } from 'react-icons/io5';
 import { useAppStore } from '../../lib/store';
 import { APP_VERSION } from '../../version';
 import { CHANGELOG, changelogSince } from '../../changelog';
+import { markVersionSeen } from '../../utils/appVersion';
 import logo from '../../assets/image/3S_logo.svg';
 import logoDark from '../../assets/image/3S_logodark.png';
 import './ChangelogModal.scss';
@@ -42,8 +43,15 @@ export default function ChangelogModal() {
       setOpen(true);
       return;
     }
-    if (appUpdatedFrom) setOpen(true);
-  }, [appUpdatedFrom]);
+    if (!appUpdatedFrom) return;
+    // Version bumped without a changelog entry for it — nothing to show, just advance.
+    if (changelogSince(appUpdatedFrom).length === 0) {
+      markVersionSeen();
+      setAppUpdatedFrom(null);
+      return;
+    }
+    setOpen(true);
+  }, [appUpdatedFrom, setAppUpdatedFrom]);
 
   // Lock the page behind the popup so the scroll wheel never scrolls the site.
   useEffect(() => {
@@ -83,7 +91,10 @@ export default function ChangelogModal() {
 
   const close = () => {
     setOpen(false);
-    if (!DUMMY_MODE) setAppUpdatedFrom(null);
+    if (!DUMMY_MODE) {
+      markVersionSeen(); // write the version only AFTER the popup has been shown
+      setAppUpdatedFrom(null);
+    }
   };
 
   return (

--- a/src/components/Changelog/ChangelogModal.scss
+++ b/src/components/Changelog/ChangelogModal.scss
@@ -1,0 +1,212 @@
+@use "../../mixins.scss" as mix;
+
+.changelog-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  background: var(--overlay-bg, rgba(0, 0, 0, 0.7));
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  animation: changelog-fade 0.18s ease;
+}
+
+.changelog-modal {
+  position: relative;
+  width: 100%;
+  max-width: 460px;
+  background: var(--card-bg, #1a1a1a);
+  color: var(--text-primary, #fff);
+  border: 1px solid var(--border-color, #3d3d3d);
+  border-radius: 18px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+  padding: 28px 24px 22px;
+  overflow: hidden;
+  animation: changelog-pop 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+
+  // Accent glow strip across the top
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, var(--accent-primary, #e53935), var(--accent-hover, #ff1744));
+  }
+
+  @include mix.respond(phone) {
+    max-width: 100%;
+    align-self: flex-end;
+    border-radius: 18px 18px 0 0;
+    animation: changelog-slide-up 0.28s ease forwards;
+  }
+}
+
+.changelog-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 50%;
+  background: var(--bg-hover, rgba(255, 255, 255, 0.08));
+  color: var(--text-primary, #fff);
+  font-size: 20px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+
+  &:hover { background: var(--bg-tertiary, rgba(255, 255, 255, 0.16)); }
+}
+
+.changelog-header {
+  text-align: center;
+  margin-bottom: 18px;
+
+  .changelog-logo {
+    height: 34px;
+    width: auto;
+    max-width: 70%;
+    object-fit: contain;
+    margin-bottom: 14px;
+  }
+
+  h2 {
+    margin: 0;
+    font-size: 21px;
+    font-weight: 700;
+  }
+
+  .changelog-subtitle {
+    margin: 6px 0 0;
+    font-size: 13.5px;
+    color: var(--text-secondary, #aaa);
+  }
+}
+
+.changelog-scroller {
+  position: relative;
+  margin-bottom: 20px;
+
+  // Soft fade hints at each scrollable edge (sit above the cards, never block input).
+  .changelog-fade {
+    position: absolute;
+    top: 0;
+    bottom: 10px; // leave the thin scrollbar visible
+    width: 40px;
+    pointer-events: none;
+    z-index: 2;
+    opacity: 1;
+    transition: opacity 0.2s ease;
+
+    &.left {
+      left: 0;
+      background: linear-gradient(to right, var(--card-bg, #1a1a1a), transparent);
+    }
+    &.right {
+      right: 0;
+      background: linear-gradient(to left, var(--card-bg, #1a1a1a), transparent);
+    }
+  }
+
+  &.at-start .changelog-fade.left { opacity: 0; }
+  &.at-end .changelog-fade.right { opacity: 0; }
+}
+
+.changelog-body {
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-bottom: 10px;
+  scroll-snap-type: x proximity;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+
+  // thin themed scrollbar
+  scrollbar-width: thin;
+  scrollbar-color: var(--accent-primary, #ff5252) transparent;
+  &::-webkit-scrollbar { height: 6px; }
+  &::-webkit-scrollbar-thumb {
+    background: var(--accent-primary, #ff5252);
+    border-radius: 10px;
+  }
+  &::-webkit-scrollbar-track { background: transparent; }
+}
+
+.changelog-entry {
+  flex: 0 0 230px;
+  min-width: 230px;
+  scroll-snap-align: start;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-tertiary, rgba(255, 255, 255, 0.04));
+  border: 1px solid var(--border-light, rgba(255, 255, 255, 0.06));
+  border-radius: 12px;
+  padding: 13px 15px;
+
+  .changelog-entry-meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 6px;
+  }
+
+  .changelog-entry-version {
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--accent-primary, #ff5252);
+    background: var(--accent-light, rgba(255, 82, 82, 0.15));
+    padding: 2px 8px;
+    border-radius: 20px;
+  }
+
+  .changelog-entry-date {
+    font-size: 11.5px;
+    color: var(--text-secondary, #888);
+  }
+
+  .changelog-entry-summary {
+    margin: 0;
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--text-primary, #eee);
+  }
+}
+
+.changelog-cta {
+  width: 100%;
+  padding: 12px;
+  border: none;
+  border-radius: 12px;
+  font-size: 15px;
+  font-weight: 600;
+  color: #fff;
+  cursor: pointer;
+  background: linear-gradient(135deg, var(--accent-primary, #e53935), var(--accent-hover, #ff1744));
+  transition: filter 0.15s ease, transform 0.05s ease;
+
+  &:hover { filter: brightness(1.08); }
+  &:active { transform: scale(0.99); }
+}
+
+@keyframes changelog-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes changelog-pop {
+  from { opacity: 0; transform: translateY(8px) scale(0.97); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+@keyframes changelog-slide-up {
+  from { transform: translateY(100%); }
+  to { transform: translateY(0); }
+}

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -30,6 +30,11 @@ export const useAppStore = create(
       setSidebarHidden: (val) => a[0]({ sidebarHidden: typeof val === 'function' ? val(a[1]().sidebarHidden) : val }),
       showNsfw: false,
       setShowNsfw: (val) => a[0]({ showNsfw: typeof val === 'function' ? val(a[1]().showNsfw) : val }),
+      // Set on startup to the previous app version when the user upgraded (null = first
+      // visit or no change). A future changelog / "what's new" prompt reads this.
+      // Deliberately NOT persisted — recomputed each load by checkAppVersion().
+      appUpdatedFrom: null,
+      setAppUpdatedFrom: (v) => a[0]({ appUpdatedFrom: v }),
     }),
     {
       name: 'user-store', // The storage key for persisting user data

--- a/src/utils/appVersion.js
+++ b/src/utils/appVersion.js
@@ -2,25 +2,40 @@ import { APP_VERSION } from '../version';
 
 export const APP_VERSION_STORAGE_KEY = '3speak_app_version';
 
-// Run once on app startup. Returns the PREVIOUS version string only when the user
-// actually upgraded (they had a stored version AND it differs from the current one).
-// First-time visitors have no stored version: we store the current one silently and
-// return null, so no "what's new" message ever pops up for them. Always advances the
-// stored version to the current one.
-export function checkAppVersion() {
-  let previousVersion = null;
+// Read the stored version and decide whether to show the "what's new" popup.
+// Returns { previousVersion, shouldPrompt }.
+//
+// IMPORTANT ordering: for an UPGRADE we do NOT write the new version here — the
+// stored value is advanced only AFTER the popup has actually been shown (see
+// markVersionSeen, called on close). That way the popup reliably appears (and keeps
+// appearing on reload) until the user has seen it.
+//
+// First-time visitors (no stored version) are recorded immediately and never
+// prompted, so the "what's new" message doesn't pop up for someone with no history.
+export function readAppVersion() {
   try {
     const stored = localStorage.getItem(APP_VERSION_STORAGE_KEY);
-    if (stored && stored !== APP_VERSION) {
-      previousVersion = stored;
+    if (!stored) {
+      localStorage.setItem(APP_VERSION_STORAGE_KEY, APP_VERSION);
+      return { previousVersion: null, shouldPrompt: false };
     }
     if (stored !== APP_VERSION) {
-      localStorage.setItem(APP_VERSION_STORAGE_KEY, APP_VERSION);
+      return { previousVersion: stored, shouldPrompt: true };
     }
+    return { previousVersion: null, shouldPrompt: false };
   } catch {
-    // localStorage unavailable (private mode / blocked) — skip silently.
+    return { previousVersion: null, shouldPrompt: false };
   }
-  return previousVersion;
+}
+
+// Advance the stored version to the current one. Call this once the "what's new"
+// popup has actually been shown to (and dismissed by) the user.
+export function markVersionSeen() {
+  try {
+    localStorage.setItem(APP_VERSION_STORAGE_KEY, APP_VERSION);
+  } catch {
+    // localStorage unavailable — ignore.
+  }
 }
 
 export { APP_VERSION };

--- a/src/utils/appVersion.js
+++ b/src/utils/appVersion.js
@@ -1,0 +1,26 @@
+import { APP_VERSION } from '../version';
+
+export const APP_VERSION_STORAGE_KEY = '3speak_app_version';
+
+// Run once on app startup. Returns the PREVIOUS version string only when the user
+// actually upgraded (they had a stored version AND it differs from the current one).
+// First-time visitors have no stored version: we store the current one silently and
+// return null, so no "what's new" message ever pops up for them. Always advances the
+// stored version to the current one.
+export function checkAppVersion() {
+  let previousVersion = null;
+  try {
+    const stored = localStorage.getItem(APP_VERSION_STORAGE_KEY);
+    if (stored && stored !== APP_VERSION) {
+      previousVersion = stored;
+    }
+    if (stored !== APP_VERSION) {
+      localStorage.setItem(APP_VERSION_STORAGE_KEY, APP_VERSION);
+    }
+  } catch {
+    // localStorage unavailable (private mode / blocked) — skip silently.
+  }
+  return previousVersion;
+}
+
+export { APP_VERSION };

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.0.0';
+export const APP_VERSION = '1.9.1';

--- a/src/version.js
+++ b/src/version.js
@@ -1,0 +1,7 @@
+// Single source of truth for the app version shown to users.
+// Bump this on every user-facing release. When a returning visitor's stored
+// version differs from this, they upgraded — see checkAppVersion() in
+// utils/appVersion.js, which surfaces the previous version via the store's
+// `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
+// First-time visitors (no stored version) never trigger that prompt.
+export const APP_VERSION = '1.0.0';


### PR DESCRIPTION
This pull request introduces a user-facing changelog system to the 3Speak app. Users will now see a "What's New" popup after upgrading, summarizing recent changes and improvements. The implementation includes a dedicated modal, changelog data structure, version management utilities, state integration, and custom styling.

**Changelog system and user notification:**

- Added a persistent changelog (`CHANGELOG`) in `src/changelog.js` that tracks user-facing updates by version, and included utilities to filter entries since the user's last seen version.
- Introduced a `ChangelogModal` component that displays new changelog entries in a modal popup after app upgrades. The modal appears only for returning users with a version change and is styled for clarity and accessibility. [[1]](diffhunk://#diff-1670c4f3440ec2de52245e4171d7342439d7c08d5efa60bc368e46e06d5b743aR1-R133) [[2]](diffhunk://#diff-5a965c8e678bb02d2e270a78ac6e26ee9056dd5bd5b339ac980330a984eec9fcR1-R212)
- Integrated the changelog modal into the main app flow (`App.jsx`), including logic to determine when to show the popup based on stored version information. [[1]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R22-R23) [[2]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R224-R231) [[3]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R344)

**Version tracking and state management:**

- Added version tracking utilities in `src/utils/appVersion.js` to manage version storage, determine if the changelog should be shown, and update the stored version after the user views the changelog.
- Updated the global app state (`useAppStore` in `src/lib/store.js`) to include `appUpdatedFrom` and its setter, which tracks if an upgrade occurred and triggers the changelog prompt.
- Established `APP_VERSION` as a single source of truth in `src/version.js` for consistent versioning across the app.