### PR TITLE
feat(app): prompt to refresh when a newer version is on GitHub develop

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -47,6 +47,7 @@ import AboutPage from "./components/LandingPage/AboutPage";
 import { toast, Toaster } from 'sonner'
 import { CircleCheck, CircleX, TriangleAlert, Info } from 'lucide-react'
 import './toast.css'
+import { fetchNewerVersion, reloadForUpdate } from './utils/checkLatestVersion'
 // Retired alongside the legacy /studio flow — kept here as comments for ease of
 // roll-back; the embed-studio equivalents at /embed-studio/{thumbnail,details,preview}
 // are what users hit now.
@@ -254,6 +255,29 @@ function App() {
   useEffect(() => {
     const { previousVersion, shouldPrompt } = readAppVersion();
     if (shouldPrompt) useAppStore.getState().setAppUpdatedFrom(previousVersion);
+  }, []);
+
+  // Compare the running build against the latest version on GitHub (develop) and
+  // prompt the user to refresh if they're on a stale (cached) build — so updates
+  // don't require a manual reload. Re-checks on tab focus and every 30 min.
+  useEffect(() => {
+    let shown = false;
+    const promptIfNewer = async () => {
+      if (shown) return;
+      const newer = await fetchNewerVersion();
+      if (!newer) return;
+      shown = true;
+      toast(`A new version (${newer}) is available`, {
+        description: 'Refresh to get the latest updates.',
+        duration: Infinity,
+        action: { label: 'Refresh', onClick: () => reloadForUpdate() },
+      });
+    };
+    promptIfNewer();
+    const onFocus = () => promptIfNewer();
+    window.addEventListener('focus', onFocus);
+    const id = setInterval(promptIfNewer, 30 * 60 * 1000);
+    return () => { window.removeEventListener('focus', onFocus); clearInterval(id); };
   }, []);
 
   // Persist the last visited non-login route so the app can return

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.20.0',
+    date: '2026-06-18',
+    summary:
+      '3Speak now notices when a newer version is available and shows a “Refresh” prompt, so you get the latest updates without manually reloading the page.',
+  },
+  {
     version: '1.19.0',
     date: '2026-06-17',
     summary:

--- a/src/utils/checkLatestVersion.js
+++ b/src/utils/checkLatestVersion.js
@@ -1,0 +1,66 @@
+import { APP_VERSION } from "../version";
+import { APP_VERSION_STORAGE_KEY } from "./appVersion";
+
+// The deployed site is built from the repo's `develop` branch, whose version.js
+// is the source of truth for the latest released version. We read it raw from
+// GitHub and compare it to the version baked into the running bundle, so a user
+// on a stale (cached) build can be prompted to refresh.
+const REMOTE_VERSION_URL =
+  "https://raw.githubusercontent.com/Mantequilla-Soft/new-3speak-tv/develop/src/version.js";
+
+// "export const APP_VERSION = '1.2.3';" → "1.2.3"
+function parseVersion(text) {
+  const m = String(text || "").match(/APP_VERSION\s*=\s*['"]([\d.]+)['"]/);
+  return m ? m[1] : null;
+}
+
+// true when version `a` is newer than `b` (numeric dot-separated parts).
+export function isNewerVersion(a, b) {
+  const pa = String(a).split(".").map((n) => parseInt(n, 10) || 0);
+  const pb = String(b).split(".").map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const x = pa[i] || 0;
+    const y = pb[i] || 0;
+    if (x !== y) return x > y;
+  }
+  return false;
+}
+
+// Returns the latest version string if GitHub's develop is newer than the
+// running build, otherwise null (also null on any network error / offline).
+export async function fetchNewerVersion() {
+  try {
+    const res = await fetch(`${REMOTE_VERSION_URL}?t=${Date.now()}`, { cache: "no-store" });
+    if (!res.ok) return null;
+    const remote = parseVersion(await res.text());
+
+    let stored = null;
+    try { stored = localStorage.getItem(APP_VERSION_STORAGE_KEY); } catch { /* ignore */ }
+    console.log(
+      `[version] GitHub (develop): ${remote} | browser storage: ${stored} | running build: ${APP_VERSION}`
+    );
+
+    if (remote && isNewerVersion(remote, APP_VERSION)) return remote;
+  } catch {
+    // offline / blocked — ignore, no prompt
+  }
+  return null;
+}
+
+// Drop caches + service workers and reload, so the browser fetches the new build
+// fresh instead of serving the cached (stale) one.
+export async function reloadForUpdate() {
+  try {
+    if (typeof caches !== "undefined") {
+      const keys = await caches.keys();
+      await Promise.all(keys.map((k) => caches.delete(k)));
+    }
+    if ("serviceWorker" in navigator) {
+      const regs = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(regs.map((r) => r.unregister()));
+    }
+  } catch {
+    // ignore — reload anyway
+  }
+  window.location.reload();
+}

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.19.0';
+export const APP_VERSION = '1.20.0';


### PR DESCRIPTION
Checks the develop branch's version.js (raw) against the running build on load, tab focus, and every 30 min; shows a Refresh popup when newer. Refresh clears caches + service workers so the new build loads. Logs GitHub / browser-storage / running versions to the console.
- changelog/version: 1.20.0