### PR TITLE
feat(cards): bigger 16:9 cards + size setting + hover/scroll video pr…

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,13 @@
     <link rel="icon" type="image/jpeg" href="3speak.jpeg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
+    <!-- Warm up connections to the video CDN + player API so card previews
+         (and playback) fetch their first manifest/segment without paying DNS/TLS setup. -->
+    <link rel="preconnect" href="https://hotipfs-3speak-1.b-cdn.net" crossorigin />
+    <link rel="preconnect" href="https://play.3speak.tv" crossorigin />
+    <link rel="dns-prefetch" href="https://hotipfs-3speak-1.b-cdn.net" />
+    <link rel="dns-prefetch" href="https://play.3speak.tv" />
+
     <!-- Primary Meta Tags -->
     <title>3Speak - Decentralized Video Platform</title>
     <meta name="title" content="3Speak - Decentralized Video Platform" />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -164,6 +164,13 @@ function App() {
   const location = useLocation();
   const { initializeAuth, initializeTheme, authenticated, LogOut, switchAccount, setUser, user: appUser } = useAppStore();
   const sessionExpired = useAppStore((s) => s.sessionExpired);
+  const homeCardSize = useAppStore((s) => s.homeCardSize);
+
+  // Reflect the card-size preference on <html> so the card grids (home, profile,
+  // playlists) can size themselves via CSS variables.
+  useEffect(() => {
+    document.documentElement.setAttribute('data-card-size', homeCardSize || 'large');
+  }, [homeCardSize]);
   const clearSessionExpired = useAppStore((s) => s.clearSessionExpired);
   const { aioha, user: aiohaUser } = useAioha();
   const sidebar = useAppStore((s) => s.sidebarOpen);

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,24 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.23.0',
+    date: '2026-06-19',
+    summary:
+      'On mobile, switch on Large cards to get a full-width video feed where the centred video auto-plays a muted preview as you scroll. Turn off Large cards or Video previews in Settings to disable it.',
+  },
+  {
+    version: '1.22.0',
+    date: '2026-06-19',
+    summary:
+      'Hover a video card on desktop to play a muted preview — with a draggable timeline and subtitles when available. You can switch previews off under Settings → Video previews.',
+  },
+  {
+    version: '1.21.0',
+    date: '2026-06-19',
+    summary:
+      'Video cards are bigger and now a consistent 16:9 on the home, profile and playlist pages. Prefer the old compact look? Switch from Large to Small cards in Settings → Appearance.',
+  },
+  {
     version: '1.20.0',
     date: '2026-06-18',
     summary:

--- a/src/components/Cards/Card3.jsx
+++ b/src/components/Cards/Card3.jsx
@@ -17,11 +17,16 @@ import img from "../../assets/image/speak.jpg";
 import { fixVideoThumbnail } from "../../utils/fixThumbnails";
 import AuthorBadge from "../AuthorBadge/AuthorBadge";
 import ProfileModal from "../modal/ProfileModal";
+import useHoverPreview from "../../hooks/useHoverPreview";
 
 
 function Card3({ videos = [], loading = false, error = null, getContentForVideo = null, isWatched = null, getViewCount = null, linkPrefix = '/watch', linkQuery = '', shortTimeAgo = true, shortsGrid = false, priority = false }) {
   const navigate = useNavigate();
   const [modalUser, setModalUser] = useState(null);
+
+  // Hover-to-play preview (single reused player overlay) — shared with other grids.
+  const { containerProps, getCardProps, overlay } = useHoverPreview();
+
   const formatViewCount = (views) => {
     if (views === null || views === undefined) return null;
     if (views >= 1000000) return `${(views / 1000000).toFixed(1)}M`;
@@ -41,19 +46,25 @@ function Card3({ videos = [], loading = false, error = null, getContentForVideo 
   if (error) return <div>Error: {error}</div>;
 
   return (
-    <div className={`card-container${shortsGrid ? ' card-container--shorts' : ''}`}>
+    <div
+      className={`card-container${shortsGrid ? ' card-container--shorts' : ''}`}
+      {...containerProps}
+    >
       {processedVideos.map((video, index) => {
         const postKey = `${video.author?.username || video.author || video.owner}/${
           video.permlink
         }`;
 
+        const cardAuthor = video.author?.username || video.author || video.owner;
+
         return (
           <Link
-            to={`${linkPrefix}?v=${video.author?.username || video.author || video.owner}/${
+            to={`${linkPrefix}?v=${cardAuthor}/${
               video.permlink
             }${linkQuery}${video._scheduled ? '&scheduled=1' : ''}`}
             className="card"
             key={postKey}
+            {...getCardProps(postKey, cardAuthor, video.permlink, video._processedThumbnail, video.status)}
           >
             {/* Thumbnail */}
             <div className="img-wrap">
@@ -190,6 +201,8 @@ function Card3({ videos = [], loading = false, error = null, getContentForVideo 
           onClose={() => setModalUser(null)}
         />
       )}
+
+      {overlay}
     </div>
   );
 }

--- a/src/components/Cards/Cards.scss
+++ b/src/components/Cards/Cards.scss
@@ -1,14 +1,24 @@
 @use "../../mixins.scss" as *;
 
+// Card-size preference (set on <html> from the store). Large is the default.
+html[data-card-size="small"] { --card-min-w: 300px; }
+html[data-card-size="large"] { --card-min-w: 460px; }
+
 .card-container {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(var(--card-min-w, 460px), 1fr));
   grid-column-gap: 16px;
   grid-row-gap: 30px;
   margin-top: 15px;
+  position: relative; // anchor for the single hover-preview overlay
   @include respond(phone) {
-      grid-row-gap: 10px;
-   }
+    grid-row-gap: 10px;
+    // Mobile: small = compact 2-up, large = full-width single column.
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    html[data-card-size="large"] & {
+      grid-template-columns: 1fr;
+    }
+  }
 
   .card {
     background-color: var(--card-bg);
@@ -42,6 +52,7 @@
       // width: 270px;
       width: 100%;
       position: relative;
+
       img {
         // width: 100%;
 
@@ -51,15 +62,13 @@
         // background-size: cover;
 
         width: 100%;
-        height: 170px; /* Or you can use 'auto' and remove fixed height */
+        aspect-ratio: 16 / 9; /* always 16:9 regardless of card width */
+        height: auto;
         border-radius: 5px;
         object-fit: cover; /* Ensures the image maintains its aspect ratio */
         object-position: center; /* Centers the image within its container */
         background-position: center;
         background-size: cover;
-        @include respond(phone) {
-          height: 195px;
-        }
       }
 
       .buttom-title {
@@ -421,7 +430,7 @@
 
 // Shorts grid: 9:16 vertical thumbnails
 .card-container--shorts {
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(270px, 1fr)); // ~1.5x larger
 
   @include respond(phone) {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -454,3 +463,102 @@
   }
 }
 
+
+// ── Hover-to-play preview overlay (single, reused; positioned over a card) ──
+// Global (not scoped to .card-container) so any grid can host it (e.g. playlists).
+.card-hover-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  border-radius: 5px;
+  overflow: hidden;
+  z-index: 4;
+  visibility: hidden;
+  pointer-events: none; // hover + clicks pass through to the card beneath
+
+  &.active { visibility: visible; }
+
+  .card-hover-video {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    background: transparent;
+    opacity: 0; // hidden (instant) until ready — the poster covers this gap
+  }
+  &.ready .card-hover-video { opacity: 1; }
+
+  // Poster = the hovered card's thumbnail, covering the (reused) video until the
+  // new clip is actually playing. Prevents the previous clip's last frame from
+  // flashing when moving between cards, and shows the thumbnail while loading.
+  .card-hover-poster {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    z-index: 1;
+    opacity: 1;
+    transition: opacity 0.25s ease;
+  }
+  &.ready .card-hover-poster { opacity: 0; }
+
+  // Subtitles, sized + positioned for the small preview (above the scrub bar).
+  .subtitle-overlay {
+    bottom: 22px;
+    padding: 0 6px;
+    z-index: 5;
+
+    .subtitle-overlay-text {
+      font-size: 16px; // ~1.5x larger
+      padding: 3px 8px;
+    }
+  }
+
+  // Scrub bar — the only interactive part of the overlay. Lifted off the very
+  // bottom edge so the track + handle aren't clipped by the overlay's overflow.
+  .card-hover-bar {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 26px; // generous hit area
+    display: none;
+    cursor: pointer;
+    pointer-events: auto;
+    z-index: 3;
+
+    &::before {
+      content: "";
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 9px;
+      height: 5px;
+      border-radius: 3px;
+      background: rgba(255, 255, 255, 0.35);
+    }
+  }
+  &.ready .card-hover-bar { display: block; }
+
+  .card-hover-bar-fill {
+    position: absolute;
+    left: 0;
+    bottom: 9px;
+    height: 5px;
+    border-radius: 3px;
+    background: var(--accent-primary, #e53935);
+  }
+  .card-hover-bar-handle {
+    position: absolute;
+    bottom: 5px;
+    width: 13px;
+    height: 13px;
+    border-radius: 50%;
+    background: #fff;
+    box-shadow: 0 0 3px rgba(0, 0, 0, 0.6);
+    transform: translateX(-50%);
+  }
+}

--- a/src/components/SettingsModal/SettingsModal.jsx
+++ b/src/components/SettingsModal/SettingsModal.jsx
@@ -38,11 +38,15 @@ function Row({ title, desc, checked, onChange }) {
  * side menu, now grouped with headers + explanations and compact switches.
  */
 export default function SettingsModal({ isOpen, onClose }) {
-  const { theme, showNsfw, setShowNsfw, toggleTheme, sidebarHidden, setSidebarHidden } = useAppStore();
+  const { theme, showNsfw, setShowNsfw, toggleTheme, sidebarHidden, setSidebarHidden, homeCardSize, setHomeCardSize, previewEnabled, setPreviewEnabled } = useAppStore();
   if (!isOpen) return null;
 
   // The left sidebar only exists on desktop, so its toggle is irrelevant on mobile/tablet.
   const isDesktop = window.matchMedia('(min-width: 1025px)').matches;
+  // Previews only work on touch devices in large mode, so hide the toggle when
+  // a touch user has small cards selected (it would have no effect).
+  const isTouch = !window.matchMedia('(hover: hover)').matches;
+  const showPreviewSetting = !isTouch || homeCardSize === 'large';
 
   return createPortal(
     <div className="settings-modal-overlay" onClick={onClose}>
@@ -78,6 +82,20 @@ export default function SettingsModal({ isOpen, onClose }) {
               desc="Collapse the left navigation sidebar for a wider content area."
               checked={!!sidebarHidden}
               onChange={(hide) => setSidebarHidden(hide)}
+            />
+          )}
+          <Row
+            title="Large cards"
+            desc="Show bigger video cards on the home, profile and playlist pages. Turn off for smaller, more compact cards."
+            checked={homeCardSize === 'large'}
+            onChange={(large) => setHomeCardSize(large ? 'large' : 'small')}
+          />
+          {showPreviewSetting && (
+            <Row
+              title="Video previews"
+              desc="Play a muted preview when you hover a video card (and, on mobile in large mode, the centred card auto-plays as you scroll)."
+              checked={previewEnabled !== false}
+              onChange={(v) => setPreviewEnabled(v)}
             />
           )}
         </div>

--- a/src/hooks/useHoverPreview.jsx
+++ b/src/hooks/useHoverPreview.jsx
@@ -1,0 +1,287 @@
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
+import { Player, ThreeSpeakApi } from "@mantequilla-soft/3speak-player";
+import { PLAYER_URL } from "../utils/config";
+import { useAppStore } from "../lib/store";
+import useSubtitles from "./useSubtitles";
+import SubtitleOverlay from "../components/SubtitleOverlay/SubtitleOverlay";
+
+// Statuses with no playable stream — never preview these.
+const NON_PLAYABLE = new Set(["scheduled", "encoding", "draft", "failed", "deleted"]);
+
+// Hover-to-play preview shared by any card grid (video cards, playlists, …).
+// Desktop: plays the hovered card. Mobile (large mode only): auto-plays the card
+// closest to the viewport centre as you scroll. Returns props to spread on the
+// grid container + each card, plus the single reused <video>/Player overlay.
+export default function useHoverPreview() {
+  const previewEnabled = useAppStore((s) => s.previewEnabled !== false);
+  const cardSize = useAppStore((s) => s.homeCardSize);
+
+  const canHover = useMemo(
+    () => typeof window !== "undefined" && window.matchMedia && window.matchMedia("(hover: hover)").matches,
+    []
+  );
+  const isMobile = !canHover;
+  // On mobile we only auto-play in large mode (full-width cards make it sensible).
+  const mobileAutoplay = previewEnabled && isMobile && cardSize === "large";
+  const active = previewEnabled && (canHover || mobileAutoplay);
+
+  const containerRef = useRef(null);
+  const overlayElRef = useRef(null);
+  const videoElRef = useRef(null);
+  const playerRef = useRef(null);
+  const hoverTimer = useRef(null);
+  const draggingRef = useRef(false);
+  const [hover, setHover] = useState(null); // { key, author, permlink, thumb, source, rect }
+  const [ready, setReady] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [curTime, setCurTime] = useState(0);
+  useEffect(() => () => clearTimeout(hoverTimer.current), []);
+
+  // ── Preload visible tiles (lowest-res) + track card nodes for mobile centring ──
+  const apiRef = useRef(null);
+  if (!apiRef.current) apiRef.current = new ThreeSpeakApi(PLAYER_URL);
+  const sourcesRef = useRef(new Map());
+  const inflightRef = useRef(new Set());
+  const cardNodesRef = useRef(new Set());
+  const preload = useCallback((key, author, permlink) => {
+    if (!key || !author || !permlink) return;
+    const sources = sourcesRef.current;
+    const inflight = inflightRef.current;
+    if (sources.has(key) || inflight.has(key)) return;
+    inflight.add(key);
+    apiRef.current.fetchSource(author, permlink)
+      .then((src) => { sources.set(key, src); apiRef.current.prefetchManifest(src.url).catch(() => {}); })
+      .catch(() => {})
+      .finally(() => inflight.delete(key));
+  }, []);
+
+  const observerRef = useRef(null);
+  const observeCard = useCallback((node) => {
+    if (!node || typeof IntersectionObserver === "undefined") return;
+    cardNodesRef.current.add(node);
+    if (!observerRef.current) {
+      observerRef.current = new IntersectionObserver((entries) => {
+        for (const e of entries) {
+          if (e.isIntersecting) {
+            const { postkey, author, permlink } = e.target.dataset;
+            preload(postkey, author, permlink);
+            observerRef.current.unobserve(e.target);
+          }
+        }
+      }, { rootMargin: "300px" });
+    }
+    observerRef.current.observe(node);
+  }, [preload]);
+  useEffect(() => () => { observerRef.current?.disconnect(); cardNodesRef.current.clear(); }, []);
+
+  // ── Single reused Player (only load() per active card) ──
+  const ensurePlayer = useCallback(() => {
+    if (playerRef.current) return playerRef.current;
+    const el = videoElRef.current;
+    if (!el) return null;
+    const player = new Player({
+      apiBase: PLAYER_URL,
+      muted: true,
+      loop: true,
+      poster: false,
+      debug: false,
+      // Lowest rendition + skip the ABR bandwidth probe so playback starts
+      // immediately at the smallest level (we cap to it anyway).
+      hlsConfig: { startLevel: 0, autoLevelCapping: 0, testBandwidth: false, maxBufferLength: 10 },
+    });
+    player.attach(el);
+    playerRef.current = player;
+    el.addEventListener("timeupdate", () => {
+      if (!el.duration) return;
+      if (!draggingRef.current) setProgress(el.currentTime / el.duration);
+      setCurTime(el.currentTime);
+    });
+    // Reveal as soon as the first frame is decoded (snappier than waiting for 'playing').
+    el.addEventListener("loadeddata", () => setReady(true));
+    el.addEventListener("playing", () => setReady(true));
+    return player;
+  }, []);
+
+  useEffect(() => {
+    const player = hover ? ensurePlayer() : playerRef.current;
+    if (!player) return;
+    if (!hover) { try { player.pause(); } catch { /* ignore */ } return; }
+    setReady(false);
+    setProgress(0);
+    setCurTime(0);
+    player.load(hover.source || `${hover.author}/${hover.permlink}`)
+      .then(() => { if (!player.destroyed) player.play().catch(() => {}); })
+      .catch(() => {});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hover?.key]);
+
+  useEffect(() => () => { try { playerRef.current?.destroy(); } catch { /* ignore */ } }, []);
+
+  // English subtitles for the active video (force 'en' if present, no persistence).
+  const { cues, subtitleStyle } = useSubtitles(hover?.author, hover?.permlink, { autoEnglish: true });
+
+  const rectOf = (node) => {
+    const cont = containerRef.current;
+    if (!node || !cont) return null;
+    const r = node.getBoundingClientRect();
+    const cr = cont.getBoundingClientRect();
+    return { top: r.top - cr.top, left: r.left - cr.left, width: r.width, height: r.height };
+  };
+
+  // ── Mobile: auto-play the card nearest the viewport centre; keep the overlay
+  //    positioned over it while scrolling. ──
+  const mobileKeyRef = useRef(null);
+  useEffect(() => {
+    if (!mobileAutoplay) return;
+    let raf = 0;
+    const positionOverlay = (node) => {
+      const el = overlayElRef.current;
+      const rect = rectOf(node);
+      if (!el || !rect) return;
+      el.style.top = `${rect.top}px`;
+      el.style.left = `${rect.left}px`;
+      el.style.width = `${rect.width}px`;
+      el.style.height = `${rect.height}px`;
+    };
+    const pick = () => {
+      raf = 0;
+      const vh = window.innerHeight;
+      const mid = vh / 2;
+      let best = null;
+      let bestD = Infinity;
+      // Only the card that straddles the viewport centre plays — so across the
+      // page's separate row grids, just one video is ever active at a time.
+      for (const node of cardNodesRef.current) {
+        if (!node.isConnected) { cardNodesRef.current.delete(node); continue; }
+        const r = node.getBoundingClientRect();
+        if (r.height === 0 || r.top > mid || r.bottom < mid) continue;
+        const d = Math.abs(r.top + r.height / 2 - mid);
+        if (d < bestD) { bestD = d; best = node; }
+      }
+      if (!best) { mobileKeyRef.current = null; setHover(null); return; }
+      // Position over the thumbnail only, not the whole card (title/meta).
+      const thumbEl = best.querySelector(".img-wrap, .video-thumbnail") || best;
+      positionOverlay(thumbEl);
+      const key = best.dataset.postkey;
+      if (key !== mobileKeyRef.current) {
+        mobileKeyRef.current = key;
+        setReady(false);
+        setHover({
+          key,
+          author: best.dataset.author,
+          permlink: best.dataset.permlink,
+          thumb: best.dataset.thumb,
+          source: sourcesRef.current.get(key),
+          rect: rectOf(thumbEl),
+        });
+      }
+    };
+    const onScroll = () => { if (!raf) raf = requestAnimationFrame(pick); };
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll, { passive: true });
+    // Retry a few times so late-loading cards get picked up without a scroll.
+    const timers = [setTimeout(pick, 300), setTimeout(pick, 900), setTimeout(pick, 1800)];
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+      timers.forEach(clearTimeout);
+      if (raf) cancelAnimationFrame(raf);
+      mobileKeyRef.current = null;
+      setHover(null);
+    };
+  }, [mobileAutoplay]);
+
+  // ── Scrub bar ──
+  const seekFromEvent = (clientX, bar) => {
+    const rect = bar.getBoundingClientRect();
+    const frac = Math.min(1, Math.max(0, (clientX - rect.left) / rect.width));
+    setProgress(frac);
+    const el = videoElRef.current;
+    if (el && el.duration) el.currentTime = frac * el.duration;
+  };
+  const onBarPointerDown = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const bar = e.currentTarget;
+    draggingRef.current = true;
+    seekFromEvent(e.clientX, bar);
+    const move = (ev) => seekFromEvent(ev.clientX, bar);
+    const up = () => {
+      draggingRef.current = false;
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+  };
+
+  // ── Desktop hover tracking ──
+  const onCardEnter = (e, postKey, author, permlink, thumb) => {
+    if (!canHover) return;
+    clearTimeout(hoverTimer.current);
+    const node = e.currentTarget;
+    setHover((h) => (h && h.key !== postKey ? null : h));
+    hoverTimer.current = setTimeout(() => {
+      setReady(false);
+      setHover({
+        key: postKey,
+        author,
+        permlink,
+        thumb,
+        source: sourcesRef.current.get(postKey),
+        rect: rectOf(node.querySelector(".img-wrap, .video-thumbnail") || node),
+      });
+    }, 500);
+  };
+  const onContainerLeave = () => {
+    if (!canHover) return;
+    clearTimeout(hoverTimer.current);
+    setHover(null);
+  };
+
+  const getCardProps = (key, author, permlink, thumb, status) => {
+    if (!active || NON_PLAYABLE.has(status)) return {};
+    return {
+      ref: observeCard,
+      "data-postkey": key,
+      "data-author": author,
+      "data-permlink": permlink,
+      "data-thumb": thumb,
+      onMouseEnter: canHover ? (e) => onCardEnter(e, key, author, permlink, thumb) : undefined,
+    };
+  };
+
+  const overlay = !active ? null : (
+    <div
+      className={`card-hover-overlay${hover ? " active" : ""}${ready ? " ready" : ""}`}
+      ref={overlayElRef}
+      // Desktop positions via state; mobile positions imperatively while scrolling.
+      style={hover && !mobileAutoplay ? { top: hover.rect.top, left: hover.rect.left, width: hover.rect.width, height: hover.rect.height } : undefined}
+      aria-hidden="true"
+    >
+      <video ref={videoElRef} className="card-hover-video" muted playsInline disablePictureInPicture />
+      {hover?.thumb && <img className="card-hover-poster" src={hover.thumb} alt="" />}
+      {ready && cues?.length > 0 && (
+        <SubtitleOverlay currentTime={curTime} cues={cues} style={{ ...(subtitleStyle || {}), fontSize: "small" }} />
+      )}
+      {/* Scrub bar on desktop hover only — seeking stalls the tiny mobile autoplay. */}
+      {!mobileAutoplay && (
+        <div
+          className="card-hover-bar"
+          onPointerDown={onBarPointerDown}
+          onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}
+        >
+          <div className="card-hover-bar-fill" style={{ width: `${progress * 100}%` }} />
+          <div className="card-hover-bar-handle" style={{ left: `${progress * 100}%` }} />
+        </div>
+      )}
+    </div>
+  );
+
+  return {
+    canHover,
+    containerProps: { ref: containerRef, onMouseLeave: onContainerLeave },
+    getCardProps,
+    overlay,
+  };
+}

--- a/src/hooks/useSubtitles.js
+++ b/src/hooks/useSubtitles.js
@@ -30,7 +30,7 @@ const subtitleCache = {};
  * @param {string} author - Video author
  * @param {string} permlink - Video permlink
  */
-export default function useSubtitles(author, permlink) {
+export default function useSubtitles(author, permlink, { autoEnglish = false } = {}) {
   const [availableLanguages, setAvailableLanguages] = useState(null);
   const [selectedLang, setSelectedLang] = useState(null);
   const [cues, setCues] = useState([]);
@@ -68,14 +68,14 @@ export default function useSubtitles(author, permlink) {
         }
         setAvailableLanguages(data);
 
-        // Auto-select only if user previously chose a language
+        // Auto-select the user's stored language; or, when `autoEnglish` is set
+        // (e.g. the hover preview), default to English if present even without a
+        // stored preference. setSelectedLang here does NOT persist a choice.
         const stored = localStorage.getItem(SUBTITLE_LANG_KEY);
-        if (stored) {
-          if (data.some(d => d.lang === stored)) {
-            setSelectedLang(stored);
-          } else if (data.some(d => d.lang === 'en')) {
-            setSelectedLang('en');
-          }
+        if (stored && data.some(d => d.lang === stored)) {
+          setSelectedLang(stored);
+        } else if ((autoEnglish || stored) && data.some(d => d.lang === 'en')) {
+          setSelectedLang('en');
         }
       } catch (err) {
         console.error('[useSubtitles] Failed to check availability:', err);
@@ -84,7 +84,7 @@ export default function useSubtitles(author, permlink) {
     })();
 
     return () => { cancelled = true; };
-  }, [author, permlink]);
+  }, [author, permlink, autoEnglish]);
 
   // Fetch + parse SRT when selectedLang changes
   useEffect(() => {

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -30,6 +30,13 @@ export const useAppStore = create(
       setSidebarHidden: (val) => a[0]({ sidebarHidden: typeof val === 'function' ? val(a[1]().sidebarHidden) : val }),
       showNsfw: false,
       setShowNsfw: (val) => a[0]({ showNsfw: typeof val === 'function' ? val(a[1]().showNsfw) : val }),
+      // Video card size: 'small' | 'large' (default large). Drives home, profile
+      // and playlist card grids.
+      homeCardSize: 'large',
+      setHomeCardSize: (val) => a[0]({ homeCardSize: typeof val === 'function' ? val(a[1]().homeCardSize) : val }),
+      // Hover/scroll video previews on cards (default on).
+      previewEnabled: true,
+      setPreviewEnabled: (val) => a[0]({ previewEnabled: typeof val === 'function' ? val(a[1]().previewEnabled) : val }),
       // Set on startup to the previous app version when the user upgraded (null = first
       // visit or no change). A future changelog / "what's new" prompt reads this.
       // Deliberately NOT persisted — recomputed each load by checkAppVersion().
@@ -46,6 +53,8 @@ export const useAppStore = create(
         sidebarOpen: state.sidebarOpen,
         sidebarHidden: state.sidebarHidden,
         showNsfw: state.showNsfw,
+        homeCardSize: state.homeCardSize,
+        previewEnabled: state.previewEnabled,
       }),
     }
   )

--- a/src/page/HomeGrouped.jsx
+++ b/src/page/HomeGrouped.jsx
@@ -171,7 +171,7 @@ const VideoRow = ({ title, videos, linkTo, isLoading, getContentForVideo, isWatc
 };
 
 const HomeGrouped = () => {
-  const { authenticated, user, showNsfw } = useAppStore();
+  const { authenticated, user, showNsfw, homeCardSize } = useAppStore();
   const queryClient = useQueryClient();
 
   const { data: homeData, isLoading: homeLoading } = useQuery({
@@ -223,7 +223,7 @@ const HomeGrouped = () => {
 
   return (
     <PullToRefresh onRefresh={handleRefresh}>
-    <div className="home-grouped-container">
+    <div className="home-grouped-container" data-card-size={homeCardSize || 'large'}>
       <ShortsStories />
       <OpenPodsLiveStrip />
 

--- a/src/page/HomeGrouped.scss
+++ b/src/page/HomeGrouped.scss
@@ -17,6 +17,41 @@
   max-width: 100%;
   overflow-x: hidden;
 
+  // Card-size preference (desktop rails). Large is the default.
+  --home-card-w: 420px;
+  --home-title-scale: 1.3;
+  &[data-card-size="small"] {
+    --home-card-w: 280px;
+    --home-title-scale: 1;
+  }
+
+  .home-card-size-toggle {
+    display: flex;
+    justify-content: flex-end;
+    gap: 6px;
+    margin: 4px 10px 0;
+
+    button {
+      padding: 4px 14px;
+      font-size: 12.5px;
+      font-weight: 500;
+      border-radius: 8px;
+      border: 1px solid var(--border-light);
+      background: var(--card-bg);
+      color: var(--text-secondary);
+      cursor: pointer;
+      transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+
+      &.active {
+        background: var(--accent-primary);
+        border-color: var(--accent-primary);
+        color: #fff;
+      }
+    }
+
+    @include respond(phone) { display: none; } // desktop-only sizing control
+  }
+
   @include respond(phone) {
     // padding: 15px 0;
   }
@@ -207,7 +242,7 @@
         grid-template-columns: none !important;
         grid-template-rows: repeat(var(--vr-rows, 3), 1fr) !important;
         grid-auto-flow: column !important;
-        grid-auto-columns: 280px !important;
+        grid-auto-columns: var(--home-card-w) !important;
         gap: 20px !important;
         grid-column-gap: 20px !important;
         grid-row-gap: 20px !important;
@@ -218,9 +253,14 @@
         }
 
         .card {
-          width: 280px;
-          min-width: 280px;
+          width: var(--home-card-w);
+          min-width: var(--home-card-w);
           transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+          // Larger title in large mode (scale = 1.5; small mode keeps 1).
+          h2 {
+            font-size: calc(13px * var(--home-title-scale));
+          }
 
           @include respond(phone) {
             width: 160px;
@@ -292,7 +332,7 @@
       display: grid;
       grid-template-rows: repeat(3, 1fr);
       grid-auto-flow: column;
-      grid-auto-columns: 280px;
+      grid-auto-columns: var(--home-card-w);
       gap: 20px;
       grid-column-gap: 20px;
       grid-row-gap: 20px;
@@ -302,8 +342,8 @@
       }
 
       .skeleton-card-horizontal {
-        width: 280px;
-        min-width: 280px;
+        width: var(--home-card-w);
+        min-width: var(--home-card-w);
         background-color: var(--card-bg);
         border-radius: 12px;
         box-shadow: var(--card-shadow);
@@ -317,7 +357,7 @@
 
         .video-thumbnail-skeleton {
           width: 100%;
-          height: 170px;
+          aspect-ratio: 16 / 9; height: auto;
           border-radius: 5px 5px 0 0;
 
           @include respond(phone) {
@@ -326,9 +366,14 @@
         }
 
         .title-skeleton {
-          height: 14px;
-          margin: 8px 4px 6px;
+          // Match the loaded card's 2-line title block (~2.8em), scaled by size.
+          height: calc(36px * var(--home-title-scale, 1));
+          margin: 5px 4px;
           border-radius: 4px;
+
+          @include respond(phone) {
+            height: 24px;
+          }
         }
 
         .skeleton-profile-row {
@@ -376,5 +421,56 @@
     background: transparent !important;
     color: var(--text-primary) !important;
     border: none !important;
+  }
+}
+
+// ── Mobile + Large card size: turn the horizontal rails into a full-width,
+//    single-column vertical feed (pairs with center-based autoplay). ──
+@include respond(phone) {
+  html[data-card-size="large"] {
+    .video-scroll-container-horizontal {
+      overflow-x: hidden;
+
+      .card-container-horizontal .card-container {
+        grid-template-rows: none !important;
+        grid-auto-flow: row !important;
+        grid-template-columns: 1fr !important;
+        grid-auto-columns: auto !important;
+        gap: 14px !important;
+
+        .card {
+          width: 100% !important;
+          min-width: 0 !important;
+
+          .img-wrap img {
+            aspect-ratio: 16 / 9 !important;
+            height: auto !important;
+          }
+          h2 { font-size: 14px; }
+        }
+      }
+    }
+  }
+}
+
+// ── Mobile + Large: loading skeletons match the full-width vertical feed ──
+// !important to beat the more-specific default phone skeleton rules (160px/90px).
+@include respond(phone) {
+  html[data-card-size="large"] .skeleton-horizontal-container {
+    grid-template-rows: none !important;
+    grid-auto-flow: row !important;
+    grid-template-columns: 1fr !important;
+    grid-auto-columns: auto !important;
+    gap: 14px !important;
+
+    .skeleton-card-horizontal {
+      width: 100% !important;
+      min-width: 0 !important;
+
+      .video-thumbnail-skeleton {
+        aspect-ratio: 16 / 9 !important;
+        height: auto !important;
+      }
+    }
   }
 }

--- a/src/page/PlaylistView.jsx
+++ b/src/page/PlaylistView.jsx
@@ -23,6 +23,7 @@ import { MdPlayArrow as MdPlayIcon } from 'react-icons/md';
 import AudioTile from '../components/AudioTile/AudioTile';
 import AddToPlaylistModal from '../components/AddToPlaylistModal/AddToPlaylistModal';
 import { fixVideoThumbnail, fallbackImg } from '../utils/fixThumbnails';
+import useHoverPreview from '../hooks/useHoverPreview';
 import { uploadThumbnail } from '../utils/uploadThumbnail';
 import { DATE_FILTERS, getSinceTimestamp, formatRelativeDate } from '../utils/dateFilters';
 dayjs.extend(relativeTime);
@@ -115,6 +116,9 @@ function PlaylistView() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { user: authenticatedUser } = useAppStore();
+
+  // Hover-to-play preview for the video cards in the grid.
+  const { containerProps, getCardProps, overlay } = useHoverPreview();
 
   // State for edit mode
   const [editableVideos, setEditableVideos] = useState(null);
@@ -624,7 +628,7 @@ function PlaylistView() {
           </div>
         ) : (
           /* Grid view (default) */
-          <div className="playlist-videos-grid">
+          <div className="playlist-videos-grid" {...containerProps}>
             {displayVideos.map((video) => video.isAudio && video.audioDoc ? (
               <AudioTile
                 key={`${video.author}-${video.permlink}`}
@@ -651,6 +655,7 @@ function PlaylistView() {
                 to={`/watch?v=${video.author}/${video.permlink}&playlist=${playlistId}&pos=${video.position}`}
                 state={{ playlist, videos: allVideos, currentIndex: video.position }}
                 className="playlist-video-card"
+                {...getCardProps(`${video.author}/${video.permlink}`, video.author, video.permlink, fixVideoThumbnail(video), video.status)}
               >
                 <div className="video-thumbnail">
                   <img
@@ -685,6 +690,7 @@ function PlaylistView() {
                 </div>
               </Link>
             ))}
+            {overlay}
           </div>
         )}
       </div>

--- a/src/page/PlaylistView.scss
+++ b/src/page/PlaylistView.scss
@@ -520,12 +520,17 @@
     // Grid view
     .playlist-videos-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(var(--card-min-w, 460px), 1fr));
       gap: 16px;
+      position: relative; // anchor for the hover-preview overlay
 
       @include respond(phone) {
         grid-template-columns: repeat(2, minmax(0, 1fr));
         gap: 10px;
+        // Large mode on mobile: full-width single column.
+        html[data-card-size="large"] & {
+          grid-template-columns: 1fr;
+        }
       }
     }
 

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.20.0';
+export const APP_VERSION = '1.23.0';


### PR DESCRIPTION
…eviews

- Larger, consistent 16:9 cards on home/profile/playlists; Large/Small toggle in Settings
- Hover-to-play muted previews on desktop (single reused player, lowest-res prefetch of visible tiles, draggable scrub bar, English subtitles, thumbnail-until-ready)
- Mobile: large mode = full-width feed; the centred card auto-plays as you scroll
- Video previews on/off in Settings; previews extracted to useHoverPreview hook (Card3 + playlists)
- Perf: preconnect to CDN/API, skip hls.js ABR probe, reveal on first frame
- changelog/version: 1.21.0, 1.22.0, 1.23.0