### PR TITLE
feat(shorts): desktop scroll-wheel nav + smaller bottom-aligned actio…

### DIFF
--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.19.0',
+    date: '2026-06-17',
+    summary:
+      'Shorts on desktop: scroll with your mouse wheel to move between shorts (like the up/down arrow keys), the action buttons are smaller and sit at the bottom, and the up/down navigation arrows now stay on the far right — with the comments panel opening to their left.',
+  },
+  {
     version: '1.18.0',
     date: '2026-06-17',
     summary:

--- a/src/page/Short.jsx
+++ b/src/page/Short.jsx
@@ -1777,6 +1777,28 @@ const VideoShort = () => {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [handleNext, handlePrevious, seekTo, togglePlayPause, toggleMute, showComments, isTransitioning]);
 
+  // Desktop: the scroll wheel navigates shorts, exactly like the Up/Down arrows
+  // (scroll down = next, scroll up = previous). Attached to the video container
+  // only, so scrolling the comments side-panel still scrolls the comments.
+  // A short cooldown stops one wheel gesture from skipping several shorts.
+  useEffect(() => {
+    if (typeof window === 'undefined' || window.innerWidth <= 768) return;
+    const el = videoContainerRef.current;
+    if (!el) return;
+    let lock = false;
+    const onWheel = (e) => {
+      if (Math.abs(e.deltaY) < 8) return; // ignore tiny trackpad jitter
+      e.preventDefault();
+      if (lock || isTransitioning) return;
+      lock = true;
+      if (e.deltaY > 0) handleNext();
+      else handlePrevious();
+      setTimeout(() => { lock = false; }, 700);
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, [handleNext, handlePrevious, isTransitioning]);
+
   // Local handler for the hidden focusable element (helps capture on mobile)
   const handleKeyDownCapture = (e) => {
     const active = document.activeElement;
@@ -2824,19 +2846,22 @@ const VideoShort = () => {
           onGeneralShare={handleShare}
         />
 
-        {/* NAVIGATION */}
-        <div className="navigationArrows">
-          <button className="navButton" onClick={handlePrevious} disabled={currentIndex === 0}>
-            <ArrowUp size={24} />
-          </button>
-          <button className="navButton" onClick={handleNext} disabled={currentIndex === videos.length - 1 && !hasMore}>
-            {loading && currentIndex === videos.length - 1 ? (
-              <Loader2 size={24} className="spinner" />
-            ) : (
-              <ArrowDown size={24} />
-            )}
-          </button>
-        </div>
+      </div>
+
+      {/* NAVIGATION — kept OUTSIDE .videoWrapper so its position:fixed anchors to
+          the viewport. The wrapper gets a transform when comments open, which
+          would otherwise become the containing block and mis-place the arrows. */}
+      <div className="navigationArrows">
+        <button className="navButton" onClick={handlePrevious} disabled={currentIndex === 0}>
+          <ArrowUp size={24} />
+        </button>
+        <button className="navButton" onClick={handleNext} disabled={currentIndex === videos.length - 1 && !hasMore}>
+          {loading && currentIndex === videos.length - 1 ? (
+            <Loader2 size={24} className="spinner" />
+          ) : (
+            <ArrowDown size={24} />
+          )}
+        </button>
       </div>
 
       {/* Mobile Comments Overlay + Panel — portaled to body so it renders above nav */}

--- a/src/page/Short.scss
+++ b/src/page/Short.scss
@@ -1332,14 +1332,20 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 1.5rem;
-    padding-bottom: 0.5rem;
+    // Desktop: bottom-align the column next to the video; gap is ~50% of the
+    // (smaller) button size.
+    align-self: flex-end;
+    gap: 1rem;
+    margin-bottom: 1rem;
+    padding-bottom: 0;
 
     @media (max-width: 768px) {
       position: absolute;
       right: 0.75rem;
       bottom: 2rem;
       z-index: 50;
+      align-self: auto;
+      margin-bottom: 0;
       padding-bottom: 0;
       gap: 0.625rem;
     }
@@ -1362,6 +1368,18 @@
   .actionButton {
     width: 3rem;
     height: 3rem;
+
+    // Desktop: ~66% of the original size (icons scaled to match).
+    @media (min-width: 769px) {
+      width: 2rem;
+      height: 2rem;
+
+      svg,
+      img {
+        width: 1rem;
+        height: 1rem;
+      }
+    }
     background-color: var(--bg-tertiary);
     backdrop-filter: blur(4px);
     border-radius: 50%;
@@ -1558,10 +1576,12 @@
 
 
   .navigationArrows {
-    position: absolute;
-    right: -5rem;
+    // Pinned to the far right of the screen (not next to the centered video).
+    position: fixed;
+    right: 1.25rem;
     top: 50%;
     transform: translateY(-50%);
+    z-index: 200; // above the comments panel (150) so they stay visible
     display: flex;
     flex-direction: column;
     gap: 1rem;
@@ -1729,7 +1749,9 @@
   .commentsPanel {
     position: fixed;
     top: 0;
-    right: 0;
+    // Desktop: sit left of the far-right nav arrows so they stay visible
+    // (arrows occupy ~1.25rem–4.25rem from the right edge). Mobile resets to 0.
+    right: 5rem;
     width: 400px;
     height: 100vh;
     background-color: var(--bg-secondary);

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.18.0';
+export const APP_VERSION = '1.19.0';


### PR DESCRIPTION
…ns + far-right arrows

- Mouse wheel navigates shorts on desktop (down=next, up=prev), 700ms cooldown, video area only so comments still scroll
- Action buttons ~66% size, bottom-aligned, gap = 50% of button size (desktop)
- Up/Down nav arrows pinned far-right (moved out of the transformed videoWrapper); comments panel sits to their left, arrows kept above it
- changelog/version: 1.19.0