### PR TITLE
Feat/multi embed

### DIFF
--- a/preview.3speak.tv.nginx
+++ b/preview.3speak.tv.nginx
@@ -107,6 +107,17 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_buffering off;
     }
+    location = /shorts/stories {
+        proxy_pass $threespeak_share_backend$request_uri;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+    }
     location ~ ^/@ {
         proxy_pass $threespeak_share_backend$request_uri;
         proxy_http_version 1.1;

--- a/server/og-server.cjs
+++ b/server/og-server.cjs
@@ -60,25 +60,34 @@ function isBot(userAgent) {
   return BOT_USER_AGENTS.some((bot) => ua.includes(bot.toLowerCase()));
 }
 
+// Routes that carry the video as a ?v=author/permlink param. The value is the
+// canonical path to echo back (og:url/canonical), and whether it's a short.
+const VPARAM_ROUTES = {
+  '/watch': { routePath: 'watch', kind: 'watch' },
+  '/shorts': { routePath: 'shorts', kind: 'shorts' },
+  '/shorts/stories': { routePath: 'shorts/stories', kind: 'shorts' },
+};
+
 /**
- * Parse video author/permlink + route kind from the URL.
+ * Parse video author/permlink + route info from the URL.
  * Supports:
- *   /watch?v=author/permlink            → { author, permlink, kind: 'watch' }
- *   /shorts?v=author/permlink           → { author, permlink, kind: 'shorts' }
- *   /@author/permlink (skip "shorts")   → { author, permlink, kind: 'watch' }
- * Returns the match or null.
+ *   /watch?v=author/permlink            → kind 'watch'
+ *   /shorts?v=author/permlink           → kind 'shorts'
+ *   /shorts/stories?v=author/permlink   → kind 'shorts' (story-feed deep link)
+ *   /@author/permlink (skip "shorts")   → kind 'watch'
+ * Returns { author, permlink, kind, routePath } or null.
  */
 function parseVideoUrl(url) {
   const { pathname, searchParams } = url;
 
-  // /watch?v=author/permlink  and  /shorts?v=author/permlink
-  if (pathname === '/watch' || pathname === '/shorts') {
+  const vRoute = VPARAM_ROUTES[pathname];
+  if (vRoute) {
     const v = searchParams.get('v');
     if (v && v.includes('/')) {
       const [author, ...rest] = v.split('/');
       const permlink = rest.join('/');
       if (author && permlink) {
-        return { author, permlink, kind: pathname === '/shorts' ? 'shorts' : 'watch' };
+        return { author, permlink, kind: vRoute.kind, routePath: vRoute.routePath };
       }
     }
     return null;
@@ -89,7 +98,7 @@ function parseVideoUrl(url) {
   if (atMatch) {
     const [, author, permlink] = atMatch;
     if (permlink === 'shorts') return null; // shorts listing page, not a video
-    return { author, permlink, kind: 'watch' };
+    return { author, permlink, kind: 'watch', routePath: 'watch' };
   }
 
   return null;
@@ -247,10 +256,26 @@ function fixThumbnail(thumbnail) {
   }
 
   if (t.startsWith('http')) {
-    return `https://images.hive.blog/0x0/${t}`;
+    return `https://images.hive.blog/${OG_IMAGE_BOX}/${t}`;
   }
 
   return t;
+}
+
+// Social crawlers reject oversized images (Discord/Twitter drop multi-MB or
+// huge-dimension files — a raw images.hive.blog upload is often the user's
+// full-res photo at 3+ MB). Route raw hive images through hive's resize proxy
+// so the card gets a bounded copy. Already-sized proxies (/WxH/), processed CDN
+// (/p/...), avatars (/u/...) and non-hive hosts (images.3speak.tv, the local
+// fallback) are left untouched — they're already small.
+const OG_IMAGE_BOX = '1280x720';
+function boundImage(url) {
+  if (!url || typeof url !== 'string') return url;
+  const m = url.match(/^https?:\/\/images\.hive\.blog\/([^/]+)\//);
+  if (!m) return url;
+  const seg = m[1];
+  if (/^\d+x\d+$/.test(seg) || seg === 'p' || seg === 'u') return url;
+  return `https://images.hive.blog/${OG_IMAGE_BOX}/${url}`;
 }
 
 function extractDescription(body) {
@@ -545,7 +570,7 @@ const server = http.createServer(async (req, res) => {
       if (thumbSource) thumbnail = thumbSource.url;
     }
     if (!thumbnail && meta.image && meta.image[0]) thumbnail = meta.image[0];
-    const image = fixThumbnail(thumbnail);
+    const image = boundImage(fixThumbnail(thumbnail));
 
     const kindLabel = video.kind === 'shorts' ? 'Short' : 'Video';
     const title =
@@ -557,10 +582,9 @@ const server = http.createServer(async (req, res) => {
       ? extractDescription(post.body)
       : `A ${kindLabel.toLowerCase()} by @${video.author} on 3Speak.`;
 
-    // Canonicalize to the same route kind that was shared (/watch vs /shorts),
-    // keeping the original share permlink so the link opens the right asset.
-    const routePath = video.kind === 'shorts' ? 'shorts' : 'watch';
-    const selfUrl = `${origin}/${routePath}?v=${video.author}/${video.permlink}`;
+    // Canonicalize to the exact route that was shared (/watch, /shorts or
+    // /shorts/stories), keeping the original permlink so the link opens right.
+    const selfUrl = `${origin}/${video.routePath}?v=${video.author}/${video.permlink}`;
     const canonicalUrl = resolveCanonical(meta, selfUrl);
     const duration = videoInfo.duration || (embed && embed.duration) || null;
     const uploadDate = toIsoDate((post && post.created) || (embed && embed.createdAt));

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,18 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.33.0',
+    date: '2026-06-25',
+    summary:
+      'Sharing a video or short now shows a proper preview. When you paste a 3Speak link on Twitter/X, Discord, Telegram, WhatsApp and similar, the post unfurls with the video’s thumbnail, title and description instead of the plain 3Speak logo.',
+  },
+  {
+    version: '1.32.0',
+    date: '2026-06-25',
+    summary:
+      'YouTube links in a video’s description now stay as normal clickable links instead of being turned into an embedded player, so descriptions with two links on one line (e.g. “Source: A & B”) keep their layout.',
+  },
+  {
     version: '1.31.0',
     date: '2026-06-22',
     summary:

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.31.0';
+export const APP_VERSION = '1.33.0';


### PR DESCRIPTION
This pull request introduces improved support for video and short link previews, ensuring that when 3Speak links are shared on social platforms (like Twitter, Discord, Telegram, WhatsApp), the preview unfurls with the video's thumbnail, title, and description instead of just the default logo. Additionally, the pull request enhances image handling for social previews and updates the version and changelog.

**Open Graph (OG) Preview Improvements:**

* Added support for `/shorts/stories` routes in both the Nginx configuration and OG server, so deep links to stories generate correct previews. [[1]](diffhunk://#diff-57cc701a13c55a7d4715b24c683854db342b22dfcec05591cf49a202d1ef9666R110-R120) [[2]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aR63-R90)
* Enhanced the `parseVideoUrl` function to correctly parse and canonicalize all supported video routes, including `/watch`, `/shorts`, and `/shorts/stories`, ensuring the unfurled link matches the original share. [[1]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aR63-R90) [[2]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aL92-R101) [[3]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aL560-R587)

**Image Handling Enhancements:**

* Introduced the `boundImage` function to ensure oversized images are automatically resized via the Hive image proxy, preventing social crawlers from dropping previews due to large files. [[1]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aL250-R280) [[2]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aL548-R573)

**Changelog and Version Updates:**

* Updated the changelog in `src/changelog.js` to document the new link unfurling and recent YouTube link handling improvements.
* Bumped the app version to `1.33.0` in `src/version.js`.