### PR TITLE
 edit/delete own messages + validate new-DM handle against Hive

### DIFF
--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.15.0',
+    date: '2026-06-15',
+    summary:
+      'You can now edit or delete your own chat messages from the ⋯ menu on a message (edited ones show an “edited” mark). Starting a new chat now only accepts real Hive usernames.',
+  },
+  {
     version: '1.14.0',
     date: '2026-06-15',
     summary:

--- a/src/components/Chat/ChatPage.jsx
+++ b/src/components/Chat/ChatPage.jsx
@@ -16,6 +16,7 @@ import { parseChatLink, timeAgo } from './chatLinks'
 import { useChat } from '../../context/ChatContext'
 import { useAppStore } from '../../lib/store'
 import { EMBED_API_KEY } from '../../utils/config'
+import { getAccounts } from '../../hive-api/hiveApi'
 import './chat.scss'
 
 const avatar = (name) => `https://images.hive.blog/u/${name}/avatar/small`
@@ -157,10 +158,16 @@ function NewDmForm() {
 
   const submit = async (e) => {
     e.preventDefault()
-    const handle = value.trim().replace(/^@/, '')
+    const handle = value.trim().replace(/^@/, '').toLowerCase()
     if (!handle || busy) return
     setBusy(true)
     try {
+      // Only let users start a DM with a real Hive account.
+      const accounts = await getAccounts([handle])
+      if (!accounts || accounts.length === 0) {
+        toast.error(`@${handle} is not a Hive account.`)
+        return
+      }
       await openDmWith(handle)
       setValue('')
     } catch (err) {
@@ -250,7 +257,7 @@ function ConversationList() {
 function Thread({ conv }) {
   const me = useAppStore((s) => s.user)
   const { backToList, shareDraft, setShareDraft } = useChat()
-  const { messages, loading, error, sendMessage } = useChatMessages(
+  const { messages, loading, error, sendMessage, editMessage } = useChatMessages(
     conv._id,
     conv.type
   )
@@ -259,7 +266,9 @@ function Thread({ conv }) {
   // chats shows that chat's own unsent text and restores it on return.
   const [draft, setDraft] = useState(() => draftStore.get(conv._id) || '')
   const [menuFor, setMenuFor] = useState(null)
+  const [menuDir, setMenuDir] = useState('up')
   const [quoteTarget, setQuoteTarget] = useState(null)
+  const [editTarget, setEditTarget] = useState(null)
   const [lightboxUrl, setLightboxUrl] = useState(null)
   const [attachments, setAttachments] = useState([]) // {id, status, url, previewUrl}
 
@@ -309,6 +318,22 @@ function Thread({ conv }) {
   }, [messages.length, typingUsers.length])
 
   const send = async () => {
+    // Edit mode: save the new content over the existing message instead of
+    // sending a new one. The SDK has no real delete — "Delete" is a soft edit.
+    if (editTarget) {
+      const body = draft.trim()
+      if (!body) return
+      const target = editTarget
+      updateDraft('')
+      setEditTarget(null)
+      setTyping(false)
+      try {
+        await editMessage(target._id, body)
+      } catch (err) {
+        toast.error(err?.message || 'Could not edit the message.')
+      }
+      return
+    }
     const parts = []
     if (quoteTarget) {
       parts.push(String(quoteTarget.content || '').split('\n').map((l) => '> ' + l).join('\n'))
@@ -330,8 +355,29 @@ function Thread({ conv }) {
 
   // Quote a message — shown as a preview above the composer; prepended on send.
   const startQuote = (m) => {
+    setEditTarget(null)
     setQuoteTarget(m)
     requestAnimationFrame(() => inputRef.current?.focus())
+  }
+
+  // Edit one of your own messages — load its raw content into the composer and
+  // switch the composer into "edit" mode (send saves over the original).
+  const startEdit = (m) => {
+    setQuoteTarget(null)
+    setEditTarget(m)
+    updateDraft(m.content || '')
+    requestAnimationFrame(() => inputRef.current?.focus())
+  }
+
+  // Soft delete — the SDK has no real delete, so replace the body with a marker.
+  const deleteMessage = async (m) => {
+    if (!window.confirm('Delete this message? It will be replaced with “[deleted]”.')) return
+    if (editTarget?._id === m._id) { setEditTarget(null); updateDraft('') }
+    try {
+      await editMessage(m._id, '[deleted]')
+    } catch (err) {
+      toast.error(err?.message || 'Could not delete the message.')
+    }
   }
 
   // Forward a message: queue it (quoted, with original sender + time) and go to
@@ -342,6 +388,18 @@ function Thread({ conv }) {
     const body = String(m.content || '').split('\n').map((l) => '> ' + l).join('\n')
     setShareDraft(`${header}\n${body}`)
     backToList()
+  }
+
+  // Toggle the per-message action menu, opening it toward whichever side has
+  // more room inside the (clipping) messages scroll area so it isn't cropped.
+  const toggleMenu = (e, id) => {
+    if (menuFor === id) { setMenuFor(null); return }
+    const btn = e.currentTarget.getBoundingClientRect()
+    const cont = scrollRef.current?.getBoundingClientRect()
+    const above = cont ? btn.top - cont.top : btn.top
+    const below = cont ? cont.bottom - btn.bottom : window.innerHeight - btn.bottom
+    setMenuDir(below >= above ? 'down' : 'up')
+    setMenuFor(id)
   }
 
   // Close the per-message action menu on any outside click.
@@ -389,6 +447,7 @@ function Thread({ conv }) {
           const postLink = parseChatLink(text)
           if (postLink) text = text.split(postLink.url).join('')
           text = text.trim()
+          const isDeleted = text === '[deleted]'
           const hasBubble = !!text || images.length > 0
           const imageOnly = !text && images.length > 0
           return (
@@ -399,7 +458,7 @@ function Thread({ conv }) {
               <div className="chat-msg-row">
                 <div className="chat-msg-content">
                   {hasBubble && (
-                    <div className={`chat-msg-bubble${imageOnly ? ' image-only' : ''}`}>
+                    <div className={`chat-msg-bubble${imageOnly ? ' image-only' : ''}${isDeleted ? ' chat-msg-deleted' : ''}`}>
                       {text && renderMessageText(text)}
                       {images.map((url) => (
                         <button
@@ -416,7 +475,7 @@ function Thread({ conv }) {
                   {postLink && <ChatLinkCard link={postLink} />}
                   {m.createdAt && (
                     <span className="chat-msg-time" title={new Date(m.createdAt).toLocaleString()}>
-                      {timeAgo(m.createdAt)}
+                      {timeAgo(m.createdAt)}{m.editedAt ? ' · edited' : ''}
                     </span>
                   )}
                 </div>
@@ -425,18 +484,28 @@ function Thread({ conv }) {
                     type="button"
                     className="chat-msg-menu-btn"
                     aria-label="Message actions"
-                    onClick={(e) => { e.stopPropagation(); setMenuFor((cur) => (cur === m._id ? null : m._id)) }}
+                    onClick={(e) => { e.stopPropagation(); toggleMenu(e, m._id) }}
                   >
                     <MoreHorizontal size={15} />
                   </button>
                   {menuFor === m._id && (
-                    <div className="chat-msg-menu">
+                    <div className={`chat-msg-menu chat-msg-menu--${menuDir}`}>
                       <button type="button" onClick={(e) => { e.stopPropagation(); startQuote(m); setMenuFor(null) }}>
                         Quote
                       </button>
                       <button type="button" onClick={(e) => { e.stopPropagation(); forwardMessage(m); setMenuFor(null) }}>
                         Forward
                       </button>
+                      {mine && (
+                        <>
+                          <button type="button" onClick={(e) => { e.stopPropagation(); startEdit(m); setMenuFor(null) }}>
+                            Edit
+                          </button>
+                          <button type="button" className="chat-msg-menu-danger" onClick={(e) => { e.stopPropagation(); setMenuFor(null); deleteMessage(m) }}>
+                            Delete
+                          </button>
+                        </>
+                      )}
                     </div>
                   )}
                 </div>
@@ -452,6 +521,17 @@ function Thread({ conv }) {
       </div>
 
       <form className="chat-composer" onSubmit={submit}>
+        {editTarget && (
+          <div className="chat-quote-preview chat-edit-preview">
+            <div className="chat-quote-preview-main">
+              <span className="chat-quote-preview-label">Editing message</span>
+              <blockquote className="chat-quote chat-quote-preview-text">{quoteSnippet(editTarget.content)}</blockquote>
+            </div>
+            <button type="button" className="chat-quote-preview-close" aria-label="Cancel edit" onClick={() => { setEditTarget(null); updateDraft('') }}>
+              <X size={16} />
+            </button>
+          </div>
+        )}
         {quoteTarget && (
           <div className="chat-quote-preview">
             <div className="chat-quote-preview-main">

--- a/src/components/Chat/chat.scss
+++ b/src/components/Chat/chat.scss
@@ -643,10 +643,8 @@ $chat-z: 1200;
 
 .chat-msg-menu {
   position: absolute;
-  bottom: 100%;
   right: 0;
   z-index: 30;
-  margin-bottom: 4px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-light);
   border-radius: 10px;
@@ -666,9 +664,21 @@ $chat-z: 1200;
     font-size: 13.5px;
     color: var(--text-primary);
     &:hover { background: var(--bg-hover); }
+    &.chat-msg-menu-danger { color: #e5484d; }
   }
 }
+.chat-msg-menu--up { bottom: 100%; margin-bottom: 4px; }
+.chat-msg-menu--down { top: 100%; margin-top: 4px; }
 .chat-msg:not(.mine) .chat-msg-menu { left: 0; right: auto; }
+
+/* Soft-deleted message ("[deleted]") — muted + italic */
+.chat-msg-bubble.chat-msg-deleted {
+  font-style: italic;
+  opacity: 0.6;
+}
+
+/* Editing-a-message banner reuses the quote-preview chrome */
+.chat-edit-preview .chat-quote-preview-label { color: var(--accent-primary); }
 
 .chat-quote {
   margin: 2px 0;

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.14.0';
+export const APP_VERSION = '1.15.0';


### PR DESCRIPTION
This pull request adds the ability for users to edit or delete their own chat messages and improves the chat message action menu. It also ensures that new chats can only be started with real Hive usernames. The UI now clearly marks edited messages and visually distinguishes deleted messages. 

**Chat message editing and deletion:**
* Users can now edit or soft-delete their own messages via the ⋯ menu; edits update the message in place, while deletes replace the message with “[deleted]” and style it accordingly (`ChatPage.jsx`, `chat.scss`). [[1]](diffhunk://#diff-f0d83f0a5b8de4d2535de43f34a53f5423440339340d4622f5b5cb9195cdc007R269-R271) [[2]](diffhunk://#diff-f0d83f0a5b8de4d2535de43f34a53f5423440339340d4622f5b5cb9195cdc007R321-R336) [[3]](diffhunk://#diff-f0d83f0a5b8de4d2535de43f34a53f5423440339340d4622f5b5cb9195cdc007R358-R382) [[4]](diffhunk://#diff-f0d83f0a5b8de4d2535de43f34a53f5423440339340d4622f5b5cb9195cdc007R450) [[5]](diffhunk://#diff-f0d83f0a5b8de4d2535de43f34a53f5423440339340d4622f5b5cb9195cdc007L402-R461) [[6]](diffhunk://#diff-f0d83f0a5b8de4d2535de43f34a53f5423440339340d4622f5b5cb9195cdc007L419-R478) [[7]](diffhunk://#diff-f0d83f0a5b8de4d2535de43f34a53f5423440339340d4622f5b5cb9195cdc007L428-R508) [[8]](diffhunk://#diff-f0d83f0a5b8de4d2535de43f34a53f5423440339340d4622f5b5cb9195cdc007R524-R534) [[9]](diffhunk://#diff-20cb346e5d70081efddf46ba48a67e17e3ab518099a138fe7bd5934235dc4439R667-R682)
* Edited messages show an “· edited” indicator next to the timestamp (`ChatPage.jsx`).
* The editing UI displays a banner showing the message being edited and allows cancelling the edit (`ChatPage.jsx`, `chat.scss`). [[1]](diffhunk://#diff-f0d83f0a5b8de4d2535de43f34a53f5423440339340d4622f5b5cb9195cdc007R524-R534) [[2]](diffhunk://#diff-20cb346e5d70081efddf46ba48a67e17e3ab518099a138fe7bd5934235dc4439R667-R682)

**Chat menu and UI improvements:**
* The per-message ⋯ action menu now opens upward or downward based on available space to avoid clipping, and includes Edit and Delete options for your own messages (`ChatPage.jsx`, `chat.scss`). [[1]](diffhunk://#diff-f0d83f0a5b8de4d2535de43f34a53f5423440339340d4622f5b5cb9195cdc007R393-R404) [[2]](diffhunk://#diff-20cb346e5d70081efddf46ba48a67e17e3ab518099a138fe7bd5934235dc4439L646-L649) [[3]](diffhunk://#diff-20cb346e5d70081efddf46ba48a67e17e3ab518099a138fe7bd5934235dc4439R667-R682)
* Deleted messages are styled as muted and italic to indicate their status (`chat.scss`).

**Chat account validation:**
* Starting a new chat now checks that the target is a real Hive account and prevents DMs to non-existent users (`ChatPage.jsx`, `hiveApi`). [[1]](diffhunk://#diff-f0d83f0a5b8de4d2535de43f34a53f5423440339340d4622f5b5cb9195cdc007R19) [[2]](diffhunk://#diff-f0d83f0a5b8de4d2535de43f34a53f5423440339340d4622f5b5cb9195cdc007L160-R170)

**Changelog and version update:**
* The changelog and app version are updated to 1.15.0 to reflect these new features (`changelog.js`, `version.js`). [[1]](diffhunk://#diff-2b5b164299e9a44e90c14ae81c0182d162656fec55e07d328651882df8c9c689R9-R14) [[2]](diffhunk://#diff-c1a80fbb2e96a42cd35c5a1e7c3d22df4a225970075327f9a65ddab9510f06a8L7-R7)