### PR TITLE
feat: @threespeak delegated posting + backend image uploads + toasts

### DIFF
--- a/server/index.cjs
+++ b/server/index.cjs
@@ -6,7 +6,7 @@ const cookieParser = require('cookie-parser')
 const rateLimit = require('express-rate-limit')
 const helmet = require('helmet')
 const crypto = require('crypto')
-const { Client, PrivateKey } = require('@hiveio/dhive')
+const { Client, PrivateKey, cryptoUtils } = require('@hiveio/dhive')
 
 // ButrAuth SDK is ESM-only — load via dynamic import at startup.
 let butr = null
@@ -25,6 +25,11 @@ const PORT = process.env.SERVER_PORT || 4020
 
 const POSTING_WIF = process.env.THREESPEAK_POSTING_WIF
 const HIVE_ACCOUNT = process.env.THREESPEAK_HIVE_ACCOUNT || 'badadib'
+// Shared app key (same one the embed TUS upload uses) — authenticates wallet
+// logins (Keychain/HiveAuth/PeakVault/Ledger) on the post-creation path, which
+// can't present a token/cookie. Same trust level the upload pipeline already
+// relies on; the path is narrowed to post ops only (see /api/broadcast).
+const EMBED_API_KEY = process.env.EMBED_API_KEY || ''
 const MANTEAUTH_CLIENT_ID = process.env.MANTEAUTH_CLIENT_ID || 'threespeak'
 const MANTEAUTH_CLIENT_SECRET = process.env.MANTEAUTH_CLIENT_SECRET
 const MANTEAUTH_URL = process.env.MANTEAUTH_URL || 'https://auth.okinoko.io'
@@ -260,66 +265,170 @@ app.post('/api/manteauth/logout', baseLimiter, (req, res) => {
 // POST /api/broadcast — broadcast posting-level operations
 // Auth via the httpOnly session cookie (no Bearer token, no localStorage)
 // =====================================================================
+// Verify a HiveSigner access token by asking hivesigner.com who it belongs to.
+// Returns the Hive username on success, or null on any failure/expiry.
+async function verifyHiveSignerToken(token) {
+  if (!token) return null
+  const ctrl = new AbortController()
+  const t = setTimeout(() => ctrl.abort(), 4000)
+  try {
+    const resp = await fetch('https://hivesigner.com/api/me', {
+      method: 'POST',
+      headers: { Authorization: token, 'Content-Type': 'application/json' },
+      signal: ctrl.signal,
+    })
+    if (!resp.ok) return null
+    const data = await resp.json()
+    return data && data.name ? data.name : null
+  } catch {
+    return null
+  } finally {
+    clearTimeout(t)
+  }
+}
+
+// Shared broadcast flow — given a username resolved from EITHER the ButrAuth
+// session cookie OR a verified HiveSigner token, validate the ops and broadcast
+// them signed with @threespeak's posting key (accepted because the user granted
+// @threespeak posting authority). Sends the HTTP response.
+async function broadcastAsThreespeak(hiveUsername, operations, res) {
+  if (!operations || !operations.length) {
+    return res.status(400).json({ error: 'No operations provided' })
+  }
+  if (operations.length > 20) {
+    return res.status(400).json({ error: 'Too many operations' })
+  }
+  if (!POSTING_WIF) {
+    return res.status(500).json({ error: 'Server is not configured' })
+  }
+
+  // Verify user granted posting authority to our service account
+  const [account] = await client.database.getAccounts([hiveUsername])
+  if (!account) return res.status(403).json({ error: 'Authorization required' })
+  const grant = account.posting.account_auths.find(([acc]) => acc === HIVE_ACCOUNT)
+  if (!grant || grant[1] < account.posting.weight_threshold) {
+    return res.status(403).json({ error: 'Authorization required' })
+  }
+
+  // Validate every operation
+  for (const [opType, opData] of operations) {
+    if (!ALLOWED_OPS.includes(opType)) {
+      return res.status(400).json({ error: 'Operation not allowed' })
+    }
+    if (opType === 'custom_json') {
+      const auths = opData.required_posting_auths || []
+      if (!auths.includes(hiveUsername)) {
+        return res.status(403).json({ error: 'Operation not allowed' })
+      }
+      if (!ALLOWED_CUSTOM_JSON_IDS.has(opData.id)) {
+        return res.status(403).json({ error: 'custom_json id not allowed for this app' })
+      }
+    } else {
+      const field = OP_USER_FIELD[opType]
+      if (field && opData[field] !== hiveUsername) {
+        return res.status(403).json({ error: 'Operation not allowed' })
+      }
+    }
+  }
+
+  const key = PrivateKey.fromString(POSTING_WIF)
+  const result = await client.broadcast.sendOperations(operations, key)
+  return res.json({ success: true, result })
+}
+
 app.post('/api/broadcast', broadcastLimiter, async (req, res) => {
   try {
-    const token = req.cookies?.[SESSION_COOKIE_NAME]
-    if (!token) return res.status(401).json({ error: 'Unauthorized' })
+    let hiveUsername = null
 
-    const tokenData = await verifyManteAuthToken(token)
-    if (!tokenData?.hiveUsername) {
-      clearSessionCookie(res)
-      return res.status(401).json({ error: 'Unauthorized' })
+    // 1) ButrAuth httpOnly session cookie
+    const cookieToken = req.cookies?.[SESSION_COOKIE_NAME]
+    if (cookieToken) {
+      const tokenData = await verifyManteAuthToken(cookieToken)
+      if (tokenData?.hiveUsername) hiveUsername = tokenData.hiveUsername
+      else clearSessionCookie(res)
     }
 
-    const hiveUsername = tokenData.hiveUsername
-    const { operations } = req.body
-
-    if (!operations || !operations.length) {
-      return res.status(400).json({ error: 'No operations provided' })
-    }
-    if (operations.length > 20) {
-      return res.status(400).json({ error: 'Too many operations' })
+    // 2) HiveSigner access token via Authorization: Bearer (HiveSigner users
+    //    can't sign client-side; verify the token and post on their behalf).
+    if (!hiveUsername) {
+      const authHeader = req.headers.authorization || ''
+      const bearer = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : ''
+      if (bearer) hiveUsername = await verifyHiveSignerToken(bearer)
     }
 
-    if (!POSTING_WIF) {
-      return res.status(500).json({ error: 'Server is not configured' })
-    }
-
-    // Verify user granted posting authority to our service account
-    const [account] = await client.database.getAccounts([hiveUsername])
-    if (!account) return res.status(403).json({ error: 'Authorization required' })
-    const grant = account.posting.account_auths.find(([acc]) => acc === HIVE_ACCOUNT)
-    if (!grant || grant[1] < account.posting.weight_threshold) {
-      return res.status(403).json({ error: 'Authorization required' })
-    }
-
-    // Validate every operation
-    for (const [opType, opData] of operations) {
-      if (!ALLOWED_OPS.includes(opType)) {
-        return res.status(400).json({ error: 'Operation not allowed' })
-      }
-      if (opType === 'custom_json') {
-        const auths = opData.required_posting_auths || []
-        if (!auths.includes(hiveUsername)) {
-          return res.status(403).json({ error: 'Operation not allowed' })
+    // 3) App-key path (wallet logins: Keychain/HiveAuth/PeakVault/Ledger). They
+    //    can't present a token/cookie, so — per policy that @threespeak (not the
+    //    user) broadcasts embed posts — we trust the frontend app key (the same
+    //    one the embed TUS upload uses) and take the claimed username from the
+    //    body. This path is narrowed to posting-level ops only (comment /
+    //    comment_options / custom_json / vote); broadcastAsThreespeak still
+    //    enforces the @threespeak posting-auth grant + author/voter/
+    //    required_posting_auths match, so the worst case is "act as a user who
+    //    opted into @threespeak" (and only posting-level, never active-key).
+    if (!hiveUsername) {
+      const apiKey = req.headers['x-api-key'] || ''
+      if (EMBED_API_KEY && apiKey === EMBED_API_KEY) {
+        const claimed = typeof req.body?.username === 'string' ? req.body.username.trim().toLowerCase() : ''
+        const ops = Array.isArray(req.body?.operations) ? req.body.operations : []
+        const postingOpsOnly = ops.length > 0 && ops.every(
+          ([t]) => t === 'comment' || t === 'comment_options' || t === 'custom_json' || t === 'vote'
+        )
+        if (claimed && !postingOpsOnly) {
+          return res.status(403).json({ error: 'Operation not allowed for app-key auth' })
         }
-        if (!ALLOWED_CUSTOM_JSON_IDS.has(opData.id)) {
-          return res.status(403).json({ error: 'custom_json id not allowed for this app' })
-        }
-      } else {
-        const field = OP_USER_FIELD[opType]
-        if (field && opData[field] !== hiveUsername) {
-          return res.status(403).json({ error: 'Operation not allowed' })
-        }
+        if (claimed) hiveUsername = claimed
       }
     }
 
-    const key = PrivateKey.fromString(POSTING_WIF)
-    const result = await client.broadcast.sendOperations(operations, key)
-    res.json({ success: true, result })
+    if (!hiveUsername) return res.status(401).json({ error: 'Unauthorized' })
+
+    return await broadcastAsThreespeak(hiveUsername, req.body.operations, res)
   } catch (err) {
     console.error('Broadcast error:', err.message)
     res.status(500).json({ error: 'Broadcast failed' })
+  }
+})
+
+// Image upload — sign the standard images.hive.blog "ImageSigningChallenge" with
+// @threespeak's posting key and upload on the user's behalf. Lets every login
+// (incl. HiveSigner, which can't sign client-side) attach covers/thumbnails with
+// no wallet signature. Gated by the shared app key (same trust as the embed
+// upload); the image is hosted under @threespeak and needs no user authority.
+const imageUploadLimiter = rateLimit({ windowMs: 60 * 1000, max: 40, standardHeaders: true, legacyHeaders: false })
+app.post('/api/upload-image', imageUploadLimiter, express.raw({ type: () => true, limit: '15mb' }), async (req, res) => {
+  try {
+    const apiKey = req.headers['x-api-key'] || ''
+    if (!EMBED_API_KEY || apiKey !== EMBED_API_KEY) return res.status(401).json({ error: 'Unauthorized' })
+    if (!POSTING_WIF) return res.status(500).json({ error: 'Server is not configured' })
+    const img = req.body
+    if (!Buffer.isBuffer(img) || img.length === 0) return res.status(400).json({ error: 'No image data' })
+
+    // Standard hive.blog image auth: sign sha256("ImageSigningChallenge" + bytes).
+    const hash = cryptoUtils.sha256(Buffer.concat([Buffer.from('ImageSigningChallenge'), img]))
+    const signature = PrivateKey.fromString(POSTING_WIF).sign(hash).toString()
+
+    const contentType = req.headers['content-type'] || 'image/png'
+    const form = new FormData()
+    form.append('file', new Blob([img], { type: contentType }), 'image')
+
+    const ctrl = new AbortController()
+    const t = setTimeout(() => ctrl.abort(), 20000)
+    let hostResp
+    try {
+      hostResp = await fetch(`https://images.hive.blog/${HIVE_ACCOUNT}/${signature}`, {
+        method: 'POST', body: form, signal: ctrl.signal,
+      })
+    } finally { clearTimeout(t) }
+
+    const data = await hostResp.json().catch(() => ({}))
+    if (!hostResp.ok || !data.url) {
+      console.error('Image host rejected:', hostResp.status, JSON.stringify(data).slice(0, 200))
+      return res.status(502).json({ error: 'Image host rejected the upload' })
+    }
+    return res.json({ success: true, url: data.url })
+  } catch (e) {
+    console.error('Image upload error:', e.message)
+    return res.status(500).json({ error: 'Image upload failed' })
   }
 })
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,9 +11,12 @@
       "dependencies": {
         "@hiveio/dhive": "^1.3.6",
         "@mantequilla-soft/butrauth-client": "^0.1.1",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.6",
         "dotenv": "^17.4.1",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.5.2",
+        "helmet": "^8.2.0",
         "jsonwebtoken": "^9.0.3"
       }
     },
@@ -299,6 +302,23 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
@@ -609,6 +629,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/extsprintf": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
@@ -812,6 +849,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
+      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
+      }
+    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -870,6 +918,14 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/server/package.json
+++ b/server/package.json
@@ -12,9 +12,12 @@
   "dependencies": {
     "@hiveio/dhive": "^1.3.6",
     "@mantequilla-soft/butrauth-client": "^0.1.1",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.6",
     "dotenv": "^17.4.1",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.5.2",
+    "helmet": "^8.2.0",
     "jsonwebtoken": "^9.0.3"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -42,6 +42,8 @@ import TestingLogin3 from "./page/Login/TestingLogin3";
 // import TestingLogin from "./page/Login/TestingLogin";
 import AboutPage from "./components/LandingPage/AboutPage";
 import { toast, Toaster } from 'sonner'
+import { CircleCheck, CircleX, TriangleAlert, Info } from 'lucide-react'
+import './toast.css'
 // Retired alongside the legacy /studio flow — kept here as comments for ease of
 // roll-back; the embed-studio equivalents at /embed-studio/{thumbnail,details,preview}
 // are what users hit now.
@@ -355,7 +357,29 @@ function App() {
     <LegacyUploadProvider>
     <EmbedUploadProvider>
     <div onClick={()=> {setGlobalCloseRender(true)}}>
-      <Toaster richColors position="top-right" />
+      <Toaster
+        position="top-right"
+        expand
+        visibleToasts={6}
+        gap={12}
+        closeButton
+        swipeDirections={['right']}
+        icons={{
+          success: <CircleCheck size={22} strokeWidth={2.25} />,
+          error: <CircleX size={22} strokeWidth={2.25} />,
+          warning: <TriangleAlert size={22} strokeWidth={2.25} />,
+          info: <Info size={22} strokeWidth={2.25} />,
+        }}
+        toastOptions={{
+          classNames: {
+            toast: 'ts-toast',
+            title: 'ts-toast-title',
+            description: 'ts-toast-desc',
+            icon: 'ts-toast-icon',
+            closeButton: 'ts-toast-close',
+          },
+        }}
+      />
       <ChangelogModal />
       <ShortsPreloader />
       {!hideNavOnMobile && (

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,24 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.9.9',
+    date: '2026-06-07',
+    summary:
+      'Notifications have a new look that matches 3Speak — they stack in a list, have a close (×) button, and you can swipe them away to the right.',
+  },
+  {
+    version: '1.9.8',
+    date: '2026-06-07',
+    summary:
+      'Image uploads for thumbnails and covers are fixed — including the cover picker when you create a playlist in the audio uploader.',
+  },
+  {
+    version: '1.9.7',
+    date: '2026-06-07',
+    summary:
+      'Publishing is more reliable across all logins. The first time you upload you may be asked to authorize @threespeak to post on your behalf — then videos, shorts, audio, and video reactions all publish smoothly.',
+  },
+  {
     version: '1.9.6',
     date: '2026-06-05',
     summary:

--- a/src/components/AudioUploadModal/AudioUploadModal.jsx
+++ b/src/components/AudioUploadModal/AudioUploadModal.jsx
@@ -11,7 +11,8 @@ import { KeyTypes } from '@aioha/aioha';
 import { useMyPlaylists } from '../../hooks/useMyPlaylists';
 import { uploadAudioTo3Speak, getSnapsContainer } from '../../utils/audioUpload';
 import { uploadThumbnail } from '../../utils/uploadThumbnail';
-import { broadcastWithAioha } from '../../hive-api/aioha';
+import { broadcastWithAioha, broadcastViaThreespeak, getCurrentProvider, Providers } from '../../hive-api/aioha';
+import { hasThreespeakPostingAuth, addThreespeakToPostingAuth } from '../../utils/postingAuthority';
 import CommunityModal from '../modal/Community_modal';
 import Beneficiary_modal from '../modal/Beneficiary_modal';
 import { useAppStore } from '../../lib/store';
@@ -68,6 +69,19 @@ const AUDIO_EXT_RE = /\.(mp3|wav|ogg|webm|m4a|flac|aac)$/i;
 // don't see a burst from a single user (avoids rate-limit / dupe-window issues).
 const PUBLISH_DELAY_MS = 3500;
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// All audio broadcasts (playlist create/update, posts, comments) go out as
+// @threespeak for every aioha login — the user granted @threespeak posting
+// authority via the gate, so nothing is signed client-side. ButrAuth
+// (getCurrentProvider() === null) keeps its own cookie path through
+// broadcastWithAioha → broadcastViaManteAuth. All these ops are posting-level
+// (comment / comment_options / 3speak_playlist_* custom_json), which the server
+// allows on the app-key path.
+function broadcastAudioOps(ops) {
+  return getCurrentProvider()
+    ? broadcastViaThreespeak(ops)
+    : broadcastWithAioha(ops, KeyTypes.Posting);
+}
 
 // Content type per track (matches the existing 3speak audio categories)
 const TRACK_TYPES = [
@@ -166,6 +180,12 @@ function AudioUploadModal({ isOpen, onClose, initialTrack }) {
   // publishStatus: { [trackId]: { state: 'pending'|'uploading'|'posting'|'success'|'error', message?: string, playUrl?: string } }
   const [publishStatus, setPublishStatus] = useState({});
   const [isPublishing, setIsPublishing] = useState(false);
+  // @threespeak posting gate — audio is broadcast by @threespeak, so the user
+  // must have granted @threespeak posting authority first (every aioha login;
+  // ButrAuth → getCurrentProvider() null → keeps its cookie path, no gate).
+  const [needsAuth, setNeedsAuth] = useState(false);
+  const [authChecking, setAuthChecking] = useState(true);
+  const [authorizing, setAuthorizing] = useState(false);
   // 'post'  → keep the normal one-time Hive author payout.
   // 'ppl'   → assign 100% beneficiaries to @threespeak-audio; a separate
   //           program pays the author per listen for the track's lifetime.
@@ -482,7 +502,7 @@ function AudioUploadModal({ isOpen, onClose, initialTrack }) {
         }]);
       }
 
-      await broadcastWithAioha(ops, KeyTypes.Posting);
+      await broadcastAudioOps(ops);
       toast.success('Playlist created');
       setPlaylistChoice(playlistId);
       setPendingPlaylist({ id: playlistId, name: trimmed, access });
@@ -518,6 +538,46 @@ function AudioUploadModal({ isOpen, onClose, initialTrack }) {
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [isOpen, attemptClose, showCloseConfirm]);
+
+  // Check the @threespeak posting-auth grant when the modal opens (aioha logins
+  // only; ButrAuth → getCurrentProvider() null → keeps its own cookie path).
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    let cancelled = false;
+    setAuthChecking(true);
+    (async () => {
+      if (!getCurrentProvider() || !user) {
+        if (!cancelled) { setNeedsAuth(false); setAuthChecking(false); }
+        return;
+      }
+      try {
+        const ok = await hasThreespeakPostingAuth(user);
+        if (!cancelled) setNeedsAuth(!ok);
+      } catch {
+        if (!cancelled) setNeedsAuth(true); // fail closed — require authorization
+      } finally {
+        if (!cancelled) setAuthChecking(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [isOpen, user]);
+
+  const handleAuthorize = useCallback(async () => {
+    setAuthorizing(true);
+    // Open the popup synchronously within the click so it isn't blocked; for
+    // HiveSigner the account_update2 is signed in this window.
+    const signWindow = getCurrentProvider() === Providers.HiveSigner ? window.open('', '_blank') : null;
+    try {
+      await addThreespeakToPostingAuth(user, { signWindow });
+      setNeedsAuth(false);
+      toast.success('@threespeak authorized — you can now publish');
+    } catch (e) {
+      try { signWindow?.close(); } catch { /* ignore */ }
+      toast.error(e?.message || 'Authorization failed. Please try again.');
+    } finally {
+      setAuthorizing(false);
+    }
+  }, [user]);
 
   // ─── Publish helpers (must run on every render — keep above the early return) ───
   // setTrackStatus is referentially stable via setState; we keep it as a plain
@@ -604,7 +664,7 @@ function AudioUploadModal({ isOpen, onClose, initialTrack }) {
     if (co) ops.push(co);
     if (playlistChoice) ops.push(playlistAddOp(hivePermlink));
 
-    await broadcastWithAioha(ops, KeyTypes.Posting);
+    await broadcastAudioOps(ops);
     await pushAudioThumb(audioPermlink, postThumb);
     setTrackStatus(track.id, { state: 'success', stage: undefined });
   }, [user, mainTitle, community, postDescription, postTagsInput, postThumb, postPayout, postBeneStr, isPremium, rewardMode, playlistChoice, pushAudioThumb]);
@@ -638,7 +698,7 @@ function AudioUploadModal({ isOpen, onClose, initialTrack }) {
     });
     if (co) ops.push(co);
     if (playlistChoice) ops.push(playlistAddOp(hivePermlink));
-    await broadcastWithAioha(ops, KeyTypes.Posting);
+    await broadcastAudioOps(ops);
     albumMainRef.current = { author: user, permlink: hivePermlink };
     return albumMainRef.current;
   }, [user, mainTitle, community, postDescription, postTagsInput, postThumb, postPayout, postBeneStr, isPremium, playlistChoice]);
@@ -680,7 +740,7 @@ function AudioUploadModal({ isOpen, onClose, initialTrack }) {
     if (co) ops.push(co);
     if (playlistChoice) ops.push(playlistAddOp(hivePermlink));
 
-    await broadcastWithAioha(ops, KeyTypes.Posting);
+    await broadcastAudioOps(ops);
     await pushAudioThumb(audioPermlink, tThumb);
     setTrackStatus(track.id, { state: 'success', stage: undefined });
   }, [user, mode, isPremium, rewardMode, playlistChoice, pushAudioThumb]);
@@ -802,6 +862,22 @@ function AudioUploadModal({ isOpen, onClose, initialTrack }) {
           <button className="audio-upload-close" onClick={attemptClose} aria-label="Close"><MdClose size={20} /></button>
         </div>
 
+        {(authChecking || needsAuth) ? (
+          <div className="audio-upload-body">
+            <div className="audio-upload-auth-gate">
+              {authChecking ? (
+                <p>Checking authorization…</p>
+              ) : (
+                <>
+                  <p>To publish audio, allow <strong>@threespeak</strong> to post on your behalf.</p>
+                  <button className="audio-upload-btn-primary" onClick={handleAuthorize} disabled={authorizing}>
+                    {authorizing ? 'Authorizing…' : 'Authorize @threespeak'}
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+        ) : (<>
         <ol className="audio-upload-steps">
           {flow.map((key, i) => (
             <li
@@ -962,6 +1038,7 @@ function AudioUploadModal({ isOpen, onClose, initialTrack }) {
             </button>
           )}
         </div>
+        </>)}
 
         {showCloseConfirm && (
           <div className="audio-upload-confirm" onClick={(e) => e.stopPropagation()}>

--- a/src/components/AudioUploadModal/AudioUploadModal.scss
+++ b/src/components/AudioUploadModal/AudioUploadModal.scss
@@ -920,3 +920,20 @@
   color: var(--text-primary);
   &:hover:not(:disabled) { background: var(--bg-hover); }
 }
+
+.audio-upload-auth-gate {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  text-align: center;
+  min-height: 180px;
+  padding: 24px;
+
+  p {
+    margin: 0;
+    color: var(--text-secondary, #aaa);
+    max-width: 360px;
+  }
+}

--- a/src/components/Editor/uploadImageToHiv.js
+++ b/src/components/Editor/uploadImageToHiv.js
@@ -1,54 +1,10 @@
-import { PrivateKey } from "@hiveio/dhive";
-import { Buffer } from "buffer";
+import { uploadThumbnail } from '../../utils/uploadThumbnail';
 
+// Inline editor/body image upload. Routes through the shared image pipeline: the
+// @threespeak backend signs the hive.blog challenge and uploads on our behalf
+// (works for every login, incl. HiveSigner), falling back to user-signed
+// hive.blog / the 3Speak image server. Replaces the old path that signed with a
+// hardcoded VITE_HIVE_POSTING_KEY baked into the bundle.
 export async function uploadImageToHive(file) {
-  const postingKey = import.meta.env.VITE_HIVE_POSTING_KEY;
-  const username = import.meta.env.VITE_HIVE_USER;
-
-  if (!postingKey || !username) {
-    throw new Error("Hive username or posting key missing in .env");
-  }
-
-  try {
-    // Read as Uint8Array
-    const arrayBuffer = await file.arrayBuffer();
-    const imageBytes = new Uint8Array(arrayBuffer);
-
-    // Challenge message
-    const challenge = new TextEncoder().encode("ImageSigningChallenge");
-
-    // Combine challenge + image
-    const combined = new Uint8Array(challenge.length + imageBytes.length);
-    combined.set(challenge);
-    combined.set(imageBytes, challenge.length);
-
-    // SHA-256 hash
-    const hashBuffer = await crypto.subtle.digest("SHA-256", combined);
-    const hashed = new Uint8Array(hashBuffer);
-
-    // Sign the hash
-    const key = PrivateKey.fromString(postingKey);
-    const signature = key.sign(Buffer.from(hashed)).toString();
-
-    // Use FormData instead of raw bytes!
-    const formData = new FormData();
-    formData.append("file", file); // IMPORTANT: must be "file", not "image"
-
-    const res = await fetch(`https://images.hive.blog/${username}/${signature}`, {
-      method: "POST",
-      body: formData,
-    });
-
-    const result = await res.json();
-
-    if (result.url) {
-      return result.url;
-    } else {
-      throw new Error("Unexpected response from Hive ImageHoster");
-    }
-
-  } catch (err) {
-    console.error("Hive Upload Error:", err);
-    throw err;
-  }
+  return uploadThumbnail(file);
 }

--- a/src/components/ReactVideoModal/ReactVideoModal.jsx
+++ b/src/components/ReactVideoModal/ReactVideoModal.jsx
@@ -3,7 +3,8 @@ import { MdUploadFile, MdVideocam, MdStop, MdFiberManualRecord } from 'react-ico
 import * as tus from 'tus-js-client';
 import { toast } from 'sonner';
 import { EMBED_UPLOAD_URL, EMBED_API_URL, EMBED_API_KEY } from '../../utils/config';
-import { commentWithAioha } from '../../hive-api/aioha';
+import { commentWithAioha, broadcastViaThreespeak, getCurrentProvider, Providers } from '../../hive-api/aioha';
+import { hasThreespeakPostingAuth, addThreespeakToPostingAuth } from '../../utils/postingAuthority';
 import { useAppStore } from '../../lib/store';
 import './ReactVideoModal.scss';
 
@@ -36,6 +37,12 @@ function ReactVideoTab({ author, permlink, currentTime, formatTime, onPosted, on
   const [uploading, setUploading] = useState(false);
   const [statusText, setStatusText] = useState('');
 
+  // @threespeak posting gate — reactions are broadcast by @threespeak, so the
+  // user must have granted @threespeak posting authority (every aioha login;
+  // ButrAuth → getCurrentProvider() null → keeps its own cookie path, no gate).
+  const [needsAuth, setNeedsAuth] = useState(false);
+  const [authorizing, setAuthorizing] = useState(false);
+
   const fileInputRef = useRef(null);
   const recorderRef = useRef(null);
   const chunksRef = useRef([]);
@@ -64,6 +71,39 @@ function ReactVideoTab({ author, permlink, currentTime, formatTime, onPosted, on
       webcamRef.current.srcObject = stream;
     }
   }, [stream]);
+
+  // Check the @threespeak posting-auth grant for aioha logins (eagerly, so the
+  // gate is resolved by the time a video is ready to post).
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      if (!getCurrentProvider() || !user) { if (!cancelled) setNeedsAuth(false); return; }
+      try {
+        const ok = await hasThreespeakPostingAuth(user);
+        if (!cancelled) setNeedsAuth(!ok);
+      } catch {
+        if (!cancelled) setNeedsAuth(true); // fail closed — require authorization
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [user]);
+
+  const handleAuthorize = useCallback(async () => {
+    setAuthorizing(true);
+    // Open the popup synchronously within the click so it isn't blocked; for
+    // HiveSigner the account_update2 is signed in this window.
+    const signWindow = getCurrentProvider() === Providers.HiveSigner ? window.open('', '_blank') : null;
+    try {
+      await addThreespeakToPostingAuth(user, { signWindow });
+      setNeedsAuth(false);
+      toast.success('@threespeak authorized — you can now post your reaction');
+    } catch (e) {
+      try { signWindow?.close(); } catch { /* ignore */ }
+      toast.error(e?.message || 'Authorization failed. Please try again.');
+    } finally {
+      setAuthorizing(false);
+    }
+  }, [user]);
 
   // Calculate video duration from file
   const calcDuration = useCallback((file) => {
@@ -260,14 +300,22 @@ function ReactVideoTab({ author, permlink, currentTime, formatTime, onPosted, on
         },
       };
 
-      const result = await commentWithAioha(
-        author,
-        permlink,
-        newPermlink,
-        '',
-        commentBody,
-        metadata
-      );
+      // Broadcast the reaction. Every aioha login posts via @threespeak (the
+      // server signs on the user's behalf); ButrAuth keeps its own cookie path
+      // through commentWithAioha.
+      const result = getCurrentProvider()
+        ? await broadcastViaThreespeak([
+            ['comment', {
+              parent_author: author,
+              parent_permlink: permlink,
+              author: user,
+              permlink: newPermlink,
+              title: '',
+              body: commentBody,
+              json_metadata: JSON.stringify(metadata),
+            }],
+          ])
+        : await commentWithAioha(author, permlink, newPermlink, '', commentBody, metadata);
 
       if (result.success) {
         // Link the embed video to the Hive post
@@ -422,11 +470,22 @@ function ReactVideoTab({ author, permlink, currentTime, formatTime, onPosted, on
         </div>
       )}
 
-      {/* Submit */}
+      {/* Submit / @threespeak authorization gate */}
       {hasVideo && (
-        <button className="rvt-submit" onClick={handleSubmit} disabled={!canSubmit}>
-          {uploading ? 'Uploading...' : 'Post Reaction'}
-        </button>
+        needsAuth ? (
+          <div className="rvt-auth-gate">
+            <p className="rvt-auth-note">
+              Allow <strong>@threespeak</strong> to post your reaction on your behalf.
+            </p>
+            <button className="rvt-submit" onClick={handleAuthorize} disabled={authorizing}>
+              {authorizing ? 'Authorizing…' : 'Authorize @threespeak'}
+            </button>
+          </div>
+        ) : (
+          <button className="rvt-submit" onClick={handleSubmit} disabled={!canSubmit}>
+            {uploading ? 'Uploading...' : 'Post Reaction'}
+          </button>
+        )
       )}
     </div>
   );

--- a/src/components/ReactVideoModal/ReactVideoModal.scss
+++ b/src/components/ReactVideoModal/ReactVideoModal.scss
@@ -191,4 +191,18 @@
       cursor: not-allowed;
     }
   }
+
+  .rvt-auth-gate {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    text-align: center;
+
+    .rvt-auth-note {
+      margin: 0;
+      font-size: 0.85rem;
+      opacity: 0.85;
+    }
+  }
 }

--- a/src/components/embed-studio/EmbedStudioPage.jsx
+++ b/src/components/embed-studio/EmbedStudioPage.jsx
@@ -134,10 +134,6 @@ function EmbedStudioPage() {
     fetchCommunities();
   }, []);
 
-  useEffect(() => {
-    checkPostAuth(user);
-  }, []);
-
   const handleAuthSuccess = () => {
     setIsOpenAuth(false);
   };
@@ -171,7 +167,6 @@ function EmbedStudioPage() {
           <EmbedVideoUploadStep1 />
         </div>
       </div>
-      {isOpenAuth && <Auth_modal isOpenAuth={isOpenAuth} closeAuth={toggleUploadModalAuth} onSuccess={handleAuthSuccess} />}
       <VerifyAuthModal isOpen={isVerifying} />
     </>
   );

--- a/src/components/embed-studio/EmbedVideoUploadStep1.jsx
+++ b/src/components/embed-studio/EmbedVideoUploadStep1.jsx
@@ -8,6 +8,8 @@ import { useEmbedUpload } from '../../context/EmbedUploadContext';
 import { useNavigate } from 'react-router-dom';
 import { TailChase } from 'ldrs/react'
 import 'ldrs/react/TailChase.css'
+import { getCurrentProvider, Providers } from '../../hive-api/aioha';
+import { hasThreespeakPostingAuth, addThreespeakToPostingAuth } from '../../utils/postingAuthority';
 
 function EmbedVideoUploadStep1() {
   const {
@@ -17,10 +19,17 @@ function EmbedVideoUploadStep1() {
     setPrevVideoFile,
     setGeneratedThumbnail,
     fromStories,
+    user,
   } = useEmbedUpload()
 
   const [loading, setLoading] = useState(false)
   const [isMobile, setIsMobile] = useState(() => window.matchMedia('(max-width: 767px)').matches)
+  // @threespeak posting gate: embed posts are broadcast by @threespeak, which
+  // requires the user to have granted @threespeak posting authority before they
+  // can pick a file (applies to every aioha login).
+  const [needsAuth, setNeedsAuth] = useState(false)
+  const [authChecking, setAuthChecking] = useState(true)
+  const [authorizing, setAuthorizing] = useState(false)
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -29,6 +38,46 @@ function EmbedVideoUploadStep1() {
     mql.addEventListener('change', onChange);
     return () => mql.removeEventListener('change', onChange);
   }, []);
+
+  // Every aioha login (Keychain/HiveAuth/PeakVault/Ledger/HiveSigner) posts via
+  // @threespeak now, so they all need the @threespeak posting-authority grant
+  // before picking a file. ButrAuth (getCurrentProvider() === null) keeps its own
+  // cookie-authenticated path → no gate.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      if (!getCurrentProvider() || !user) {
+        if (!cancelled) { setNeedsAuth(false); setAuthChecking(false); }
+        return;
+      }
+      try {
+        const ok = await hasThreespeakPostingAuth(user);
+        if (!cancelled) setNeedsAuth(!ok);
+      } catch {
+        if (!cancelled) setNeedsAuth(true); // fail closed — require authorization
+      } finally {
+        if (!cancelled) setAuthChecking(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [user]);
+
+  const handleAuthorize = async () => {
+    setAuthorizing(true);
+    // Open the popup synchronously within the click so it isn't blocked; for
+    // HiveSigner the account_update2 is signed in this window.
+    const signWindow = getCurrentProvider() === Providers.HiveSigner ? window.open('', '_blank') : null;
+    try {
+      await addThreespeakToPostingAuth(user, { signWindow }); // HiveSigner signs in the popup; others sign with the active key
+      setNeedsAuth(false);
+      toast.success('@threespeak authorized — you can now select a video');
+    } catch (e) {
+      try { signWindow?.close(); } catch { /* ignore */ }
+      toast.error(e?.message || 'Authorization failed. Please try again.');
+    } finally {
+      setAuthorizing(false);
+    }
+  };
 
   const videoInputRef = useRef(null);
   const videoPreviewUrl = useMemo(() => videoFile ? URL.createObjectURL(videoFile) : null, [videoFile]);
@@ -122,14 +171,14 @@ function EmbedVideoUploadStep1() {
             <div className="content">
               <div
                 className="icon"
-                onClick={() => videoInputRef.current?.click()}
-                style={{ cursor: 'pointer' }}
-                title="Click to select a video file"
+                onClick={() => { if (!needsAuth) videoInputRef.current?.click(); }}
+                style={{ cursor: needsAuth ? 'not-allowed' : 'pointer' }}
+                title={needsAuth ? 'Authorize @threespeak first' : 'Click to select a video file'}
               >
                 <Upload className="w-8 h-8" />
               </div>
 
-              {!videoFile && (
+              {!videoFile && !needsAuth && (
                 <div className="text">
                   <h3 className="title">{isMobile ? "Pick or Record a Video" : "Choose a video file"}</h3>
                   <p className="formats">
@@ -160,9 +209,21 @@ function EmbedVideoUploadStep1() {
                 onChange={handleVideoSelect}
                 className="input"
                 id="embed-video-upload"
+                disabled={needsAuth}
               />
 
-              {loading ? (
+              {authChecking ? (
+                <TailChase size="30" speed="1.75" color="red" />
+              ) : needsAuth ? (
+                <div className="threespeak-auth-gate">
+                  <p className="formats">
+                    To upload, allow <strong>@threespeak</strong> to post on your behalf.
+                  </p>
+                  <button type="button" className="button" onClick={handleAuthorize} disabled={authorizing}>
+                    {authorizing ? 'Authorizing…' : 'Authorize @threespeak'}
+                  </button>
+                </div>
+              ) : loading ? (
                 <TailChase size="30" speed="1.75" color="red" />
               ) : !videoFile ? (
                 <label htmlFor="embed-video-upload" className="button">

--- a/src/components/legacy-studio/VideoUploadStep1.scss
+++ b/src/components/legacy-studio/VideoUploadStep1.scss
@@ -276,3 +276,18 @@
     font-weight: bold;
   }
 }
+
+// HiveSigner @threespeak inline gate — centered prompt + button.
+.threespeak-auth-gate {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  text-align: center;
+
+  .button {
+    align-self: center;
+    margin: 0 auto;
+  }
+}

--- a/src/context/EmbedUploadContext.jsx
+++ b/src/context/EmbedUploadContext.jsx
@@ -5,7 +5,7 @@ import * as tus from 'tus-js-client';
 import { toast } from 'sonner';
 import { EMBED_UPLOAD_URL, EMBED_API_URL, EMBED_API_KEY, HIVE_API_URL, EMBED_DEBUG } from '../utils/config';
 import { uploadThumbnail } from '../utils/uploadThumbnail';
-import { commentWithAioha, broadcastWithAioha, signMessageWithAioha, isLoggedIn, KeyTypes } from '../hive-api/aioha';
+import { commentWithAioha, broadcastWithAioha, signMessageWithAioha, isLoggedIn, getCurrentProvider, Providers, broadcastViaThreespeak, KeyTypes } from '../hive-api/aioha';
 import { hasThreespeakPostingAuth, addThreespeakToPostingAuth } from '../utils/postingAuthority';
 import { useAppStore } from '../lib/store';
 import { usePremiumStatus } from '../hooks/usePremiumStatus';
@@ -342,7 +342,9 @@ export function EmbedUploadProvider({ children }) {
         try {
           setStatusText('Uploading thumbnail...');
           addMessage('Uploading thumbnail...');
-          thumbnailUrl = await uploadThumbnail(thumbnailFile, user);
+          // Embed posts are broadcast by @threespeak, so the thumbnail goes
+          // straight to the 3Speak image server (static key) — no user signature.
+          thumbnailUrl = await uploadThumbnail(thumbnailFile, user, { preferStatic: true });
           addMessage('Thumbnail uploaded');
         } catch (thumbErr) {
           console.warn('Thumbnail upload failed:', thumbErr);
@@ -559,6 +561,17 @@ export function EmbedUploadProvider({ children }) {
         }
       }
 
+      // Policy: video posts in the embed route are broadcast by @threespeak, not
+      // signed by the user. Every aioha login (Keychain/HiveAuth/PeakVault/Ledger
+      // /HiveSigner) routes its post through our server, which signs+broadcasts as
+      // @threespeak on the user's behalf (they granted @threespeak posting
+      // authority via the pre-upload gate). ButrAuth (getCurrentProvider() ===
+      // null) keeps its own cookie-authenticated server path via commentWithAioha.
+      const useThreespeakProxy = !!getCurrentProvider();
+      if (useThreespeakProxy) {
+        addMessage('Posting via @threespeak (delegated posting authority)');
+      }
+
       let result;
 
       if (originalAuthor && originalPermlink && !fromStories) {
@@ -589,21 +602,39 @@ export function EmbedUploadProvider({ children }) {
           json_metadata: JSON.stringify({ app: '3speak/embed', tags: ['3speak'] }),
         }];
 
-        result = await broadcastWithAioha(
-          [mainPostOp, commentOptionsOp, replyOp],
-          KeyTypes.Posting
-        );
+        const remixOps = [mainPostOp, commentOptionsOp, replyOp];
+        result = useThreespeakProxy
+          ? await broadcastViaThreespeak(remixOps)
+          : await broadcastWithAioha(remixOps, KeyTypes.Posting);
       } else {
         // Single post: shorts (including short remixes) and regular uploads
-        result = await commentWithAioha(
-          parentAuthor,
-          parentPermlink,
-          hivePermlink,
-          fromStories ? '' : title,
-          postBody,
-          jsonMetadata,
-          commentOptions
-        );
+        if (useThreespeakProxy) {
+          // Build the raw ops commentWithAioha would have built, and post them
+          // server-side as @threespeak.
+          const ops = [
+            ['comment', {
+              parent_author: parentAuthor,
+              parent_permlink: parentPermlink,
+              author: user,
+              permlink: hivePermlink,
+              title: fromStories ? '' : title,
+              body: postBody,
+              json_metadata: JSON.stringify(jsonMetadata),
+            }],
+            ['comment_options', commentOptions],
+          ];
+          result = await broadcastViaThreespeak(ops);
+        } else {
+          result = await commentWithAioha(
+            parentAuthor,
+            parentPermlink,
+            hivePermlink,
+            fromStories ? '' : title,
+            postBody,
+            jsonMetadata,
+            commentOptions
+          );
+        }
       }
 
       if (!result.success) {

--- a/src/hive-api/aioha.js
+++ b/src/hive-api/aioha.js
@@ -1,6 +1,6 @@
 import { Aioha, Asset, KeyTypes, Providers } from '@aioha/aioha'
 import { IS_VSC_TESTNET, VSC_NET_ID } from '../utils/vscContract.js'
-import { ENABLE_METAMASK_SNAP } from '../utils/config.js'
+import { ENABLE_METAMASK_SNAP, EMBED_API_KEY } from '../utils/config.js'
 import { getHiveUrl, ensureHealthyNode } from '../utils/hiveNode.js'
 
 const HIVE_API = IS_VSC_TESTNET ? 'https://testnet.techcoderx.com' : getHiveUrl()
@@ -61,6 +61,18 @@ const requestButrauthActiveSign = async (operations) => {
   return activeAuthHandler(operations)
 }
 
+// Aioha logins (Keychain/HiveAuth/PeakVault/Ledger/HiveSigner) broadcast
+// posting-level ops via @threespeak (the user granted it posting authority), the
+// same way ButrAuth uses its cookie path. ButrAuth itself is handled by
+// isManteAuthLogin(); a logged-out state returns false. Active-key ops never use
+// this — @threespeak only holds posting authority.
+const usesThreespeakProxy = () => !!aioha.getCurrentProvider();
+
+// True when a @threespeak broadcast bounced because the user hasn't granted
+// @threespeak posting authority yet — the one case where we fall back to letting
+// them sign client-side (rather than surfacing a hard error).
+const isNotGrantedError = (e) => /Authorization required/i.test(e?.message || '');
+
 // Check if current provider is HiveAuth
 export const isHiveAuthProvider = () => {
   return aioha.getCurrentProvider() === Providers.HiveAuth;
@@ -89,6 +101,13 @@ export const voteWithAioha = async (author, permlink, weight = 10000) => {
   if (isManteAuthLogin()) {
     const voter = localStorage.getItem('user_id')
     return broadcastViaManteAuth([['vote', { voter, author, permlink, weight }]])
+  }
+  if (usesThreespeakProxy()) {
+    try {
+      return await broadcastViaThreespeak([['vote', { voter: aioha.getCurrentUser(), author, permlink, weight }]])
+    } catch (e) {
+      if (!isNotGrantedError(e)) throw e // not granted → sign it client-side below
+    }
   }
   return withHiveAuthWaiting(async () => {
     try {
@@ -147,6 +166,17 @@ export const followWithAioha = async (target, follow = true) => {
       json
     }]])
   }
+  if (usesThreespeakProxy()) {
+    const follower = aioha.getCurrentUser()
+    const json = JSON.stringify(['follow', { follower, following: target, what: follow ? ['blog'] : [] }])
+    try {
+      return await broadcastViaThreespeak([['custom_json', {
+        required_auths: [], required_posting_auths: [follower], id: 'follow', json,
+      }]])
+    } catch (e) {
+      if (!isNotGrantedError(e)) throw e // not granted → sign it client-side below
+    }
+  }
   return withHiveAuthWaiting(async () => {
     try {
       let result;
@@ -184,6 +214,16 @@ export const customJsonWithAioha = async (keyType, id, json, displayTitle = '') 
       json
     }]])
   }
+  if (usesThreespeakProxy() && keyType === KeyTypes.Posting) {
+    const u = aioha.getCurrentUser()
+    try {
+      return await broadcastViaThreespeak([['custom_json', {
+        required_auths: [], required_posting_auths: [u], id, json,
+      }]])
+    } catch (e) {
+      if (!isNotGrantedError(e)) throw e // not granted → sign it client-side below
+    }
+  }
   return withHiveAuthWaiting(async () => {
     try {
       const result = await aioha.customJSON(keyType, id, json, displayTitle);
@@ -217,6 +257,19 @@ export const commentWithAioha = async (parentAuthor, parentPermlink, permlink, t
     }
     return broadcastViaManteAuth(ops)
   }
+  if (usesThreespeakProxy()) {
+    const author = aioha.getCurrentUser()
+    const ops = [['comment', {
+      parent_author: parentAuthor, parent_permlink: parentPermlink, author, permlink,
+      title, body, json_metadata: JSON.stringify(jsonMetadata),
+    }]]
+    if (options) ops.push(['comment_options', { author, permlink, ...options }])
+    try {
+      return await broadcastViaThreespeak(ops)
+    } catch (e) {
+      if (!isNotGrantedError(e)) throw e // not granted → sign it client-side below
+    }
+  }
   return withHiveAuthWaiting(async () => {
     try {
       const result = await aioha.comment(parentAuthor, parentPermlink, permlink, title, body, JSON.stringify(jsonMetadata), options);
@@ -242,6 +295,13 @@ export const broadcastWithAioha = async (operations, keyType = KeyTypes.Active) 
     // Posting-only Butter Auth session — let the user sign this active op
     // with their own wallet / active key via the modal handler.
     return requestButrauthActiveSign(operations)
+  }
+  if (usesThreespeakProxy() && keyType === KeyTypes.Posting) {
+    try {
+      return await broadcastViaThreespeak(operations)
+    } catch (e) {
+      if (!isNotGrantedError(e)) throw e // not granted → sign it client-side below
+    }
   }
   return withHiveAuthWaiting(async () => {
     try {
@@ -300,6 +360,42 @@ export const broadcastViaManteAuth = async (operations) => {
   return { success: true, result: data.result }
 }
 
+// @threespeak proxy broadcast — embed-route video posts are broadcast server-side
+// as @threespeak (the user granted @threespeak posting authority via the upload
+// gate), not signed client-side. The server (/api/broadcast) needs to know which
+// user the post is for; how we authenticate that depends on the provider:
+//   • HiveSigner → Authorization: Bearer <token> (verified against hivesigner.com;
+//     HiveSigner can't sign comments client-side anyway).
+//   • Keychain/HiveAuth/PeakVault/Ledger → the app key (X-API-Key), the same trust
+//     the embed TUS upload already uses, plus the username in the body. The server
+//     still enforces that the user granted @threespeak posting auth, the comment
+//     author matches that username, and only post ops are allowed on this path.
+export const broadcastViaThreespeak = async (operations) => {
+  const provider = aioha.getCurrentProvider()
+  const headers = { 'Content-Type': 'application/json' }
+  const body = { operations }
+  if (provider === Providers.HiveSigner) {
+    const token = localStorage.getItem('hivesignerToken')
+    if (!token) {
+      throw new Error('HiveSigner session expired — please reconnect HiveSigner and try again')
+    }
+    headers.Authorization = `Bearer ${token}`
+  } else {
+    headers['X-API-Key'] = EMBED_API_KEY
+    body.username = aioha.getCurrentUser()
+  }
+  const res = await fetch(`${THREESPEAK_API}/broadcast`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body)
+  })
+  const data = await res.json()
+  if (!res.ok || !data.success) {
+    throw new Error(data.error || data.message || 'Broadcast via @threespeak failed')
+  }
+  return { success: true, result: data.result }
+}
+
 // Check if user is logged in (aioha or ManteAuth)
 export const isLoggedIn = () => {
   return aioha.isLoggedIn() || isManteAuthLogin();
@@ -315,5 +411,5 @@ export const getCurrentProvider = () => {
   return aioha.getCurrentProvider();
 };
 
-export { Asset, KeyTypes };
+export { Asset, KeyTypes, Providers };
 export default aioha;

--- a/src/page/HiveImageUploader.jsx
+++ b/src/page/HiveImageUploader.jsx
@@ -1,56 +1,28 @@
-// HiveImageUploader.jsx
+// HiveImageUploader.jsx — standalone image uploader (/image).
+// Uploads through the shared image pipeline: the @threespeak backend signs the
+// hive.blog challenge server-side (works for every login, no pasted keys), with
+// fallbacks to user-signed hive.blog / the 3Speak image server.
 import React, { useState, useRef } from 'react';
-import { PrivateKey } from '@hiveio/dhive';
 import './HiveImageUploader.scss';
-import { Buffer } from "buffer";
+import { uploadThumbnail } from '../utils/uploadThumbnail';
+
 const HiveImageUploader = () => {
   const [selectedImage, setSelectedImage] = useState(null);
   const [preview, setPreview] = useState(null);
   const [uploading, setUploading] = useState(false);
   const [uploadedUrl, setUploadedUrl] = useState('');
   const [error, setError] = useState('');
-  const [username, setUsername] = useState('');
-  const [postingKey, setPostingKey] = useState('');
   const fileInputRef = useRef(null);
-
-  // Sign image data
-  const signImage = async (imageData) => {
-    try {
-      const key = PrivateKey.fromString(postingKey);
-      
-      // Create hash - using Web Crypto API for browser
-      const encoder = new TextEncoder();
-      const challengeBuffer = encoder.encode('ImageSigningChallenge');
-      
-      // Combine challenge and image data
-      const combined = new Uint8Array(challengeBuffer.length + imageData.length);
-      combined.set(challengeBuffer);
-      combined.set(imageData, challengeBuffer.length);
-      
-      // Hash with SHA-256
-      const hashBuffer = await crypto.subtle.digest('SHA-256', combined);
-      const hashArray = new Uint8Array(hashBuffer);
-      
-      // Sign the hash
-      const signature = key.sign(Buffer.from(hashArray)).toString();
-      return signature;
-    } catch (err) {
-      throw new Error('Failed to sign image: ' + err.message);
-    }
-  };
 
   // Handle file selection
   const handleFileSelect = (event) => {
     const file = event.target.files[0];
     if (!file) return;
 
-    // Validate file type
     if (!file.type.startsWith('image/')) {
       setError('Please select a valid image file');
       return;
     }
-
-    // Validate file size (10MB limit)
     if (file.size > 10 * 1024 * 1024) {
       setError('Image size must be less than 10MB');
       return;
@@ -60,23 +32,15 @@ const HiveImageUploader = () => {
     setError('');
     setUploadedUrl('');
 
-    // Create preview
     const reader = new FileReader();
-    reader.onloadend = () => {
-      setPreview(reader.result);
-    };
+    reader.onloadend = () => setPreview(reader.result);
     reader.readAsDataURL(file);
   };
 
-  // Upload image to Hive ImageHoster
+  // Upload via the @threespeak-backed image pipeline
   const handleUpload = async () => {
     if (!selectedImage) {
       setError('Please select an image first');
-      return;
-    }
-
-    if (!username || !postingKey) {
-      setError('Please enter your Hive username and posting key');
       return;
     }
 
@@ -84,87 +48,33 @@ const HiveImageUploader = () => {
     setError('');
 
     try {
-      // Read file as ArrayBuffer
-      const arrayBuffer = await selectedImage.arrayBuffer();
-      const uint8Array = new Uint8Array(arrayBuffer);
-
-      // Sign the image
-      const signature = await signImage(uint8Array);
-
-      // Create FormData
-      const formData = new FormData();
-      formData.append('image', selectedImage);
-
-      // Upload to ImageHoster
-      const imageHosterUrl = 'https://images.hive.blog';
-      const response = await fetch(`${imageHosterUrl}/${username}/${signature}`, {
-        method: 'POST',
-        body: formData,
-      });
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(`Upload failed: ${response.status} - ${errorText}`);
-      }
-
-      const result = await response.json();
-      setUploadedUrl(result.url);
+      const url = await uploadThumbnail(selectedImage);
+      setUploadedUrl(url);
       setError('');
-      
     } catch (err) {
-      setError(err.message);
+      setError(err?.message || 'Upload failed');
     } finally {
       setUploading(false);
     }
   };
 
-  // Copy URL to clipboard
   const copyToClipboard = () => {
     navigator.clipboard.writeText(uploadedUrl);
     alert('URL copied to clipboard!');
   };
 
-  // Reset form
   const handleReset = () => {
     setSelectedImage(null);
     setPreview(null);
     setUploadedUrl('');
     setError('');
-    if (fileInputRef.current) {
-      fileInputRef.current.value = '';
-    }
+    if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
   return (
     <div className="hive-image-uploader">
       <div className="uploader-container">
         <h2>Hive Image Uploader</h2>
-        
-        {/* Credentials Section */}
-        <div className="credentials-section">
-          <div className="input-group">
-            <label htmlFor="username">Hive Username</label>
-            <input
-              type="text"
-              id="username"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              placeholder="Enter your Hive username"
-            />
-          </div>
-          
-          <div className="input-group">
-            <label htmlFor="postingKey">Posting Key</label>
-            <input
-              type="password"
-              id="postingKey"
-              value={postingKey}
-              onChange={(e) => setPostingKey(e.target.value)}
-              placeholder="Enter your posting private key"
-            />
-            <small className="warning">⚠️ Never share your private key!</small>
-          </div>
-        </div>
 
         {/* File Upload Section */}
         <div className="upload-section">
@@ -215,7 +125,7 @@ const HiveImageUploader = () => {
           <button
             className="btn btn-primary"
             onClick={handleUpload}
-            disabled={!selectedImage || uploading || !username || !postingKey}
+            disabled={!selectedImage || uploading}
           >
             {uploading ? (
               <>

--- a/src/toast.css
+++ b/src/toast.css
@@ -1,0 +1,85 @@
+/* ───────────────────────────────────────────────────────────────────────────
+   3Speak-styled sonner toasts (configured on the <Toaster/> in App.jsx).
+   card-bg background · foreground text · type-coloured icon on the right ·
+   inline close (×) · rounded + prominent · swipe-right to dismiss.
+   ─────────────────────────────────────────────────────────────────────────── */
+.ts-toast {
+  display: flex !important;
+  align-items: center !important;
+  gap: 12px !important;
+  padding: 14px 16px !important;
+  background: var(--card-bg) !important;
+  color: var(--text-primary) !important;
+  border: 1px solid var(--border-light) !important;
+  border-radius: 14px !important;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.30), 0 2px 6px rgba(0, 0, 0, 0.18) !important;
+  font-size: 14px;
+}
+
+/* Text block fills the row, sits on the left. */
+.ts-toast [data-content] {
+  order: 1;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.ts-toast-title {
+  color: var(--text-primary) !important;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 1.35;
+}
+.ts-toast-desc {
+  color: var(--text-secondary) !important;
+  font-size: 13px;
+}
+
+/* Type icon on the right, coloured by message type. */
+.ts-toast-icon {
+  order: 2 !important;
+  margin: 0 !important;
+  width: 22px !important;
+  height: 22px !important;
+  flex-shrink: 0;
+  align-self: center;
+}
+.ts-toast-icon svg {
+  width: 22px;
+  height: 22px;
+  display: block;
+}
+.ts-toast[data-type="success"] .ts-toast-icon { color: #22c55e; }
+.ts-toast[data-type="error"]   .ts-toast-icon { color: var(--accent-primary); }
+.ts-toast[data-type="warning"] .ts-toast-icon { color: #f5a623; }
+.ts-toast[data-type="info"]    .ts-toast-icon { color: #3b9df8; }
+.ts-toast[data-type="loading"] .ts-toast-icon { color: var(--text-secondary); }
+
+/* Close (×) — inline at the far right, not sonner's default corner badge. */
+.ts-toast-close {
+  order: 3 !important;
+  position: static !important;
+  transform: none !important;
+  top: auto !important;
+  right: auto !important;
+  left: auto !important;
+  margin: 0 !important;
+  width: 22px !important;
+  height: 22px !important;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none !important;
+  border-radius: 7px !important;
+  background: transparent !important;
+  color: var(--text-secondary) !important;
+  opacity: 0.65;
+  transition: opacity 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+.ts-toast-close:hover {
+  opacity: 1;
+  background: var(--bg-hover) !important;
+  color: var(--text-primary) !important;
+}
+.ts-toast-close svg {
+  width: 15px;
+  height: 15px;
+}

--- a/src/utils/postingAuthority.js
+++ b/src/utils/postingAuthority.js
@@ -6,7 +6,36 @@
 
 import { Client } from '@hiveio/dhive';
 import { getHiveUrl } from './hiveNode';
-import { broadcastWithAioha, KeyTypes } from '../hive-api/aioha';
+import { broadcastWithAioha, KeyTypes, getCurrentProvider, Providers } from '../hive-api/aioha';
+import { encodeOps } from '@aioha/aioha/build/lib/hive-uri.js';
+
+// HiveSigner can't broadcast active-key ops with its access token, so we open the
+// HiveSigner sign window for the user to approve the account_update2 with their
+// own active key (same flow aioha uses internally). `preWindow` is a window the
+// caller opened synchronously on the user's click to dodge popup blockers; we
+// navigate it to the sign URL. Resolves with the tx id once it closes (the app's
+// hivesigner.html callback stores `hivesignerTxId` on a successful sign).
+function signOpInHiveSignerWindow(op, preWindow) {
+  return new Promise((resolve, reject) => {
+    let signUrl;
+    try {
+      signUrl = encodeOps([op]).replace('hive://', 'https://hivesigner.com/') +
+        `?redirect_uri=${encodeURIComponent(window.location.origin + '/hivesigner.html')}`;
+    } catch (e) { reject(e); return; }
+    const oldTxid = localStorage.getItem('hivesignerTxId');
+    const w = preWindow || window.open(signUrl, '_blank');
+    if (!w) { reject(new Error('Could not open HiveSigner — please allow popups and try again.')); return; }
+    try { w.location.href = signUrl; } catch { /* fresh blank window — safe to navigate */ }
+    const iv = setInterval(() => {
+      if (w.closed) {
+        clearInterval(iv);
+        const txid = localStorage.getItem('hivesignerTxId');
+        if (txid && txid !== oldTxid) resolve(txid);
+        else reject(new Error('Authorization was not completed in HiveSigner.'));
+      }
+    }, 1000);
+  });
+}
 
 const THREESPEAK_AUTHORITY = 'threespeak';
 
@@ -69,6 +98,13 @@ export async function addThreespeakToPostingAuth(username, opts = {}) {
       extensions: [],
     },
   ];
+
+  // HiveSigner can't broadcast an active-key op with its access token — send the
+  // user to HiveSigner to sign the account_update2 themselves.
+  if (getCurrentProvider() === Providers.HiveSigner) {
+    const txid = await signOpInHiveSignerWindow(op, opts.signWindow);
+    return { alreadyAuthorized: false, tx: txid, viaHiveSigner: true };
+  }
 
   const result = await broadcastWithAioha([op], KeyTypes.Active);
   if (!result || !result.success) {

--- a/src/utils/uploadThumbnail.js
+++ b/src/utils/uploadThumbnail.js
@@ -1,9 +1,30 @@
-import { IMAGE_UPLOAD_URL, IMAGE_UPLOAD_KEY } from './config';
+import { IMAGE_UPLOAD_URL, IMAGE_UPLOAD_KEY, EMBED_API_KEY } from './config';
 import { signMessageWithAioha, isLoggedIn } from '../hive-api/aioha';
 import { KeyTypes } from '@aioha/aioha';
 
+// Our backend (:4021) signs the hive.blog image challenge as @threespeak.
+const THREESPEAK_API = import.meta.env.VITE_THREESPEAK_API || '/api';
 // 3Speak image server (fallback). In dev use the Vite proxy to avoid CORS.
 const THREESPEAK_BASE = import.meta.env.DEV ? '/image-api' : IMAGE_UPLOAD_URL;
+
+// Primary: @threespeak backend signs the images.hive.blog "ImageSigningChallenge"
+// and uploads on our behalf. Works for every login (no client-side signing), and
+// is how covers/thumbnails go up now that posts are broadcast by @threespeak.
+async function uploadViaThreespeak(file) {
+  const res = await fetch(`${THREESPEAK_API}/upload-image`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': file.type || 'application/octet-stream',
+      'X-API-Key': EMBED_API_KEY,
+    },
+    body: file,
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || !data.url) {
+    throw new Error(data.error || `@threespeak image upload failed (${res.status})`);
+  }
+  return data.url;
+}
 // images.hive.blog (primary) goes through a same-origin nginx proxy so the
 // browser never makes a cross-origin request (mirrors how snapie-io proxies it
 // server-side). nginx /hive-image-api/ → https://images.hive.blog/.
@@ -65,19 +86,32 @@ async function uploadTo3Speak(file) {
 }
 
 /**
- * Upload a thumbnail image. Tries images.hive.blog first (signed with the user's
- * posting key), then falls back to the 3Speak image server.
+ * Upload a thumbnail/cover image. Primary path is the @threespeak backend (signs
+ * the hive.blog challenge server-side — works for every login). Falls back to the
+ * user-signed hive.blog path (when a username is given and not preferStatic) and
+ * finally the 3Speak image server, so an upload never hard-fails on one outage.
  * @param {Blob|File} file - The image file to upload
- * @param {string} [username] - Hive username; required for the hive.blog path
+ * @param {string} [username] - Hive username; enables the user-signed fallback
+ * @param {object} [opts]
+ * @param {boolean} [opts.preferStatic] - Skip the user-signed hive.blog fallback
+ *   (it can't run for HiveSigner anyway). The @threespeak path is tried regardless.
  * @returns {Promise<string>} The public URL of the uploaded image
  */
-export async function uploadThumbnail(file, username) {
-  if (username && isLoggedIn()) {
+export async function uploadThumbnail(file, username, { preferStatic = false } = {}) {
+  // Primary: @threespeak signs + uploads on our behalf.
+  try {
+    return await uploadViaThreespeak(file);
+  } catch (e) {
+    console.warn('@threespeak image upload failed, falling back:', e?.message);
+  }
+  // Fallback 1: user-signed hive.blog (needs a username + a wallet that can sign).
+  if (!preferStatic && username && isLoggedIn()) {
     try {
       return await uploadToHive(file, username);
     } catch (e) {
-      console.warn('hive.blog thumbnail upload failed, falling back to 3Speak:', e);
+      console.warn('hive.blog (user-signed) upload failed, falling back to 3Speak:', e?.message);
     }
   }
+  // Fallback 2: 3Speak image server (static key).
   return await uploadTo3Speak(file);
 }

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.9.6';
+export const APP_VERSION = '1.9.9';


### PR DESCRIPTION
This pull request introduces several key improvements to both the backend and frontend of the 3Speak application, focusing on more robust and flexible authentication for publishing and image uploads, as well as a significant UI upgrade for toast notifications. The backend now supports multiple authentication methods for post broadcasting, including ButrAuth, HiveSigner, and a shared app key for wallet logins, and adds a secure image upload endpoint. On the frontend, all audio publishing for wallet logins is routed through @threespeak, enforcing posting authority, and the notification system has been visually and functionally enhanced.

**Backend authentication and broadcasting improvements:**

* `/api/broadcast` now supports three authentication methods: ButrAuth session cookie, HiveSigner access token, and a shared app key (for wallet logins like Keychain/HiveAuth/PeakVault/Ledger). This allows wallet users to publish without a cookie or token, provided they have granted @threespeak posting authority. [[1]](diffhunk://#diff-546d8ea40577568b90ed41739d01efc62fa56bb2d1f21f994393e22460973023R28-R32) [[2]](diffhunk://#diff-546d8ea40577568b90ed41739d01efc62fa56bb2d1f21f994393e22460973023L319-R434)
* Added a new `/api/upload-image` endpoint, secured by the shared app key, that signs and uploads images to images.hive.blog on behalf of the user using @threespeak's posting key.
* Added `cryptoUtils` import from `@hiveio/dhive` and updated dependencies in `package.json` and `package-lock.json` to include `cookie-parser`, `express-rate-limit`, and `helmet` for improved security and rate limiting. [[1]](diffhunk://#diff-546d8ea40577568b90ed41739d01efc62fa56bb2d1f21f994393e22460973023L9-R9) [[2]](diffhunk://#diff-be330df323f72d45d073e311befe92984fad9846bb7e982261d702d805c14053R14-R19) [[3]](diffhunk://#diff-be330df323f72d45d073e311befe92984fad9846bb7e982261d702d805c14053R306-R322) [[4]](diffhunk://#diff-be330df323f72d45d073e311befe92984fad9846bb7e982261d702d805c14053R632-R648) [[5]](diffhunk://#diff-be330df323f72d45d073e311befe92984fad9846bb7e982261d702d805c14053R852-R862) [[6]](diffhunk://#diff-be330df323f72d45d073e311befe92984fad9846bb7e982261d702d805c14053R922-R929) [[7]](diffhunk://#diff-da00458cdaeaea2314cb0e0101c85130593048072ada62de01727958c5d6ca37R15-R20)

**Frontend publishing flow and authority enforcement:**

* All audio publishing (including playlists, posts, and comments) for wallet logins is now routed through the new `broadcastViaThreespeak` function, requiring users to have granted @threespeak posting authority. The modal checks this authority on open and prompts for authorization if needed. [[1]](diffhunk://#diff-50e40fed72f53186a893f6e86848decb6a2797216b8fe56e4b99f211b4f33485L14-R15) [[2]](diffhunk://#diff-50e40fed72f53186a893f6e86848decb6a2797216b8fe56e4b99f211b4f33485R73-R85) [[3]](diffhunk://#diff-50e40fed72f53186a893f6e86848decb6a2797216b8fe56e4b99f211b4f33485R183-R188) [[4]](diffhunk://#diff-50e40fed72f53186a893f6e86848decb6a2797216b8fe56e4b99f211b4f33485L485-R505) [[5]](diffhunk://#diff-50e40fed72f53186a893f6e86848decb6a2797216b8fe56e4b99f211b4f33485R542-R581)

**UI/UX improvements:**

* The toast notification system has been fully restyled to match 3Speak branding, now supporting stacking, swipe-to-dismiss, close buttons, and custom icons for different notification types. [[1]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R45-R46) [[2]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661L358-R382)
* Changelog entries have been updated to reflect the new notification look, image upload fixes, and improved publishing reliability.