### PR TITLE
fix(thumbnails): bypass hive.blog proxy for ecency-hosted thumbnails

### DIFF
--- a/src/utils/fixThumbnails.js
+++ b/src/utils/fixThumbnails.js
@@ -49,14 +49,18 @@ export function fixVideoThumbnail(video, portrait = false) {
   }
 
   // ✅ Already a SIZED Hive proxy URL (…/p/… or …/WxH/…) — already small, leave it.
-  // (Full-size CDN images on images.hive.blog / files.peakd.com / images.3speak.tv /
-  // images.ecency.com fall through to the resize proxy below instead of loading full-res.)
   if (cleanThumbnail.includes("images.hive.blog/p/") || /images\.hive\.blog\/\d+x\d+\//.test(cleanThumbnail)) {
     // For shorts, re-request the proxied image at portrait dimensions (the
     // baked-in params are landscape). The /p/<hash> form re-proxies the original.
     if (portrait && cleanThumbnail.includes("images.hive.blog/p/")) {
       return `${cleanThumbnail.split('?')[0]}?format=jpeg&mode=cover&width=${size.w}&height=${size.h}`;
     }
+    return cleanThumbnail;
+  }
+
+  // ⚠️ images.hive.blog's resize proxy 403s on ecency-hosted sources, so load
+  // ecency thumbnails directly instead of routing them through that proxy.
+  if (cleanThumbnail.includes("i.ecency.com") || cleanThumbnail.includes("images.ecency.com")) {
     return cleanThumbnail;
   }
 


### PR DESCRIPTION
## Summary
- `images.hive.blog`'s `/p/` resize proxy returns `403 Forbidden` for images sourced from `i.ecency.com` / `images.ecency.com`, so any video thumbnail hosted on ecency's CDN was rendering broken instead of showing the actual image.
- Confirmed by hand: the original ecency URL returns `200` directly, but the same URL routed through the hive.blog proxy returns `403` (tested with two different ecency-hosted images).
- Since ecency's CDN already serves the image fine on its own, `fixVideoThumbnail()` in `src/utils/fixThumbnails.js` now passes ecency URLs through directly instead of rewriting them through the hive.blog proxy.

## Test plan
- [x] Verified the original ecency image URL loads with `200 image/jpeg`
- [x] Verified the previous hive.blog proxy rewrite of that same URL returned `403`
- [x] Confirmed the updated `fixVideoThumbnail()` now returns the ecency URL unchanged for `i.ecency.com` / `images.ecency.com` sources
- [ ] Manual check in the running app: load a video/post whose thumbnail is hosted on ecency and confirm it renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)