### PR TITLE
feat(embed-studio): post-faithful publish preview (v1.34.0)

### DIFF
--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.34.0',
+    date: '2026-06-26',
+    summary:
+      'The review step before publishing a video now looks just like the finished post: your video player (showing the thumbnail until you press play), then the title and the description exactly as viewers will see them — YouTube links stay as normal links instead of turning into embeds. Community, payout, beneficiaries, tags and the other publish settings are listed below the post.',
+  },
+  {
     version: '1.33.0',
     date: '2026-06-25',
     summary:

--- a/src/components/embed-studio/EmbedPreview.jsx
+++ b/src/components/embed-studio/EmbedPreview.jsx
@@ -3,12 +3,12 @@ import "../legacy-studio/Preview.scss";
 import "./EmbedPreview.scss";
 import { Navigate, useNavigate } from "react-router-dom";
 import { CheckCircle, Upload, FileText, Info, Users, Coins, Gift, Repeat2, Tag, ShieldAlert } from "lucide-react";
-import VideoPreview from "../studio/VideoPreview";
 import { StepProgress } from "../legacy-studio/StepProgress";
 import EmbedUploadProgressBar from "./EmbedUploadProgressBar";
 import { useEmbedUpload } from "../../context/EmbedUploadContext";
 import "../legacy-studio/VideoUploadStatus.scss";
-import EditorPreview from "../Editor/EditorPreview";
+import BlogContent from "../playVideo/BlogContent";
+import EmbedPreviewPlayer from "./EmbedPreviewPlayer";
 import PromoteModal from "../Promote/PromoteModal";
 import { Rocket } from "lucide-react";
 
@@ -64,6 +64,19 @@ function EmbedPreview() {
   const isRemix = !!(originalAuthor && originalPermlink);
   const remixLabel = isRemix ? "On (this is a remix)" : reusable ? "Allowed" : "Not allowed";
 
+  // The body the viewer will actually read = description (+ remix credit). The
+  // published body also prepends the embed URL and appends a "Watch on 3Speak"
+  // footer, but BlogContent strips both on render — so rendering this through the
+  // same BlogContent the watch page uses gives a faithful preview. The player is
+  // shown separately above, standing in for that leading embed URL.
+  const previewBody = isRemix
+    ? `${description}\n\n---\n*Based on a video by [@${originalAuthor}](${
+        fromStories
+          ? `${window.location.origin}/shorts?v=${originalAuthor}/${originalPermlink}`
+          : `${window.location.origin}/@${originalAuthor}/${originalPermlink}`
+      })*`
+    : description;
+
   // `beneficiaries` is an array initially but the beneficiary modal stores it as
   // a JSON string — normalise both shapes before rendering.
   let beneList = [];
@@ -96,100 +109,87 @@ function EmbedPreview() {
 
           <div className="studio-page-content">
             <div className="ep-review">
-              <div className="ep-grid">
-                {/* LEFT: thumbnail, video, settings */}
-                <div className="ep-left">
-                  {selectedThumbnail && (
-                    <div className="ep-media-block">
-                      <span className="ep-media-label">Thumbnail</span>
-                      <img
-                        className={`ep-thumb${fromStories ? ' ep-thumb--portrait' : ''}`}
-                        src={selectedThumbnail}
-                        alt="Thumbnail"
-                      />
-                    </div>
-                  )}
+              {/* POST PREVIEW — rendered like the final post: player (standing in
+                  for the leading embed URL) → title → description body. */}
+              <div className="ep-post">
+                {title && <h2 className="ep-title">{title}</h2>}
 
-                  {prevVideoFile && (
-                    <div className="ep-media-block">
-                      <span className="ep-media-label">Video</span>
-                      <div className={`ep-media-video${fromStories ? ' ep-media-video--portrait' : ''}`}>
-                        <VideoPreview file={prevVideoFile} />
-                      </div>
-                    </div>
-                  )}
+                {/* One card wrapping the player + description so the video reads
+                    as part of the post body, not a detached element. */}
+                <div className="ep-post-card">
+                  <EmbedPreviewPlayer
+                    file={prevVideoFile}
+                    poster={selectedThumbnail}
+                    portrait={fromStories}
+                  />
 
-                  <div className="ep-settings">
-                    <div className="ep-settings__head">Publish settings</div>
-
-                    <div className="ep-setting">
-                      <span className="ep-setting__icon"><Users size={18} /></span>
-                      <span className="ep-setting__label">Community</span>
-                      <span className="ep-setting__value ep-setting__value--community">
-                        <img src={`https://images.hive.blog/u/${communityDisplay.name}/avatar`} alt="" />
-                        {communityDisplay.title}
-                      </span>
-                    </div>
-
-                    <div className="ep-setting">
-                      <span className="ep-setting__icon"><Coins size={18} /></span>
-                      <span className="ep-setting__label">Payout</span>
-                      <span className="ep-setting__value">{payoutLabel}</span>
-                    </div>
-
-                    <div className="ep-setting ep-setting--top">
-                      <span className="ep-setting__icon"><Gift size={18} /></span>
-                      <span className="ep-setting__label">Beneficiaries</span>
-                      <span className="ep-setting__value">
-                        {userBeneficiaries.length === 0 ? (
-                          <span className="ep-muted">None</span>
-                        ) : (
-                          <span className="ep-benes">
-                            {userBeneficiaries.map((b, i) => (
-                              <span className="ep-bene" key={i}>@{b.account} · {(Number(b.weight) / 100).toFixed(0)}%</span>
-                            ))}
-                          </span>
-                        )}
-                      </span>
-                    </div>
-
-                    <div className="ep-setting ep-setting--top">
-                      <span className="ep-setting__icon"><Tag size={18} /></span>
-                      <span className="ep-setting__label">Tags</span>
-                      <span className="ep-setting__value">
-                        {tagsPreview && tagsPreview.length > 0 ? (
-                          <span className="ep-tags">
-                            {tagsPreview.map((tag, index) => (
-                              <span className="ep-tag" key={index}>#{tag}</span>
-                            ))}
-                          </span>
-                        ) : <span className="ep-muted">None</span>}
-                      </span>
-                    </div>
-
-                    <div className="ep-setting">
-                      <span className="ep-setting__icon"><Repeat2 size={18} /></span>
-                      <span className="ep-setting__label">Remix / clip</span>
-                      <span className="ep-setting__value">{remixLabel}</span>
-                    </div>
-
-                    <div className="ep-setting">
-                      <span className="ep-setting__icon"><ShieldAlert size={18} /></span>
-                      <span className="ep-setting__label">Adult / NSFW</span>
-                      <span className="ep-setting__value">
-                        {isNsfw ? <span className="ep-nsfw-on">Yes</span> : <span className="ep-muted">No</span>}
-                      </span>
-                    </div>
+                  <div className="ep-body">
+                    <BlogContent description={previewBody} alwaysExpanded />
                   </div>
                 </div>
+              </div>
 
-                {/* RIGHT: title + description */}
-                <div className="ep-right">
-                  <span className="ep-media-label">Body</span>
-                  {title && <h2 className="ep-title">{title}</h2>}
-                  <div className="ep-desc">
-                    <EditorPreview content={description} />
-                  </div>
+              {/* Everything that isn't the post body, shown below it. */}
+              <div className="ep-settings">
+                <div className="ep-settings__head">Publish settings</div>
+
+                <div className="ep-setting">
+                  <span className="ep-setting__icon"><Users size={18} /></span>
+                  <span className="ep-setting__label">Community</span>
+                  <span className="ep-setting__value ep-setting__value--community">
+                    <img src={`https://images.hive.blog/u/${communityDisplay.name}/avatar`} alt="" />
+                    {communityDisplay.title}
+                  </span>
+                </div>
+
+                <div className="ep-setting">
+                  <span className="ep-setting__icon"><Coins size={18} /></span>
+                  <span className="ep-setting__label">Payout</span>
+                  <span className="ep-setting__value">{payoutLabel}</span>
+                </div>
+
+                <div className="ep-setting ep-setting--top">
+                  <span className="ep-setting__icon"><Gift size={18} /></span>
+                  <span className="ep-setting__label">Beneficiaries</span>
+                  <span className="ep-setting__value">
+                    {userBeneficiaries.length === 0 ? (
+                      <span className="ep-muted">None</span>
+                    ) : (
+                      <span className="ep-benes">
+                        {userBeneficiaries.map((b, i) => (
+                          <span className="ep-bene" key={i}>@{b.account} · {(Number(b.weight) / 100).toFixed(0)}%</span>
+                        ))}
+                      </span>
+                    )}
+                  </span>
+                </div>
+
+                <div className="ep-setting ep-setting--top">
+                  <span className="ep-setting__icon"><Tag size={18} /></span>
+                  <span className="ep-setting__label">Tags</span>
+                  <span className="ep-setting__value">
+                    {tagsPreview && tagsPreview.length > 0 ? (
+                      <span className="ep-tags">
+                        {tagsPreview.map((tag, index) => (
+                          <span className="ep-tag" key={index}>#{tag}</span>
+                        ))}
+                      </span>
+                    ) : <span className="ep-muted">None</span>}
+                  </span>
+                </div>
+
+                <div className="ep-setting">
+                  <span className="ep-setting__icon"><Repeat2 size={18} /></span>
+                  <span className="ep-setting__label">Remix / clip</span>
+                  <span className="ep-setting__value">{remixLabel}</span>
+                </div>
+
+                <div className="ep-setting">
+                  <span className="ep-setting__icon"><ShieldAlert size={18} /></span>
+                  <span className="ep-setting__label">Adult / NSFW</span>
+                  <span className="ep-setting__value">
+                    {isNsfw ? <span className="ep-nsfw-on">Yes</span> : <span className="ep-muted">No</span>}
+                  </span>
                 </div>
               </div>
 

--- a/src/components/embed-studio/EmbedPreview.scss
+++ b/src/components/embed-studio/EmbedPreview.scss
@@ -1,91 +1,112 @@
 @use "../../mixins.scss" as mix;
 
-/* Redesigned embed-studio review/preview step */
+/* Redesigned embed-studio review/preview step — single column, rendered to look
+   like the final post (player → title → description), with publish settings
+   shown below the post body. */
 .ep-review {
-  max-width: 1040px;
+  max-width: 760px;
   margin: 0 auto;
   width: 100%;
 }
 
-.ep-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  gap: 22px;
-  align-items: stretch;
-
-  @include mix.respond(phone) {
-    grid-template-columns: 1fr;
-    gap: 16px;
-  }
-}
-
-/* ---- Left: thumbnail, video, settings ---- */
-.ep-left {
+/* ---- The post preview itself ---- */
+.ep-post {
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  min-width: 0;
+  gap: 12px;
 }
 
-.ep-media-video {
+/* One card wrapping the player + description (the unified "post body"). The
+   card background/radius live here now, NOT on the inner markdown container. */
+.ep-post-card {
+  background: var(--card-bg);
   border-radius: 14px;
   overflow: hidden;
+  box-shadow: 0 6px 22px rgba(0, 0, 0, 0.12);
+
+  /* Player sits flush at the top of the card — the card clips its corners and
+     provides the shadow, so it drops its own. */
+  .ep-player {
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  /* Neutralise BlogContent's own card so it doesn't double up inside ours. */
+  .blog-content-container {
+    background-color: transparent;
+    border-radius: 0;
+  }
+}
+
+/* Player — stands in for the leading embed URL of the published body. */
+.ep-player {
+  position: relative;
+  overflow: hidden;
   background: #000;
-  box-shadow: 0 6px 22px rgba(0, 0, 0, 0.18);
   aspect-ratio: 16 / 9;
 
-  video, & > * {
+  video,
+  .ep-player__still {
     width: 100%;
     height: 100%;
-    object-fit: contain;
     display: block;
   }
+  video { object-fit: contain; }
+  .ep-player__still { object-fit: cover; }
 
   &--portrait {
     aspect-ratio: 9 / 16;
     max-width: 320px;
+    width: 100%;
     margin: 0 auto;
   }
 }
 
-.ep-media-block {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.ep-media-label {
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-  color: var(--text-secondary, #888);
-}
-
-.ep-thumb {
+/* Thumbnail-as-poster with a play button, shown until the user hits play. */
+.ep-player__poster {
+  position: relative;
+  display: block;
   width: 100%;
-  border-radius: 12px;
-  aspect-ratio: 16 / 9;
-  object-fit: cover;
-  border: 1px solid var(--border-color, rgba(0, 0, 0, 0.1));
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: #000;
+  cursor: pointer;
 
-  &--portrait {
-    aspect-ratio: 9 / 16;
-    max-width: 200px;
+  img {
+    width: 100%;
+    height: 100%;
     object-fit: cover;
+    display: block;
   }
+
+  &[disabled] { cursor: default; }
 }
 
-/* ---- Right: title + description (tall) ---- */
-.ep-right {
+.ep-player__play {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 64px;
+  height: 64px;
   display: flex;
-  flex-direction: column;
-  gap: 12px;
-  min-width: 0;
+  align-items: center;
+  justify-content: center;
+  padding-left: 4px; /* optical centering of the play triangle */
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  pointer-events: none;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+.ep-player__poster:hover .ep-player__play {
+  background: var(--accent-primary, #e53935);
+  transform: scale(1.05);
 }
 
 .ep-title {
-  font-size: 22px;
+  font-size: 24px;
   line-height: 1.25;
   font-weight: 700;
   margin: 0;
@@ -93,24 +114,9 @@
   word-break: break-word;
 }
 
-/* The renderer (EditorPreview → .editor-preview) already draws its own card, so
-   this is just a flex wrapper that stretches it taller — no second container. */
-.ep-desc {
-  flex: 1;
-  display: flex;
-  min-height: 0;
-
-  .editor-preview {
-    flex: 1;
-    width: 100%;
-    margin: 0;
-    min-height: 340px;
-    max-height: 70vh;
-
-    @include mix.respond(phone) {
-      min-height: 180px;
-    }
-  }
+/* Description rendered through the same BlogContent the watch page uses. */
+.ep-body {
+  width: 100%;
 }
 
 .ep-tags {
@@ -128,8 +134,9 @@
   color: var(--text-secondary, #555);
 }
 
-/* ---- Publish settings panel ---- */
+/* ---- Publish settings panel (below the post body) ---- */
 .ep-settings {
+  margin-top: 26px;
   border: 1px solid var(--border-color, rgba(0, 0, 0, 0.1));
   border-radius: 14px;
   overflow: hidden;

--- a/src/components/embed-studio/EmbedPreviewPlayer.jsx
+++ b/src/components/embed-studio/EmbedPreviewPlayer.jsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import { FileVideo, Play } from "lucide-react";
+
+// Preview-step stand-in for the final 3Speak player. The published body starts
+// with the embed URL, which renders as the video player at the top of the post;
+// here we emulate that with the locally-selected file. Until the user hits play
+// we show the thumbnail (the poster the published player would show), matching
+// what viewers see before they start the video.
+const EmbedPreviewPlayer = ({ file, poster, portrait = false }) => {
+  const [objectUrl, setObjectUrl] = useState(null);
+  const [playing, setPlaying] = useState(false);
+  const [previewError, setPreviewError] = useState(false);
+
+  useEffect(() => {
+    if (!file) {
+      setObjectUrl(null);
+      return;
+    }
+    setPreviewError(false);
+    const url = URL.createObjectURL(file);
+    setObjectUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
+
+  const cls = `ep-player${portrait ? " ep-player--portrait" : ""}`;
+
+  // Poster state — thumbnail with a play button, until the user clicks it.
+  if (poster && !playing) {
+    return (
+      <div className={cls}>
+        <button
+          type="button"
+          className="ep-player__poster"
+          onClick={() => setPlaying(true)}
+          aria-label="Play video"
+          disabled={!objectUrl}
+        >
+          <img src={poster} alt="" />
+          {objectUrl && (
+            <span className="ep-player__play">
+              <Play size={30} fill="currentColor" />
+            </span>
+          )}
+        </button>
+      </div>
+    );
+  }
+
+  // No local file to play (e.g. handed over from an external uploader) — fall
+  // back to just the poster if we have one.
+  if (!objectUrl) {
+    return poster ? (
+      <div className={cls}>
+        <img className="ep-player__still" src={poster} alt="" />
+      </div>
+    ) : null;
+  }
+
+  // Browsers can't decode some codecs (e.g. HEVC/H.265 from iPhones) for an
+  // inline preview, even though the file uploads and is transcoded fine.
+  if (previewError) {
+    return (
+      <div className="video-preview-fallback" style={{ marginTop: 0 }}>
+        <FileVideo className="video-preview-fallback-icon" />
+        <p>
+          Your browser can't preview this video — this is common for HEVC/H.265
+          clips (e.g. iPhone “High Efficiency” recordings). That's fine: it will
+          still upload and be converted so it plays for everyone.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cls}>
+      <video
+        src={objectUrl}
+        poster={poster || undefined}
+        controls
+        autoPlay={playing}
+        onError={() => setPreviewError(true)}
+      />
+    </div>
+  );
+};
+
+export default EmbedPreviewPlayer;

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.33.0';
+export const APP_VERSION = '1.34.0';


### PR DESCRIPTION
Rework the embed-studio review step to render like the finished post in a single column instead of the two-column settings/body split:

- Show the description through the same BlogContent the watch page uses, so it matches exactly — including keeping YouTube links inline instead of embedding them.
- Stand in for the published body's leading embed URL with a click-to-play player (new EmbedPreviewPlayer) that shows the thumbnail as a poster until the user presses play; appends the remix credit like the publish flow does.
- Wrap the player + description in one card (background/radius moved off the inner markdown container, scoped to the preview so the watch page is untouched); title sits above the card.
- Move community/payout/beneficiaries/tags/remix/NSFW below the post body.

Add changelog entry + bump APP_VERSION 1.33.0 -> 1.34.0.