### PR TITLE
feat(chat+openpods): 3Speak Chat + background auth for all logins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@mantequilla-soft/3speak-player": "^0.3.2",
         "@rajesh896/video-thumbnails-generator": "^2.3.9",
         "@reduxjs/toolkit": "^2.6.1",
+        "@snapie/chat-client": "^0.1.0",
         "@snapie/hangouts-core": "^0.6.3",
         "@snapie/hangouts-react": "^0.8.8",
         "@snapie/renderer": "^0.1.1",
@@ -4720,6 +4721,23 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@snapie/chat-client": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@snapie/chat-client/-/chat-client-0.1.0.tgz",
+      "integrity": "sha512-/CvrFdzjR+GMP3Jk7DySm0L+FxP7+zRKsM0E97nJsvtQtispGN/RxIdF6OyTHC/OYFeo6QdA8YecjEwd7lIUeQ==",
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@snapie/hangouts-core": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@mantequilla-soft/3speak-player": "^0.3.2",
     "@rajesh896/video-thumbnails-generator": "^2.3.9",
     "@reduxjs/toolkit": "^2.6.1",
+    "@snapie/chat-client": "^0.1.0",
     "@snapie/hangouts-core": "^0.6.3",
     "@snapie/hangouts-react": "^0.8.8",
     "@snapie/renderer": "^0.1.1",

--- a/server/index.cjs
+++ b/server/index.cjs
@@ -396,6 +396,109 @@ app.post('/api/broadcast', broadcastLimiter, async (req, res) => {
   }
 })
 
+// ---------------------------------------------------------------------------
+// Delegated challenge signing for OpenPods (Hangouts) and Snapie chat.
+//
+// These endpoints sign a login *challenge* with @threespeak's posting key on the
+// user's behalf, so EVERY login type — including HiveSigner / ManteAuth that
+// can't sign client-side — authenticates without a wallet popup. The downstream
+// service (Hangouts /auth/verify, Snapie chat /auth/verify) accepts the
+// signature because the user granted @threespeak posting authority. This mirrors
+// how /api/broadcast already acts for users on 3speak.
+//
+// SECURITY — these are signing oracles for @threespeak's posting key, so:
+//   • username is resolved from a server-side credential where possible
+//     (ManteAuth cookie / verified HiveSigner token). Wallet logins
+//     (Keychain/HiveAuth/PeakVault/Ledger) have no server credential, so they
+//     use the public app key + claimed username — the SAME trust model as
+//     /api/broadcast (worst case: act as a user who opted into @threespeak).
+//   • each endpoint validates the challenge shape so the signed bytes can never
+//     be a serialized Hive transaction (no on-chain replay as @threespeak).
+//   • the user must currently grant @threespeak posting authority.
+// ---------------------------------------------------------------------------
+
+// Resolve the acting Hive user from cookie → HiveSigner token → app-key+username.
+async function resolveDelegatedSignUser(req, res) {
+  const cookieToken = req.cookies?.[SESSION_COOKIE_NAME]
+  if (cookieToken) {
+    const tokenData = await verifyManteAuthToken(cookieToken)
+    if (tokenData?.hiveUsername) return tokenData.hiveUsername.toLowerCase()
+    clearSessionCookie(res)
+  }
+  const authHeader = req.headers.authorization || ''
+  const bearer = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : ''
+  if (bearer) {
+    const u = await verifyHiveSignerToken(bearer)
+    if (u) return u.toLowerCase()
+  }
+  // Wallet logins: trust the public app key + claimed username (same as broadcast).
+  const apiKey = req.headers['x-api-key'] || ''
+  if (EMBED_API_KEY && apiKey === EMBED_API_KEY) {
+    const claimed = typeof req.body?.username === 'string' ? req.body.username.trim().toLowerCase() : ''
+    if (claimed) return claimed
+  }
+  return null
+}
+
+// True when `hiveUsername` granted @threespeak posting authority at/above threshold.
+async function hasThreespeakPostingGrant(hiveUsername) {
+  const [account] = await client.database.getAccounts([hiveUsername])
+  if (!account) return false
+  const grant = account.posting.account_auths.find(([acc]) => acc === HIVE_ACCOUNT)
+  return !!grant && grant[1] >= account.posting.weight_threshold
+}
+
+const signChallengeLimiter = rateLimit({ windowMs: 60 * 1000, max: 60, standardHeaders: true, legacyHeaders: false })
+
+// POST /api/openpods/sign-challenge — challenge shape: `hivehangouts:<user>:<ts>:<hex>`
+app.post('/api/openpods/sign-challenge', signChallengeLimiter, async (req, res) => {
+  try {
+    if (!POSTING_WIF) return res.status(500).json({ error: 'Server is not configured' })
+    const hiveUsername = await resolveDelegatedSignUser(req, res)
+    if (!hiveUsername) return res.status(401).json({ error: 'Unauthorized' })
+
+    const challenge = typeof req.body?.challenge === 'string' ? req.body.challenge : ''
+    const escapedUser = hiveUsername.replace(/[.\-]/g, '\\$&')
+    if (!new RegExp(`^hivehangouts:${escapedUser}:\\d+:[0-9a-f]+$`).test(challenge)) {
+      return res.status(400).json({ error: 'Invalid challenge' })
+    }
+    if (!(await hasThreespeakPostingGrant(hiveUsername))) {
+      return res.status(403).json({ error: 'Authorization required' })
+    }
+
+    const signature = PrivateKey.fromString(POSTING_WIF).sign(cryptoUtils.sha256(challenge)).toString()
+    return res.json({ success: true, signature, username: hiveUsername })
+  } catch (err) {
+    console.error('OpenPods sign-challenge error:', err.message)
+    res.status(500).json({ error: 'Signing failed' })
+  }
+})
+
+// POST /api/snapie-chat/sign-challenge — Snapie chat challenges are bare UUIDv4s.
+// Validating the UUID shape keeps this from signing arbitrary bytes (no tx replay).
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+app.post('/api/snapie-chat/sign-challenge', signChallengeLimiter, async (req, res) => {
+  try {
+    if (!POSTING_WIF) return res.status(500).json({ error: 'Server is not configured' })
+    const hiveUsername = await resolveDelegatedSignUser(req, res)
+    if (!hiveUsername) return res.status(401).json({ error: 'Unauthorized' })
+
+    const challenge = typeof req.body?.challenge === 'string' ? req.body.challenge.trim() : ''
+    if (!UUID_RE.test(challenge)) {
+      return res.status(400).json({ error: 'Invalid challenge' })
+    }
+    if (!(await hasThreespeakPostingGrant(hiveUsername))) {
+      return res.status(403).json({ error: 'Authorization required' })
+    }
+
+    const signature = PrivateKey.fromString(POSTING_WIF).sign(cryptoUtils.sha256(challenge)).toString()
+    return res.json({ success: true, signature, username: hiveUsername })
+  } catch (err) {
+    console.error('Snapie-chat sign-challenge error:', err.message)
+    res.status(500).json({ error: 'Signing failed' })
+  }
+})
+
 // Image upload — sign the standard images.hive.blog "ImageSigningChallenge" with
 // @threespeak's posting key and upload on the user's behalf. Lets every login
 // (incl. HiveSigner, which can't sign client-side) attach covers/thumbnails with

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -78,6 +78,8 @@ import { LegacyUploadProvider } from "./context/LegacyUploadContext";
 import { EmbedUploadProvider } from "./context/EmbedUploadContext";
 import { HiveAuthProvider } from "./context/HiveAuthContext";
 import { HangoutContextProvider, useHangout } from "./context/HangoutContext";
+import { ChatProvider } from "./context/ChatContext";
+import ChatPage from "./components/Chat/ChatPage";
 import OpenPods from "./page/OpenPods";
 import OpenPodPublish from "./page/OpenPodPublish";
 
@@ -404,6 +406,7 @@ function App() {
     <HiveAuthProvider>
     <LegacyUploadProvider>
     <EmbedUploadProvider>
+    <ChatProvider>
     <div onClick={()=> {setGlobalCloseRender(true)}}>
       <Toaster
         position="top-right"
@@ -495,6 +498,7 @@ function App() {
             <Route path="/openpods" element={<OpenPods />} />
             <Route path="/openpods/publish" element={<OpenPodPublish />} />
             <Route path="/openpods/:roomName" element={<OpenPods />} />
+            <Route path="/chat" element={<ChatPage />} />
             <Route path="*" element={<HiveLinkRedirect />} />
           </Routes>
           <OpenPodModalMounter />
@@ -531,6 +535,7 @@ function App() {
       </div>
     </div>
 
+    </ChatProvider>
     </EmbedUploadProvider>
     </LegacyUploadProvider>
     </HiveAuthProvider>

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.12.0',
+    date: '2026-06-13',
+    summary:
+      'New 3Speak Chat: message any Hive user with direct messages, and join channels, from the new chat icon in the top bar (or the /chat page). It connects on its own — no extra signature popup. And hosting OpenPods rooms now works no matter how you logged in (HiveSigner, Keychain, HiveAuth, PeakVault or Ledger).',
+  },
+  {
     version: '1.11.1',
     date: '2026-06-12',
     summary:

--- a/src/components/Chat/ChatButton.jsx
+++ b/src/components/Chat/ChatButton.jsx
@@ -1,0 +1,33 @@
+import { NavLink } from 'react-router-dom'
+import { MessageCircle } from 'lucide-react'
+import { useUnreadCount } from '@snapie/chat-client/react'
+import { useChat } from '../../context/ChatContext'
+
+// Split out so the unread subscription only mounts once chat is connected —
+// the SDK hook keys its subscription on the client, not on auth state, so we
+// remount it (via conditional render) when `ready` flips.
+function UnreadDot() {
+  const { unreadCount } = useUnreadCount()
+  if (!unreadCount) return null
+  return (
+    <span className="chat-nav-badge" aria-hidden="true">
+      {unreadCount > 9 ? '9+' : unreadCount}
+    </span>
+  )
+}
+
+export default function ChatButton() {
+  const { ready } = useChat()
+
+  return (
+    <NavLink
+      to="/chat"
+      className={({ isActive }) => `chat-nav-btn${isActive ? ' open' : ''}`}
+      aria-label="Chat"
+      title="Chat"
+    >
+      <MessageCircle size={21} />
+      {ready && <UnreadDot />}
+    </NavLink>
+  )
+}

--- a/src/components/Chat/ChatPage.jsx
+++ b/src/components/Chat/ChatPage.jsx
@@ -1,0 +1,292 @@
+import { useState, useRef, useEffect } from 'react'
+import { ArrowLeft, Send, MessageCirclePlus, Loader2 } from 'lucide-react'
+import {
+  useConversations,
+  useChatMessages,
+  useTyping,
+} from '@snapie/chat-client/react'
+import { toast } from 'sonner'
+import { useChat } from '../../context/ChatContext'
+import { useAppStore } from '../../lib/store'
+import './chat.scss'
+
+const avatar = (name) => `https://images.hive.blog/u/${name}/avatar/small`
+
+function convTitle(conv) {
+  if (!conv) return ''
+  if (conv.type === 'dm') return conv.peer || conv.name
+  return conv.name
+}
+
+/** Shown when the client isn't authenticated to the Snapie chat backend yet. */
+function ConnectGate() {
+  const { connect, connecting, error, canConnect } = useChat()
+  return (
+    <div className="chat-gate">
+      <div className="chat-gate-icon">
+        <MessageCirclePlus size={44} />
+      </div>
+      <h3>Connect to 3Speak Chat</h3>
+      <p>
+        Chat is powered by Snapie. Connecting signs a one-time login challenge
+        with your Hive posting key — no transaction, no cost.
+      </p>
+      {error && <p className="chat-gate-error">{error}</p>}
+      <button
+        type="button"
+        className="chat-btn-primary"
+        onClick={connect}
+        disabled={connecting || !canConnect}
+      >
+        {connecting ? (
+          <>
+            <Loader2 size={16} className="chat-spin" /> Connecting…
+          </>
+        ) : (
+          'Connect chat'
+        )}
+      </button>
+      {!canConnect && (
+        <p className="chat-gate-hint">
+          Your current login can’t sign the chat challenge. Use Keychain,
+          HiveAuth, PeakVault or Ledger.
+        </p>
+      )}
+    </div>
+  )
+}
+
+function NewDmForm() {
+  const { openDmWith } = useChat()
+  const [value, setValue] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  const submit = async (e) => {
+    e.preventDefault()
+    const handle = value.trim().replace(/^@/, '')
+    if (!handle || busy) return
+    setBusy(true)
+    try {
+      await openDmWith(handle)
+      setValue('')
+    } catch (err) {
+      toast.error(err?.message || 'Could not open that conversation.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <form className="chat-newdm" onSubmit={submit}>
+      <span className="chat-newdm-at">@</span>
+      <input
+        type="text"
+        placeholder="Message a Hive user…"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        spellCheck={false}
+        autoCapitalize="none"
+      />
+      <button type="submit" disabled={!value.trim() || busy} aria-label="Start chat">
+        {busy ? <Loader2 size={16} className="chat-spin" /> : <Send size={16} />}
+      </button>
+    </form>
+  )
+}
+
+function ConversationList() {
+  const { conversations, loading } = useConversations()
+  const { openConversation, activeConversation } = useChat()
+
+  return (
+    <div className="chat-list">
+      <NewDmForm />
+      {loading && conversations.length === 0 && (
+        <div className="chat-empty">Loading conversations…</div>
+      )}
+      {!loading && conversations.length === 0 && (
+        <div className="chat-empty">
+          No conversations yet. Start one above by entering a Hive username.
+        </div>
+      )}
+      <ul className="chat-conv-ul">
+        {conversations.map((conv) => {
+          const title = convTitle(conv)
+          const isDm = conv.type === 'dm'
+          const active = activeConversation?._id === conv._id
+          return (
+            <li
+              key={conv._id}
+              className={`chat-conv-row${conv.unread ? ' unread' : ''}${active ? ' active' : ''}`}
+              onClick={() => openConversation(conv)}
+            >
+              <img
+                className="chat-conv-avatar"
+                src={isDm ? avatar(title) : avatar(conv.owner || 'spknetwork')}
+                alt=""
+                onError={(e) => {
+                  e.currentTarget.style.visibility = 'hidden'
+                }}
+              />
+              <div className="chat-conv-meta">
+                <div className="chat-conv-name">
+                  {isDm ? `@${title}` : `# ${title}`}
+                </div>
+                {conv.lastMessage && (
+                  <div className="chat-conv-last">
+                    {conv.lastMessage.sender
+                      ? `${conv.lastMessage.sender}: `
+                      : ''}
+                    {conv.lastMessage.content}
+                  </div>
+                )}
+              </div>
+              {conv.unread && <span className="chat-conv-dot" />}
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
+function Thread({ conv }) {
+  const me = useAppStore((s) => s.user)
+  const { backToList } = useChat()
+  const { messages, loading, error, sendMessage } = useChatMessages(
+    conv._id,
+    conv.type
+  )
+  const { typingUsers, setTyping } = useTyping(conv._id)
+  const [draft, setDraft] = useState('')
+  const scrollRef = useRef(null)
+
+  // Auto-scroll to the newest message.
+  useEffect(() => {
+    const el = scrollRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [messages.length, typingUsers.length])
+
+  const submit = async (e) => {
+    e.preventDefault()
+    const content = draft.trim()
+    if (!content) return
+    setDraft('')
+    setTyping(false)
+    await sendMessage(content)
+  }
+
+  const others = typingUsers.filter((u) => u !== me)
+  const isDm = conv.type === 'dm'
+  const title = convTitle(conv)
+
+  return (
+    <div className="chat-thread">
+      <header className="chat-thread-header">
+        <button
+          type="button"
+          className="chat-icon-btn chat-thread-back"
+          onClick={backToList}
+          aria-label="Back to conversations"
+        >
+          <ArrowLeft size={20} />
+        </button>
+        <img className="chat-thread-avatar" src={avatar(isDm ? title : conv.owner || 'spknetwork')} alt="" />
+        <span className="chat-thread-title">{isDm ? `@${title}` : `# ${title}`}</span>
+      </header>
+
+      <div className="chat-messages" ref={scrollRef}>
+        {loading && <div className="chat-empty">Loading messages…</div>}
+        {error && <div className="chat-gate-error">{error}</div>}
+        {!loading && messages.length === 0 && (
+          <div className="chat-empty">No messages yet — say hi 👋</div>
+        )}
+        {messages.map((m) => {
+          const mine = m.sender === me
+          return (
+            <div key={m._id} className={`chat-msg${mine ? ' mine' : ''}`}>
+              {!mine && conv.type !== 'dm' && (
+                <span className="chat-msg-sender">@{m.sender}</span>
+              )}
+              <div className="chat-msg-bubble">{m.content}</div>
+            </div>
+          )
+        })}
+        {others.length > 0 && (
+          <div className="chat-typing">
+            {others.join(', ')} {others.length === 1 ? 'is' : 'are'} typing…
+          </div>
+        )}
+      </div>
+
+      <form className="chat-composer" onSubmit={submit}>
+        <input
+          type="text"
+          placeholder="Type a message…"
+          value={draft}
+          onChange={(e) => {
+            setDraft(e.target.value)
+            setTyping(e.target.value.length > 0)
+          }}
+        />
+        <button type="submit" disabled={!draft.trim()} aria-label="Send">
+          <Send size={18} />
+        </button>
+      </form>
+    </div>
+  )
+}
+
+export default function ChatPage() {
+  const { ready, connecting, activeConversation } = useChat()
+  const authenticated = useAppStore((s) => s.authenticated)
+
+  if (!authenticated) {
+    return (
+      <div className="chat-page">
+        <div className="chat-gate">
+          <div className="chat-gate-icon">
+            <MessageCirclePlus size={44} />
+          </div>
+          <h3>Log in to use chat</h3>
+          <p>Sign in with your Hive account to send and receive messages.</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!ready) {
+    // While the silent background connect runs, show a spinner rather than the
+    // gate — the gate only appears if auto-connect couldn't establish a session.
+    return (
+      <div className="chat-page">
+        {connecting ? (
+          <div className="chat-gate">
+            <Loader2 size={40} className="chat-spin" />
+            <p>Connecting to chat…</p>
+          </div>
+        ) : (
+          <ConnectGate />
+        )}
+      </div>
+    )
+  }
+
+  // `has-active` drives the mobile single-pane swap (list vs thread).
+  return (
+    <div className={`chat-page two-pane${activeConversation ? ' has-active' : ''}`}>
+      <div className="chat-page-sidebar">
+        <ConversationList />
+      </div>
+      <div className="chat-page-main">
+        {activeConversation ? (
+          <Thread conv={activeConversation} />
+        ) : (
+          <div className="chat-empty chat-page-placeholder">
+            Select a conversation, or start a new one.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/Chat/chat.scss
+++ b/src/components/Chat/chat.scss
@@ -1,0 +1,301 @@
+// 3Speak Chat (Snapie @snapie/chat-client) — slide-over panel + nav button.
+@use "../../mixins.scss" as mix;
+
+$chat-width: 380px;
+$chat-z: 1200;
+
+/* ---- Nav button + unread badge ---- */
+.chat-nav-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--text-primary);
+  padding: 4px;
+  border-radius: 8px;
+  transition: background 0.15s ease, color 0.15s ease;
+
+  &:hover { background: var(--bg-hover); }
+  &.open { color: var(--accent-primary); }
+
+  .chat-nav-badge {
+    position: absolute;
+    top: -2px;
+    right: -2px;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 4px;
+    border-radius: 8px;
+    background: var(--accent-primary);
+    color: #fff;
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 16px;
+    text-align: center;
+  }
+}
+
+/* ---- Page layout ---- */
+// Fits the area under the sticky nav, inside `.container` (which adds ~20px top
+// + 20px bottom padding). --nav-height is set globally from JS.
+.chat-page {
+  height: calc(100vh - var(--nav-height, 60px) - 40px);
+  display: flex;
+  background: var(--bg-secondary);
+  overflow: hidden;
+
+  // Tablet/phone also have a fixed 56px BottomNav at the bottom — subtract it
+  // (and use dvh for the mobile URL-bar) so the composer stays above it.
+  @include mix.respond(tab) {
+    height: calc(100dvh - var(--nav-height, 60px) - var(--bottom-nav-height, 56px) - 24px);
+  }
+  @include mix.respond(phone) {
+    height: calc(100dvh - var(--nav-height, 60px) - var(--bottom-nav-height, 56px) - 16px);
+  }
+}
+
+.chat-page.two-pane {
+  .chat-page-sidebar {
+    width: $chat-width;
+    flex: 0 0 $chat-width;
+    border-right: 1px solid var(--border-light);
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+  .chat-page-main {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  // Mobile: one pane at a time — list, or thread once a conversation is open.
+  @include mix.respond(phone) {
+    .chat-page-sidebar { width: 100%; flex: 1 1 auto; border-right: none; }
+    .chat-page-main { display: none; }
+    &.has-active {
+      .chat-page-sidebar { display: none; }
+      .chat-page-main { display: flex; }
+    }
+  }
+}
+
+.chat-page-placeholder {
+  margin: auto;
+  max-width: 260px;
+}
+
+// The back button only matters on mobile single-pane.
+.chat-thread-back { display: none; }
+@include mix.respond(phone) {
+  .chat-thread-back { display: inline-flex; }
+}
+
+.chat-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  border-radius: 8px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  &:hover { background: var(--bg-hover); color: var(--text-primary); }
+}
+
+.chat-thread-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-light);
+  flex: 0 0 auto;
+
+  .chat-thread-avatar { width: 30px; height: 30px; border-radius: 50%; object-fit: cover; background: var(--bg-tertiary); }
+  .chat-thread-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+/* ---- Connect gate ---- */
+.chat-gate {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 32px 28px;
+  gap: 10px;
+
+  .chat-gate-icon { color: var(--accent-primary); }
+  h3 { margin: 4px 0 0; color: var(--text-primary); font-size: 18px; }
+  p { margin: 0; color: var(--text-secondary); font-size: 13.5px; line-height: 1.5; }
+  .chat-gate-error { color: var(--accent-primary); font-weight: 500; }
+  .chat-gate-hint { font-size: 12px; color: var(--text-muted); }
+}
+
+.chat-btn-primary {
+  margin-top: 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--accent-primary);
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 10px 20px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease;
+  &:hover:not(:disabled) { background: var(--accent-hover); }
+  &:disabled { opacity: 0.6; cursor: not-allowed; }
+}
+
+/* ---- Conversation list ---- */
+.chat-list { display: flex; flex-direction: column; min-height: 0; flex: 1; }
+
+.chat-newdm {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-light);
+
+  .chat-newdm-at { color: var(--text-muted); font-weight: 600; }
+  input {
+    flex: 1;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-light);
+    border-radius: 8px;
+    padding: 8px 10px;
+    color: var(--text-primary);
+    font-size: 13.5px;
+    outline: none;
+    &:focus { border-color: var(--accent-primary); }
+  }
+  button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    border: none;
+    border-radius: 8px;
+    background: var(--accent-primary);
+    color: #fff;
+    cursor: pointer;
+    &:disabled { opacity: 0.5; cursor: not-allowed; }
+  }
+}
+
+.chat-conv-ul { list-style: none; margin: 0; padding: 0; overflow-y: auto; flex: 1; }
+
+.chat-conv-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border-light);
+  transition: background 0.12s ease;
+  &:hover { background: var(--bg-hover); }
+  &.active { background: var(--bg-hover); }
+  &.unread .chat-conv-name { font-weight: 700; }
+
+  .chat-conv-avatar { width: 38px; height: 38px; border-radius: 50%; object-fit: cover; flex: 0 0 auto; background: var(--bg-tertiary); }
+  .chat-conv-meta { min-width: 0; flex: 1; }
+  .chat-conv-name { color: var(--text-primary); font-size: 14px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .chat-conv-last { color: var(--text-secondary); font-size: 12.5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .chat-conv-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent-primary); flex: 0 0 auto; }
+}
+
+.chat-empty { padding: 24px 20px; text-align: center; color: var(--text-muted); font-size: 13px; line-height: 1.5; }
+
+/* ---- Thread ---- */
+.chat-thread { display: flex; flex-direction: column; min-height: 0; flex: 1; }
+
+.chat-messages {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 14px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.chat-msg {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  max-width: 80%;
+
+  &.mine { align-self: flex-end; align-items: flex-end; }
+
+  .chat-msg-sender { font-size: 11px; color: var(--text-muted); margin: 0 0 2px 4px; }
+  .chat-msg-bubble {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    padding: 8px 12px;
+    border-radius: 14px;
+    font-size: 14px;
+    line-height: 1.4;
+    word-break: break-word;
+    white-space: pre-wrap;
+  }
+  &.mine .chat-msg-bubble { background: var(--accent-primary); color: #fff; }
+}
+
+.chat-typing { font-size: 12px; color: var(--text-muted); font-style: italic; padding: 2px 4px; }
+
+.chat-composer {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  // A little breathing room at the bottom (+ iOS safe-area).
+  padding: 10px 12px calc(16px + env(safe-area-inset-bottom, 0px));
+  border-top: 1px solid var(--border-light);
+
+  input {
+    flex: 1;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-light);
+    border-radius: 20px;
+    padding: 10px 14px;
+    color: var(--text-primary);
+    font-size: 14px;
+    outline: none;
+    &:focus { border-color: var(--accent-primary); }
+  }
+  button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border: none;
+    border-radius: 50%;
+    background: var(--accent-primary);
+    color: #fff;
+    cursor: pointer;
+    flex: 0 0 auto;
+    &:disabled { opacity: 0.5; cursor: not-allowed; }
+  }
+}
+
+.chat-spin { animation: chat-spin 0.8s linear infinite; }
+@keyframes chat-spin { to { transform: rotate(360deg); } }

--- a/src/components/OpenPod/OpenPodModal.jsx
+++ b/src/components/OpenPod/OpenPodModal.jsx
@@ -6,7 +6,9 @@ import { getCreatorSettings, isUploadBlocked } from '../../utils/creatorSettings
 import { useSupportBlock } from '../../lib/supportBlockStore';
 import './OpenPodModal.scss';
 
-const API_URL = import.meta.env.VITE_HANGOUTS_API_URL;
+// Strip any trailing slash — useHangoutsRoom builds `${apiBaseUrl}/rooms` with a
+// raw fetch, so a trailing slash yields `//rooms` and a 404 from the API.
+const API_URL = (import.meta.env.VITE_HANGOUTS_API_URL || '').replace(/\/$/, '');
 const LK_URL  = import.meta.env.VITE_LIVEKIT_URL || 'wss://livekit.3speak.tv';
 const IMAGE_KEY = import.meta.env.VITE_IMAGE_SERVER_API_KEY;
 

--- a/src/components/nav/Nav.jsx
+++ b/src/components/nav/Nav.jsx
@@ -15,6 +15,7 @@ import { useMyPlaylists } from "../../hooks/useMyPlaylists";
 import ShortsIcon from "../icons/ShortsIcon";
 import UploadLinks from "../UploadLinks";
 import NotificationBell from "./NotificationBell";
+import ChatButton from "../Chat/ChatButton";
 import PremiumBadge from "../PremiumBadge/PremiumBadge";
 import { FiSettings, FiLogIn } from "react-icons/fi";
 import SettingsModal from "../SettingsModal/SettingsModal";
@@ -213,6 +214,7 @@ function Nav({ setSideBar, toggleProfileNav, openLoginModal }) {
           <Link to="/discover" className="nav-mobile-discover" title="Discover">
             <MdOutlineSearch size={19} />
           </Link>
+          <ChatButton />
           <NotificationBell />
           <span className="nav-avatar-wrap" onClick={toggleProfileNav}>
             <img src={`https://images.hive.blog/u/${user}/avatar`} alt="" />

--- a/src/context/ChatContext.jsx
+++ b/src/context/ChatContext.jsx
@@ -1,0 +1,150 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  useRef,
+} from 'react'
+import { ChatProvider as SdkChatProvider } from '@snapie/chat-client/react'
+import { useAppStore } from '../lib/store'
+import {
+  getChatClient,
+  authenticateChat,
+  canSignChatChallenge,
+} from '../lib/snapieChat'
+
+const ChatUIContext = createContext(null)
+
+export function useChat() {
+  const ctx = useContext(ChatUIContext)
+  if (!ctx) throw new Error('useChat must be used inside <ChatProvider>')
+  return ctx
+}
+
+export function ChatProvider({ children }) {
+  const client = useMemo(() => getChatClient(), [])
+  const user = useAppStore((s) => s.user)
+  const authenticated = useAppStore((s) => s.authenticated)
+
+  // `ready` = the SDK client holds a valid token for the current Hive user.
+  const [ready, setReady] = useState(
+    () => client.isAuthenticated() && client.getUsername() === user
+  )
+  const [connecting, setConnecting] = useState(false)
+  const [error, setError] = useState(null)
+
+  // The conversation currently open in the thread view (null = list view).
+  const [activeConversation, setActiveConversation] = useState(null)
+
+  // Username we've already auto-attempted, so the silent background connect
+  // fires once per login (not on every render).
+  const autoTriedRef = useRef(null)
+
+  // Core auth runner. `allowClientFallback` decides whether a failed background
+  // (@threespeak) sign may fall back to a wallet signature (which can pop a
+  // dialog) — true for the manual "Connect" button, false for auto-connect.
+  const runAuthenticate = useCallback(async (uname, { allowClientFallback }) => {
+    setConnecting(true)
+    if (allowClientFallback) setError(null)
+    try {
+      await authenticateChat(uname, { allowClientFallback })
+      setReady(true)
+      return true
+    } catch (e) {
+      // Silent auto attempts don't surface an error (expected when the user
+      // hasn't granted @threespeak and can't sign client-side).
+      if (allowClientFallback) setError(e?.message || 'Could not connect to chat.')
+      setReady(false)
+      return false
+    } finally {
+      setConnecting(false)
+    }
+  }, [])
+
+  // Keep chat auth in sync with login state, and auto-connect silently (no
+  // wallet popup) the first time we see a logged-in user without a token.
+  useEffect(() => {
+    const loggedInAs = authenticated ? user : null
+    if (!loggedInAs) {
+      if (client.isAuthenticated()) client.logout()
+      setReady(false)
+      setError(null)
+      setActiveConversation(null)
+      autoTriedRef.current = null
+      return
+    }
+    if (client.isAuthenticated() && client.getUsername() === loggedInAs) {
+      setReady(true)
+      return
+    }
+    // No token for this user (or a stale one) — drop it and try a silent
+    // background @threespeak connect once.
+    if (client.isAuthenticated()) client.logout()
+    setReady(false)
+    setActiveConversation(null)
+    if (autoTriedRef.current !== loggedInAs) {
+      autoTriedRef.current = loggedInAs
+      runAuthenticate(loggedInAs, { allowClientFallback: false })
+    }
+  }, [client, user, authenticated, runAuthenticate])
+
+  // Manual connect (from the fallback gate): may use a wallet signature.
+  const connect = useCallback(async () => {
+    if (!authenticated || !user) {
+      setError('Log in first to use chat.')
+      return false
+    }
+    return runAuthenticate(user, { allowClientFallback: true })
+  }, [authenticated, user, runAuthenticate])
+
+  const openConversation = useCallback((conv) => {
+    setActiveConversation(conv)
+  }, [])
+  const backToList = useCallback(() => setActiveConversation(null), [])
+
+  // Open (or resume) a DM with a Hive user and switch to its thread.
+  const openDmWith = useCallback(
+    async (targetUser) => {
+      const handle = String(targetUser || '').trim().replace(/^@/, '').toLowerCase()
+      if (!handle) return
+      const conv = await client.openDm(handle)
+      setActiveConversation(conv)
+      return conv
+    },
+    [client]
+  )
+
+  const value = useMemo(
+    () => ({
+      client,
+      ready,
+      connecting,
+      error,
+      canConnect: canSignChatChallenge(),
+      connect,
+      activeConversation,
+      openConversation,
+      backToList,
+      openDmWith,
+    }),
+    [
+      client,
+      ready,
+      connecting,
+      error,
+      connect,
+      activeConversation,
+      openConversation,
+      backToList,
+      openDmWith,
+    ]
+  )
+
+  return (
+    <ChatUIContext.Provider value={value}>
+      <SdkChatProvider client={client}>{children}</SdkChatProvider>
+    </ChatUIContext.Provider>
+  )
+}

--- a/src/context/HangoutContext.jsx
+++ b/src/context/HangoutContext.jsx
@@ -1,8 +1,9 @@
 import { createContext, useContext, useState, useEffect, useRef, useCallback } from 'react';
-import { HangoutsApiClient, loginWithAioha } from '@snapie/hangouts-core';
+import { HangoutsApiClient, loginWithAioha, loginWithSignFn } from '@snapie/hangouts-core';
 import { Providers } from '@aioha/aioha';
 import { useAppStore } from '../lib/store';
-import aioha from '../hive-api/aioha';
+import aioha, { isManteAuthLogin } from '../hive-api/aioha';
+import { EMBED_API_KEY } from '../utils/config';
 
 const HangoutContext = createContext(undefined);
 
@@ -56,6 +57,53 @@ function buildTokenStorage(mode) {
 
 const HANGOUTS_API_URL = import.meta.env.VITE_HANGOUTS_API_URL || '';
 const OPENPODS_ENABLED = !!HANGOUTS_API_URL;
+
+// preview-3speak's own backend (broadcast/manteauth). Same base aioha.js uses.
+const THREESPEAK_API = import.meta.env.VITE_THREESPEAK_API || '/api';
+
+// True when the current login can sign a challenge message client-side.
+// Wallet providers (Keychain/HiveAuth/PeakVault/Ledger) can; HiveSigner can't
+// sign arbitrary buffers, and ManteAuth/ButrAuth holds no client-side key.
+function canSignClientSide() {
+  if (isManteAuthLogin()) return false;
+  const provider = aioha.getCurrentProvider?.() ?? null;
+  return !!provider && provider !== Providers.HiveSigner;
+}
+
+// Sign a Hangouts challenge via @threespeak (delegated posting authority) so the
+// background service signs for the user — no wallet popup — for ALL login types.
+// Auth to the preview backend: HiveSigner → Bearer token; ManteAuth → httpOnly
+// cookie; wallet (Keychain/HiveAuth/PeakVault/Ledger) → public app key + claimed
+// username (same trust as /api/broadcast). The backend verifies the user granted
+// @threespeak posting auth before signing; the patched Hangouts /auth/verify
+// accepts the delegated signature. Throws on failure (e.g. authority not
+// granted) so the caller can fall back to a client-side signature.
+async function signOpenPodsChallengeViaThreespeak(challenge, username) {
+  const provider = aioha.getCurrentProvider?.() ?? null;
+  const headers = { 'Content-Type': 'application/json' };
+  const body = { challenge };
+  if (provider === Providers.HiveSigner) {
+    const token = localStorage.getItem('hivesignerToken');
+    if (!token) throw new Error('HiveSigner session expired — reconnect and try again');
+    headers.Authorization = `Bearer ${token}`;
+  } else if (!isManteAuthLogin()) {
+    // Wallet login: no server-side credential → app key + claimed username.
+    headers['X-API-Key'] = EMBED_API_KEY;
+    body.username = username;
+  }
+  // ManteAuth: httpOnly cookie travels via credentials:'include'.
+  const res = await fetch(`${THREESPEAK_API}/openpods/sign-challenge`, {
+    method: 'POST',
+    headers,
+    credentials: 'include',
+    body: JSON.stringify(body),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || !data.signature) {
+    throw new Error(data.error || 'Could not sign the OpenPods challenge');
+  }
+  return data.signature;
+}
 // No-op stub when the OpenPods API URL isn't configured, so the rest of the
 // app can mount the provider without crashing. Anything that does network is
 // guarded by `OPENPODS_ENABLED` and never reaches the stub.
@@ -109,14 +157,11 @@ export function HangoutContextProvider({ children, tokenStorage = 'none' }) {
       return cached;
     }
 
-    // No cached token, so we'd have to sign a fresh challenge. That needs a
-    // wallet provider that can actually sign a message. The app's
-    // `authenticated` flag can be true without one (a restored/stale session,
-    // or a provider like HiveSigner that can't sign messages) — in that case
-    // don't start a signature that can never complete. Bail and let the caller
-    // stay in OpenPods guest mode instead of hanging on "Waiting for wallet…".
-    const provider = aioha.getCurrentProvider?.() ?? null;
-    if (!provider || provider === Providers.HiveSigner) return null;
+    // No cached token, so we sign a fresh challenge. Per 3speak policy, ALL
+    // logins go through the background @threespeak signer first (no wallet
+    // popup). Only if that fails — e.g. the user never granted @threespeak
+    // posting authority — do wallet providers fall back to a client-side
+    // Aioha signature (the actual fallback happens at the loginPromise below).
 
     // Deduplicate: if a login is already in-flight, await it
     if (pendingLogin?.user === requestedUser) {
@@ -140,10 +185,23 @@ export function HangoutContextProvider({ children, tokenStorage = 'none' }) {
 
     setSessionLoading(true);
 
-    // Hand the already-authenticated Aioha session to the hangouts server.
-    // loginWithAioha resolves the username, fetches a challenge, and signs it
-    // with the active provider's posting key (Keychain, HiveAuth, PeakVault, …).
-    const loginPromise = loginWithAioha(hangoutsClient, aioha, requestedUser)
+    // Background @threespeak signer for every login (no wallet popup). If it
+    // fails (e.g. the user hasn't granted @threespeak posting authority) and the
+    // provider CAN sign client-side, fall back to a client-side Aioha signature.
+    const loginPromise = (async () => {
+      try {
+        return await loginWithSignFn(
+          hangoutsClient,
+          requestedUser,
+          (challenge) => signOpenPodsChallengeViaThreespeak(challenge, requestedUser),
+        );
+      } catch (bgErr) {
+        if (canSignClientSide()) {
+          return loginWithAioha(hangoutsClient, aioha, requestedUser);
+        }
+        throw bgErr;
+      }
+    })()
       .then(session => {
         const tokenUser = session.username || requestedUser;
         sessionCache.set(tokenUser, session.token);

--- a/src/lib/snapieChat.js
+++ b/src/lib/snapieChat.js
@@ -1,0 +1,125 @@
+import { ChatClient } from '@snapie/chat-client'
+import aioha, {
+  signMessageWithAioha,
+  getCurrentProvider,
+  isManteAuthLogin,
+  KeyTypes,
+  Providers,
+} from '../hive-api/aioha'
+import { EMBED_API_KEY } from '../utils/config'
+
+// preview-3speak's own backend (broadcast/manteauth/sign). Same base aioha uses.
+const THREESPEAK_API = import.meta.env.VITE_THREESPEAK_API || '/api'
+
+// The SDK talks to `{baseUrl}/api/chat/*`. The Snapie chat API does not send
+// CORS headers, so we can't hit https://snapie.io directly from the browser —
+// instead we go same-origin through a dev-server/nginx proxy. `/snapie-chat` is
+// rewritten to https://snapie.io (see vite.config.js `server.proxy`). Override
+// with VITE_SNAPIE_CHAT_BASE_URL if a different Snapie instance is wanted.
+export const SNAPIE_CHAT_BASE_URL =
+  import.meta.env.VITE_SNAPIE_CHAT_BASE_URL || '/snapie-chat'
+
+let client = null
+
+/** Lazily create the one shared ChatClient. */
+export function getChatClient() {
+  if (!client) {
+    client = new ChatClient({ baseUrl: SNAPIE_CHAT_BASE_URL })
+  }
+  return client
+}
+
+// Chat auth is a Hive posting-key *signMessage* challenge. Only providers that
+// can sign an arbitrary buffer client-side qualify. HiveSigner can't sign
+// buffers, and Butter Auth / ManteAuth sessions hold no client-side key (they
+// broadcast posting ops through @threespeak) — neither can satisfy the
+// challenge, so we surface a clear reason instead of a cryptic signing error.
+const SIGN_CAPABLE_PROVIDERS = new Set([
+  Providers.Keychain,
+  Providers.HiveAuth,
+  Providers.PeakVault,
+  Providers.Ledger,
+])
+
+export function canSignChatChallenge() {
+  if (isManteAuthLogin()) return false
+  return SIGN_CAPABLE_PROVIDERS.has(getCurrentProvider())
+}
+
+export function chatAuthUnavailableReason() {
+  if (isManteAuthLogin()) {
+    return 'Chat needs a wallet that can sign a login challenge. Butter Auth sessions can’t — log in with Keychain, HiveAuth, PeakVault or Ledger to use chat.'
+  }
+  if (getCurrentProvider() === Providers.HiveSigner) {
+    return 'HiveSigner can’t sign the chat login challenge. Log in with Keychain, HiveAuth, PeakVault or Ledger to use chat.'
+  }
+  return 'Chat requires a wallet that can sign a login challenge (Keychain, HiveAuth, PeakVault or Ledger).'
+}
+
+// Sign a chat challenge (a UUID) via @threespeak through the preview backend, so
+// the background service signs for ALL logins — no wallet popup. Backend auth:
+// HiveSigner → Bearer token; ManteAuth → httpOnly cookie; wallet → public app
+// key + claimed username (same trust as /api/broadcast). Throws on failure so
+// the caller may fall back to a client-side signature.
+async function signChatChallengeViaThreespeak(challenge, username) {
+  const provider = getCurrentProvider()
+  const headers = { 'Content-Type': 'application/json' }
+  const body = { challenge }
+  if (provider === Providers.HiveSigner) {
+    const token = localStorage.getItem('hivesignerToken')
+    if (!token) throw new Error('HiveSigner session expired — reconnect and try again')
+    headers.Authorization = `Bearer ${token}`
+  } else if (!isManteAuthLogin()) {
+    headers['X-API-Key'] = EMBED_API_KEY
+    body.username = username
+  }
+  const res = await fetch(`${THREESPEAK_API}/snapie-chat/sign-challenge`, {
+    method: 'POST',
+    headers,
+    credentials: 'include',
+    body: JSON.stringify(body),
+  })
+  const data = await res.json().catch(() => ({}))
+  if (!res.ok || !data.signature) {
+    throw new Error(data.error || 'Could not sign the chat challenge')
+  }
+  return data.signature
+}
+
+async function signChatChallengeClientSide(challenge) {
+  const res = await signMessageWithAioha(challenge, KeyTypes.Posting, 'Sign in to 3Speak Chat')
+  if (!res?.success || !res.result) {
+    throw new Error('Chat login signature was rejected.')
+  }
+  return res.result
+}
+
+/**
+ * Authenticate the shared client for `username` against the Snapie chat API.
+ * Reuses an existing valid token when one is already stored for this user.
+ *
+ * Tries the background @threespeak signer first (no wallet popup, works for
+ * every login type). If that fails — e.g. the user never granted @threespeak
+ * posting authority — and `allowClientFallback` is set and the provider can sign
+ * client-side, it falls back to a wallet signature. Returns the ChatClient;
+ * throws with a human-readable message on failure.
+ */
+export async function authenticateChat(username, { allowClientFallback = true } = {}) {
+  const c = getChatClient()
+  if (c.isAuthenticated() && c.getUsername() === username) return c
+
+  try {
+    await c.authenticate(username, (challenge) =>
+      signChatChallengeViaThreespeak(challenge, username)
+    )
+    return c
+  } catch (bgErr) {
+    if (allowClientFallback && canSignChatChallenge()) {
+      await c.authenticate(username, signChatChallengeClientSide)
+      return c
+    }
+    throw bgErr
+  }
+}
+
+export { aioha }

--- a/src/page/OpenPods.jsx
+++ b/src/page/OpenPods.jsx
@@ -17,7 +17,9 @@ import {
 import { providerSignPrompt } from '../utils/aiohaProviderUi';
 import './OpenPods.scss';
 
-const API_URL = import.meta.env.VITE_HANGOUTS_API_URL;
+// Strip any trailing slash — useHangoutsRoom builds `${apiBaseUrl}/rooms` with a
+// raw fetch, so a trailing slash yields `//rooms` and a 404 from the API.
+const API_URL = (import.meta.env.VITE_HANGOUTS_API_URL || '').replace(/\/$/, '');
 const LK_URL = import.meta.env.VITE_LIVEKIT_URL || 'wss://livekit.3speak.tv';
 const IMAGE_KEY = import.meta.env.VITE_IMAGE_SERVER_API_KEY;
 const HANGOUT_BASE_URL = 'https://3speak.tv/openpods';

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.11.1';
+export const APP_VERSION = '1.12.0';

--- a/vite.config.js
+++ b/vite.config.js
@@ -152,6 +152,13 @@ export default defineConfig({
 
   resolve: {
     alias: {
+      // Use the local @snapie/chat-client SDK source (snapie-io repo) instead of
+      // the npm package (not yet published with the current SDK), so changes
+      // there are picked up live. The /react subpath must come first.
+      '@snapie/chat-client/react':
+        '/mnt/HC_Volume_103240961/prodops/services/snapie-io/packages/chat-client/src/react/index.tsx',
+      '@snapie/chat-client':
+        '/mnt/HC_Volume_103240961/prodops/services/snapie-io/packages/chat-client/src/index.ts',
       // Ensure browser-compatible versions of Node.js modules
       crypto: "crypto-browserify",
       stream: "stream-browserify",
@@ -208,6 +215,11 @@ export default defineConfig({
 
   server: {
     allowedHosts: ["3speak.okinoko.io", "preview.3speak.tv"],
+    // Let Vite serve the local @snapie/chat-client SDK source (sibling snapie-io
+    // repo, outside the project root). '.' keeps the project root served.
+    fs: {
+      allow: ['.', '/mnt/HC_Volume_103240961/prodops/services/snapie-io/packages/chat-client'],
+    },
     proxy: {
       // Proxy upload API calls to video.3speak.tv to avoid CORS issues in dev.
       // In production, VITE_UPLOAD_URL should point directly to video.3speak.tv.
@@ -240,6 +252,21 @@ export default defineConfig({
         changeOrigin: true,
         secure: true,
         rewrite: (path) => path.replace(/^\/image-api/, ''),
+      },
+      // Snapie chat API (@snapie/chat-client). Same-origin proxy:
+      // /snapie-chat/api/chat/* -> https://prod-snapie.okinoko.io/api/chat/*.
+      // Points at LOCAL prod-snapie (which carries the delegated-verify patch so
+      // background @threespeak chat signing works); snapie.io doesn't have it yet.
+      '/snapie-chat': {
+        target: 'https://prod-snapie.okinoko.io',
+        changeOrigin: true,
+        secure: true,
+        rewrite: (path) => path.replace(/^\/snapie-chat/, ''),
+        configure: (proxy) => {
+          proxy.on('proxyReq', (proxyReq) => {
+            proxyReq.removeHeader('origin');
+          });
+        },
       },
     },
   },


### PR DESCRIPTION
Chat (new):
- /chat route + nav chat button (unread badge). Slide-in conversation list, DMs, channels, typing indicators via @snapie/chat-client.
- Auto-connects silently using the background @threespeak signer (no wallet popup); falls back to a client-side signature only when needed.
- ChatContext manages auth lifecycle; snapieChat.js wraps the SDK; same-origin /snapie-chat dev proxy to the chat backend.

OpenPods:
- HangoutContext now authenticates ALL login types via the background @threespeak signer (HiveSigner/ManteAuth + wallet), client-sign fallback — so anyone can host, not just client-signable wallets.
- Fix room creation hitting `//rooms` (404): strip trailing slash on VITE_HANGOUTS_API_URL where useHangoutsRoom builds the URL.

Backend (server/index.cjs):
- POST /api/openpods/sign-challenge and /api/snapie-chat/sign-challenge — sign the login challenge with @threespeak's posting key for delegating users (cookie/Bearer/app-key auth; challenge-shape guarded against tx replay).

Changelog + APP_VERSION bumped to 1.12.0.