### PR TITLE
feat(watch): YouTube-style desktop layout + unified action buttons

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -480,7 +480,7 @@ function App() {
             <Route path="/" element={<HomeGrouped />} />
             <Route path="/home-feed" element={<Feed />} />
             <Route path="/follow-feed" element={<FollowFeed />} />
-            <Route path="/watch" element={<Watch />} />
+            <Route path="/watch" element={<Watch v2 />} />
             <Route path="/notifications" element={<Notifications />} />
             <Route path="/post/:author/:permlink" element={<PostView />} />
             <Route path="/upload" element={<UploadVideo />} />

--- a/src/components/playVideo/PlayVideo.jsx
+++ b/src/components/playVideo/PlayVideo.jsx
@@ -43,7 +43,7 @@ import { removeFromPlaylist } from "../../utils/playlistOperations";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import AuthorBadge from "../AuthorBadge/AuthorBadge";
 import Button from "../Button/Button";
-import { Repeat2, Scissors, Tornado, Film, Music, Rocket } from 'lucide-react';
+import { Repeat2, Scissors, Tornado, Film, Music, Rocket, Gift } from 'lucide-react';
 import PromoteModal from '../Promote/PromoteModal';
 import { recordReshare, getResharesForVideo } from '../../utils/reshares';
 import EditorModal from '../modal/EditorModal';
@@ -57,7 +57,7 @@ import SummaryModal from '../SummaryModal/SummaryModal';
 
 dayjs.extend(relativeTime);
 
-const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlaylist, videoControls, mobileReactionPanel, cinemaReactionPanel, videoRef, wrapperRef, onVideoEdited, overrideBody, scheduled = false, scheduledOn = null, onEditScheduled }) => {
+const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlaylist, videoControls, mobileReactionPanel, cinemaReactionPanel, videoRef, wrapperRef, onVideoEdited, overrideBody, scheduled = false, scheduledOn = null, onEditScheduled, v2 = false }) => {
   const { user, authenticated } = useAppStore();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -334,9 +334,21 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
     try {
       const res = await axios.get(`${FEED_URL}/apiv2/@${author}/${permlink}`);
       setSpeakData(res.data);
-      setView(res.data.views);
     } catch (err) {
-      console.error("Error fetching speak data:", err);
+      // Legacy endpoint — best-effort; the view count comes from the checker below.
+    }
+    // View count from the checker /views — the same source the cards use
+    // (the legacy apiv2 endpoint is gone, which is why this read as 0 before).
+    try {
+      const vres = await axios.post(
+        `${CHECKER_URL}/views`,
+        { videos: [{ author, permlink }] },
+        { timeout: 15000 },
+      );
+      const count = vres.data?.data?.[`${author}/${permlink}`];
+      if (typeof count === 'number') setView(count);
+    } catch (err) {
+      console.error('Error fetching view count:', err.message);
     }
   }, [author, permlink]);
 
@@ -603,6 +615,66 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
     return <BarLoader />;
   }
 
+  // Views/age + payout/votes. In v2 this is rendered on the right of the title
+  // (stacked); in the classic layout it sits as its own row below the buttons.
+  // Defined once so the refs/tooltips only ever attach to a single instance.
+  const statsRow = (
+    <div className="info-stats-row">
+      <div className="wrap-left">
+        <ViewCount views={view} author={author} permlink={permlink} size={13} />
+        <div className="wrap">
+          <LuTimer />
+          <span>{formatRelativeTime(videoDetails?.created_at)}</span>
+        </div>
+      </div>
+      <div className="wrap-right-stats">
+        <span
+          ref={payoutRef}
+          onMouseEnter={() => setShowBeneficiaries(true)}
+          onMouseLeave={() => setShowBeneficiaries(false)}
+          onClick={() => setPinnedBeneficiaries(prev => !prev)}
+          style={{ cursor: 'pointer' }}
+        >
+          <PayoutAmount amount={videoDetails?.stats?.total_hive_reward ?? 0} size={13} />
+        </span>
+        {(showBeneficiaries || pinnedBeneficiaries) && beneficiaries.length > 0 && (
+          <BeneficiariesTooltip
+            beneficiaries={beneficiaries}
+            payoutInfo={payoutInfo}
+            displayTotal={videoDetails?.stats?.total_hive_reward ?? 0}
+            anchorRef={payoutRef}
+            pinned={pinnedBeneficiaries}
+            onClose={() => setPinnedBeneficiaries(false)}
+          />
+        )}
+        <span className="wrap" ref={voteCountRef}>
+          <UpvoteCount
+            count={optimisticVoteCount}
+            voted={isVoted}
+            onClick={toggleTooltip}
+            loading={isLoading}
+            onCountEnter={() => setOpenToolTip(true)}
+            onCountLeave={() => setOpenToolTip(false)}
+            onCountClick={() => setPinnedTooltip(prev => !prev)}
+            size={13}
+          >
+            <div className="loader-circle">
+              <TailChase className="loader-circle" size="15" speed="1.5" color="red" />
+            </div>
+          </UpvoteCount>
+          {(openTooltip || pinnedTooltip) && (
+            <ToolTip
+              tooltipVoters={tooltipVoters}
+              anchorRef={voteCountRef}
+              pinned={pinnedTooltip}
+              onClose={() => setPinnedTooltip(false)}
+            />
+          )}
+        </span>
+      </div>
+    </div>
+  );
+
   return (
     <>
       <div className="play-video">
@@ -783,6 +855,7 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
                 )}
               </div>
             </div>
+            {v2 && <div className="pv2-title-meta">{statsRow}</div>}
             <button
               type="button"
               className="mobile-title-toggle"
@@ -846,67 +919,14 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
                 </span>
               </div>
             )}
-            <div className="info-stats-row">
-              <div className="wrap-left">
-                <ViewCount views={view} author={author} permlink={permlink} size={13} />
-                <div className="wrap">
-                  <LuTimer />
-                  <span>{formatRelativeTime(videoDetails?.created_at)}</span>
-                </div>
-              </div>
-              <div className="wrap-right-stats">
-                <span
-                  ref={payoutRef}
-                  onMouseEnter={() => setShowBeneficiaries(true)}
-                  onMouseLeave={() => setShowBeneficiaries(false)}
-                  onClick={() => setPinnedBeneficiaries(prev => !prev)}
-                  style={{ cursor: 'pointer' }}
-                >
-                  <PayoutAmount amount={videoDetails?.stats?.total_hive_reward ?? 0} size={13} />
-                </span>
-                {(showBeneficiaries || pinnedBeneficiaries) && beneficiaries.length > 0 && (
-                  <BeneficiariesTooltip
-                    beneficiaries={beneficiaries}
-                    payoutInfo={payoutInfo}
-                    displayTotal={videoDetails?.stats?.total_hive_reward ?? 0}
-                    anchorRef={payoutRef}
-                    pinned={pinnedBeneficiaries}
-                    onClose={() => setPinnedBeneficiaries(false)}
-                  />
-                )}
-                <span className="wrap" ref={voteCountRef}>
-                  <UpvoteCount
-                    count={optimisticVoteCount}
-                    voted={isVoted}
-                    onClick={toggleTooltip}
-                    loading={isLoading}
-                    onCountEnter={() => setOpenToolTip(true)}
-                    onCountLeave={() => setOpenToolTip(false)}
-                    onCountClick={() => setPinnedTooltip(prev => !prev)}
-                    size={13}
-                  >
-                    <div className="loader-circle">
-                      <TailChase className="loader-circle" size="15" speed="1.5" color="red" />
-                    </div>
-                  </UpvoteCount>
-                  {(openTooltip || pinnedTooltip) && (
-                    <ToolTip
-                      tooltipVoters={tooltipVoters}
-                      anchorRef={voteCountRef}
-                      pinned={pinnedTooltip}
-                      onClose={() => setPinnedTooltip(false)}
-                    />
-                  )}
-                </span>
-              </div>
-            </div>
+            {!v2 && statsRow}
 
             <div className="info-buttons-row">
               {FEATURE_EDITOR && canRemixClip && (
                 <div className="info-buttons-left">
                   <button
                     type="button"
-                    className={`clip-btn${clipMode ? ' active' : ''}`}
+                    className={`pv-btn clip-btn${clipMode ? ' active' : ''}`}
                     onClick={clipMode ? handleCancelClip : handleStartClipMode}
                     title={!authenticated ? 'Log in to clip' : clipMode ? 'Cancel clip' : 'Clip video'}
                     disabled={!authenticated}
@@ -943,7 +963,7 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
                   (authenticated && user === author) && (
                     <button
                       type="button"
-                      className="edit-video-btn"
+                      className="pv-btn edit-video-btn"
                       onClick={() => onEditScheduled?.()}
                       title="Edit scheduled post (details, date, or cancel)"
                     >
@@ -955,7 +975,7 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
                 {titleMeta.hasSummary && (
                   <button
                     type="button"
-                    className="summary-btn"
+                    className="pv-btn summary-btn"
                     onClick={() => setSummaryOpen(true)}
                     title="AI summary of this video"
                   >
@@ -971,7 +991,7 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
                   // already voted to avoid showing a stale CTA.
                   <button
                     type="button"
-                    className="vote-btn"
+                    className="pv-btn vote-btn"
                     onClick={toggleTooltip}
                     title="Vote on this video"
                   >
@@ -981,28 +1001,30 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
                 )}
                 <button
                   type="button"
-                  className="share-btn"
+                  className="pv-btn share-btn"
                   onClick={() => setShareChooserOpen(true)}
                   title="Share"
                 >
                   <MdShare size={16} />
+                  <span>Share</span>
                 </button>
 
                 <button
                   type="button"
-                  className={`reshare-btn${hasReshared ? ' reshared' : ''}`}
+                  className={`pv-btn reshare-btn${hasReshared ? ' reshared' : ''}`}
                   onClick={handleReshare}
                   disabled={!authenticated || !isLoggedIn()}
                   title={!authenticated ? 'Log in to reshare' : hasReshared ? 'Reshared' : 'Reshare'}
                 >
                   <Repeat2 size={16} />
+                  <span>Reshare</span>
                   {reshareCount > 0 && <span className="reshare-count">{reshareCount}</span>}
                 </button>
 
                 {authenticated && isLoggedIn() && (
                   <button
                     type="button"
-                    className="promote-btn"
+                    className="pv-btn promote-btn"
                     onClick={() => setPromoteOpen(true)}
                     title="Promote this video"
                   >
@@ -1014,7 +1036,7 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
                 {authenticated && user === author && (
                   <button
                     type="button"
-                    className="edit-video-btn"
+                    className="pv-btn edit-video-btn"
                     onClick={() => {
                       videoControls?.onPause?.();
                       setIsEditOpen(true);
@@ -1027,17 +1049,18 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
 
                 <button
                   type="button"
-                  className={`report-btn${isReported('post', `${author}/${permlink}`) ? ' reported' : ''}`}
+                  className={`pv-btn report-btn${isReported('post', `${author}/${permlink}`) ? ' reported' : ''}`}
                   onClick={() => setIsReportOpen(true)}
                   title="Report video"
                 >
                   <MdFlag size={16} />
+                  <span>Report</span>
                 </button>
 
                 {isInWatchLater && (
                   <button
                     type="button"
-                    className={`watch-later-remove-btn ${isRemovingWatchLater ? 'loading' : ''}`}
+                    className={`pv-btn watch-later-remove-btn ${isRemovingWatchLater ? 'loading' : ''}`}
                     onClick={handleRemoveFromWatchLater}
                     disabled={isRemovingWatchLater}
                     title="Remove from Watch Later"
@@ -1051,10 +1074,14 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
 
                 {authenticated && isLoggedIn() && (
                   <>
-                    <button type="button" className="playlist-btn" onClick={() => setIsPlaylistModalOpen(true)} title="Add to playlist">
+                    <button type="button" className="pv-btn playlist-btn" onClick={() => setIsPlaylistModalOpen(true)} title="Add to playlist">
                       <MdPlaylistAdd />
+                      <span>Playlist</span>
                     </button>
-                    <Button text="Tip" prominent onClick={() => setIsTipModalOpen(true)} />
+                    <button type="button" className="pv-btn tip-btn" onClick={() => setIsTipModalOpen(true)} title="Tip the creator">
+                      <Gift size={16} />
+                      <span>Tip</span>
+                    </button>
                   </>
                 )}
 
@@ -1088,7 +1115,7 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
             <div className="tools-row mobile-only">
               <button
                 type="button"
-                className={`clip-btn${clipMode ? ' active' : ''}`}
+                className={`pv-btn clip-btn${clipMode ? ' active' : ''}`}
                 onClick={clipMode ? handleCancelClip : handleStartClipMode}
                 title={!authenticated ? 'Log in to clip' : clipMode ? 'Cancel clip' : 'Clip video'}
                 disabled={!authenticated}

--- a/src/components/playVideo/PlayVideo.scss
+++ b/src/components/playVideo/PlayVideo.scss
@@ -332,239 +332,87 @@
                 }
             }
 
+            // ---- Action bar: one row of pills, ordered. Vote · Tip · Reshare ·
+            // Clip on the left; the rest on the right with Report always last.
+            // The left/right groups are flattened (display:contents) so every
+            // button orders within the single row.
             .info-buttons-row {
                 display: flex;
+                flex-wrap: wrap;
                 align-items: center;
-                justify-content: space-between;
-                gap: 7px;
-                @include mix.respond(phone) {
-                    gap: 5px;
-                }
+                gap: 8px;
 
-                .info-buttons-left {
-                    display: flex;
-                    align-items: center;
-                    gap: 7px;
+                // On mobile the actions live in the FAB (speed-dial), so hide
+                // this inline bar entirely.
+                @include mix.respond(phone) { display: none; }
 
-                    @include mix.respond(phone) {
-                        display: none;
-                    }
-                }
+                .info-buttons-left,
+                .info-buttons-right { display: contents; }
 
-                .info-buttons-right {
-                    display: flex;
-                    align-items: center;
-                    gap: 7px;
-                    // Stay right-aligned even when the left (clip) group isn't
-                    // rendered — otherwise space-between would drop this group
-                    // to the left when the author disallows clipping.
-                    margin-left: auto;
-                    @include mix.respond(phone) {
-                        gap: 5px;
-                    }
-                }
+                .vote-btn   { order: 1; }
+                .tip-btn    { order: 2; }
+                .reshare-btn{ order: 3; }
+                .clip-btn   { order: 4; }
+                .share-btn  { order: 10; margin-left: auto; }
+                .promote-btn{ order: 12; }
+                .playlist-btn { order: 13; }
+                .summary-btn  { order: 14; }
+                .edit-video-btn { order: 15; }
+                .watch-later-remove-btn { order: 16; }
+                .report-btn { order: 99; }
             }
 
-            .watch-later-remove-btn {
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                padding: 4px 8px;
-                background-color: rgba(255, 255, 255, 0.1);
-                color: var(--text-secondary);
-                border: none;
-                border-radius: 5px;
-                font-size: 20px;
-                cursor: pointer;
-                transition: all 0.2s ease;
-
-                .watch-later-icon-wrap {
-                  position: relative;
-                  display: flex;
-                  align-items: center;
-                  justify-content: center;
-
-                  .x-badge {
-                    position: absolute;
-                    top: -6px;
-                    right: -8px;
-                    font-size: 12px;
-                    font-weight: 700;
-                    line-height: 1;
-                    background: rgba(255, 255, 255, 0.15);
-                    color: var(--text-secondary);
-                    width: 14px;
-                    height: 14px;
-                    border-radius: 50%;
-                    display: flex;
-                    align-items: center;
-                    justify-content: center;
-                  }
-                }
-
-                &:hover {
-                  background-color: var(--accent-primary);
-                  color: var(--text-inverse);
-
-                  .x-badge {
-                    background: rgba(0, 0, 0, 0.3);
-                    color: var(--text-inverse);
-                  }
-                }
-
-                &.loading {
-                  opacity: 0.5;
-                  cursor: not-allowed;
-                }
-            }
-            .playlist-btn {
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                padding: 4px 8px;
-                background-color: rgba(255, 255, 255, 0.1);
-                color: var(--text-secondary);
-                border: none;
-                border-radius: 5px;
-                font-size: 20px;
-                cursor: pointer;
-                transition: all 0.2s ease;
-
-                &:hover {
-                  background-color: var(--accent-primary);
-                  color: var(--text-inverse);
-                }
-            }
-
-            .share-btn {
+            // ====================================================================
+            // ONE button class for every action in the bar. All the per-button
+            // classes (.vote-btn, .share-btn, …) are kept ONLY for ordering/state
+            // above — the look lives here, in a single place.
+            // ====================================================================
+            .pv-btn {
                 display: inline-flex;
                 align-items: center;
-                padding: 4px 8px;
-                background-color: rgba(255, 255, 255, 0.1);
-                color: var(--text-secondary);
+                justify-content: center;
+                gap: 6px;
+                height: 36px;
+                padding: 0 14px;
                 border: none;
-                border-radius: 5px;
-                font-size: 13px;
-                cursor: pointer;
-                transition: all 0.2s ease;
-
-                &:hover {
-                  background-color: var(--accent-primary);
-                  color: var(--text-inverse);
-                }
-            }
-
-            .vote-btn,
-            .promote-btn,
-            .summary-btn {
-                display: inline-flex;
-                align-items: center;
-                gap: 5px;
-                padding: 4px 10px;
-                background-color: rgba(255, 255, 255, 0.1);
-                color: var(--text-secondary);
-                border: none;
-                border-radius: 5px;
-                font-size: 13px;
+                border-radius: 999px;
+                background: var(--bg-tertiary, rgba(127, 127, 127, 0.14));
+                color: var(--text-primary);
+                font-size: 14px;
                 font-weight: 500;
-                cursor: pointer;
-                transition: all 0.2s ease;
-
-                &:hover {
-                  background-color: var(--accent-primary);
-                  color: var(--text-inverse);
-                }
-            }
-
-            .promote-btn {
-                @include mix.respond(phone) { span { display: none; } }
-            }
-
-            .summary-btn {
+                line-height: 1;
                 white-space: nowrap;
-
-                @include mix.respond(phone) {
-                    // Keep just the icon on small screens to save room.
-                    span { display: none; }
-                }
-            }
-
-            .edit-video-btn {
-                display: inline-flex;
-                align-items: center;
-                padding: 4px 8px;
-                background-color: rgba(255, 255, 255, 0.1);
-                color: var(--text-secondary);
-                border: none;
-                border-radius: 5px;
-                font-size: 13px;
                 cursor: pointer;
-                transition: all 0.2s ease;
+                transition: background 0.15s ease, color 0.15s ease;
 
-                &:hover {
-                  background-color: var(--accent-primary);
-                  color: var(--text-inverse);
-                }
-            }
+                svg { flex-shrink: 0; }
+                span { font-size: 14px; font-weight: 500; }
 
-            .report-btn {
-                display: inline-flex;
-                align-items: center;
-                padding: 4px 8px;
-                background-color: rgba(255, 255, 255, 0.1);
-                color: var(--text-secondary);
-                border: none;
-                border-radius: 5px;
-                font-size: 13px;
-                cursor: pointer;
-                transition: all 0.2s ease;
+                &:hover { background: var(--border-color, rgba(127, 127, 127, 0.28)); }
+                &:disabled { opacity: 0.4; cursor: not-allowed; }
 
-                &:hover {
-                  background-color: var(--accent-primary);
-                  color: var(--text-inverse);
-                }
+                // State variants
+                &.reshared { background: rgba(34, 197, 94, 0.15); color: #22c55e; }
+                &.reported { background: rgba(227, 19, 55, 0.14); color: #e31337; }
+                &.active   { background: rgba(229, 57, 53, 0.16); color: var(--accent-primary); }
+                &.loading  { opacity: 0.5; cursor: not-allowed; }
 
-                &.reported {
-                  color: #e31337;
-                  background-color: rgba(227, 19, 55, 0.12);
+                .reshare-count { font-weight: 600; }
 
-                  &:hover {
-                    background-color: rgba(227, 19, 55, 0.2);
-                    color: #e31337;
-                  }
-                }
-            }
-
-            .reshare-btn {
-                display: inline-flex;
-                align-items: center;
-                gap: 4px;
-                padding: 4px 8px;
-                background-color: rgba(255, 255, 255, 0.1);
-                color: var(--text-secondary);
-                border: none;
-                border-radius: 5px;
-                font-size: 13px;
-                cursor: pointer;
-                transition: all 0.2s ease;
-
-                &:hover {
-                  background-color: var(--accent-primary);
-                  color: var(--text-inverse);
-                }
-
-                &.reshared {
-                  color: #22c55e;
-                  background-color: rgba(34, 197, 94, 0.12);
-
-                  &:hover {
-                    background-color: rgba(34, 197, 94, 0.2);
-                    color: #22c55e;
-                  }
-                }
-
-                .reshare-count {
-                  font-weight: 500;
+                // Watch-later "remove" badge sitting on the clock icon.
+                .watch-later-icon-wrap {
+                    position: relative;
+                    display: inline-flex;
+                    align-items: center;
+                    .x-badge {
+                        position: absolute;
+                        top: -7px; right: -9px;
+                        width: 14px; height: 14px;
+                        display: flex; align-items: center; justify-content: center;
+                        font-size: 11px; font-weight: 700; line-height: 1;
+                        border-radius: 50%;
+                        background: var(--accent-primary); color: #fff;
+                    }
                 }
             }
         }
@@ -575,8 +423,8 @@
         display: inline;
     }
 
-    .remix-btn,
-    .clip-btn {
+    // .clip-btn styling now lives in the unified .pv-btn rule above.
+    .remix-btn {
         display: inline-flex;
         align-items: center;
         justify-content: center;
@@ -593,27 +441,6 @@
         &:hover {
           background-color: var(--accent-primary);
           color: var(--text-inverse);
-        }
-
-        &.active {
-          color: var(--accent-primary);
-          background-color: rgba(var(--accent-primary-rgb, 255, 0, 0), 0.15);
-        }
-
-        &:disabled {
-          opacity: 0.35;
-          cursor: not-allowed;
-          &:hover {
-            background-color: rgba(255, 255, 255, 0.1);
-            color: var(--text-secondary);
-          }
-        }
-
-        @include mix.respond(phone) {
-            flex: 1;
-            padding: 6px 14px;
-            border-radius: 16px;
-            font-size: 13px;
         }
     }
 
@@ -665,17 +492,13 @@
         gap: 7px;
         margin-top: 8px;
 
+        // The mobile clip control uses the shared .pv-btn pill, full-width.
+        .pv-btn { flex: 1; }
+
+        // The mobile-only "Clip Video" entry button is redundant — the FAB
+        // already has Clip Video (the clip controls bar is separate). Hide it.
         &.mobile-only {
             display: none;
-
-            @include mix.respond(phone) {
-                display: flex;
-                gap: 8px;
-
-                .tools-row-label {
-                    display: inline;
-                }
-            }
         }
     }
 

--- a/src/page/Watch.jsx
+++ b/src/page/Watch.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo, useEffect, useCallback, useRef } from 'react';
 import { getHiveClient } from '../utils/hiveNode';
 import './Watch.scss';
+import './WatchV2.scss';
 import PlayVideo from '../components/playVideo/PlayVideo';
 import Card3 from '../components/Cards/Card3';
 import { useSearchParams, useLocation, useNavigate } from 'react-router-dom';
@@ -87,7 +88,7 @@ function filterValidVideos(videos) {
   });
 }
 
-function Watch() {
+function Watch({ v2 = false }) {
   const [searchParams] = useSearchParams();
   const location = useLocation();
   const navigate = useNavigate();
@@ -1085,9 +1086,10 @@ function Watch() {
   }
 
   return (
-    <div className={`play-container${isReactionPlayerVisible && reactions.length > 0 ? ` reaction-${reactionSize}` : ''}`}>
+    <div className={`play-container${isReactionPlayerVisible && reactions.length > 0 ? ` reaction-${reactionSize}` : ''}${v2 ? ' watch-v2' : ''}`}>
       <AmbientGlow getVideoEl={() => player?.element} glowMode={glowMode} />
       <PlayVideo
+        v2={v2}
         videoDetails={videoDetails}
         author={author}
         permlink={permlink}

--- a/src/page/WatchV2.scss
+++ b/src/page/WatchV2.scss
@@ -1,0 +1,221 @@
+@use "../mixins.scss" as *;
+
+/* ============================================================================
+   /watch2 — experimental YouTube-style desktop layout for the watch page.
+   Everything is scoped under .watch-v2 (the page root), which is an ancestor of
+   .play-video, so these rules outrank the existing deep PlayVideo.scss selectors
+   without touching the markup. Original /watch is unaffected.
+   Desktop-first: phone keeps the existing layout (these mostly apply >=768px).
+   ============================================================================ */
+
+.watch-v2 {
+  // YouTube-ish design tokens (theme-aware via existing CSS vars).
+  --v2-pill-bg: var(--bg-tertiary, rgba(127, 127, 127, 0.14));
+  --v2-pill-bg-hover: var(--border-color, rgba(127, 127, 127, 0.28));
+  --v2-card-bg: var(--bg-secondary, rgba(127, 127, 127, 0.08));
+  --v2-radius: 12px;
+
+  /* ---- Stats row (posted-ago · views · rewards · votes) — shared flex styling
+     so it's a single row on BOTH desktop and mobile. It was relocated out of
+     .play-video-info into the title meta, so it loses the original flex rules. */
+  .play-video .pv2-title-meta {
+    .info-stats-row {
+      display: flex;
+      flex-flow: row wrap;
+      align-items: center;
+      gap: 14px;
+      font-size: 13px;
+      color: var(--text-secondary);
+    }
+    .wrap-left { display: flex; align-items: center; gap: 14px; margin: 0; }
+    .wrap-left .wrap { display: inline-flex; align-items: center; gap: 4px; order: -1; }
+    .wrap-right-stats { display: flex; align-items: center; gap: 14px; margin: 0; }
+    .wrap-right-stats .wrap { display: inline-flex; align-items: center; margin-left: 0; }
+  }
+
+  /* ---- Mobile: the action buttons live in the FAB, so hide the inline pill
+     row; show the stats as a row directly under the title. ---- */
+  @include respond(phone) {
+    // (The action bar is hidden on mobile in PlayVideo.scss — the FAB owns it.)
+    .play-video .video-title-row { flex-wrap: wrap; }
+    .play-video .pv2-title-meta {
+      flex-basis: 100%;
+      width: 100%;
+      order: 5;
+      margin-top: 6px;
+      .info-stats-row { justify-content: flex-start; }
+    }
+  }
+
+  @media screen and (min-width: 768px) {
+    align-items: flex-start;
+
+    /* ---- Main column: drop the big card wrapper so the player + meta sit
+       flush on the page, YouTube-style (less boxed-in / less cluttered). ---- */
+    .play-video .top-container {
+      padding: 0;
+      background: transparent;
+      box-shadow: none;
+      border-radius: 0;
+      overflow: visible;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .play-video .video-iframe-wrapper {
+      border-radius: var(--v2-radius);
+      overflow: hidden;
+      background: #000;
+    }
+
+    /* ---- Title: larger and bolder, with views + age aligned right ---- */
+    .play-video .video-title-row {
+      margin-top: 14px;
+      order: 1;
+      align-items: flex-start;
+
+      h3 {
+        font-size: 20px;
+        font-weight: 700;
+        line-height: 1.3;
+      }
+    }
+    .play-video .mobile-title-toggle { display: none; }
+
+    /* All indicators (views · age · payout · likes) on one row, right of title. */
+    .play-video .pv2-title-meta {
+      flex-shrink: 0;
+      margin-top: 4px;
+
+      // The block was relocated out of .play-video-info, so it loses the
+      // original flex styling (which was scoped to that location) — re-apply it
+      // here so the indicators sit on one row instead of stacking as blocks.
+      .info-stats-row {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 14px;
+        font-size: 13px;
+        color: var(--text-secondary);
+        white-space: nowrap;
+      }
+      .wrap-left {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        margin: 0;
+      }
+      // Order: posted-ago, then views (the time .wrap sits before ViewCount).
+      .wrap-left .wrap {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        order: -1;
+      }
+      .wrap-right-stats {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        margin: 0;
+      }
+      .wrap-right-stats .wrap {
+        display: inline-flex;
+        align-items: center;
+        margin-left: 0;
+      }
+    }
+
+    /* The mobile collapse wrapper: row-wrap so the channel row and hashtags share
+       a line (tags sit to the right of the community pill, saving vertical space)
+       and the action/stats block drops to its own line below. */
+    .play-video .video-details-collapsible {
+      order: 2;
+      display: flex;
+      flex-flow: row wrap;
+      align-items: center;
+      column-gap: 14px;
+      row-gap: 12px;
+      margin-top: 12px;
+    }
+
+    /* ---- Channel row: avatar + name + followers + Follow, then community ---- */
+    .play-video .badges-row {
+      order: 1;
+      flex: 0 1 auto;
+      align-items: center;
+      gap: 12px;
+      margin: 0;
+    }
+
+    /* ---- Hashtags: subtle chips, right-aligned. NOTE: the original CSS sets
+       .tag-wrapper { display: contents }, so the chips are direct flex children
+       of .community-tags-row — the right-alignment must live there, not on the
+       wrapper. ---- */
+    .play-video .community-tags-row {
+      order: 2;
+      flex: 1 1 auto;
+      min-width: 0;
+      justify-content: flex-end;
+
+      .tag-wrapper span {
+        background: var(--v2-pill-bg);
+        color: var(--text-secondary);
+        padding: 3px 10px;
+        border: none;
+        border-radius: 999px;
+        margin-right: 0;
+        font-size: 12px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: background 0.15s ease;
+        &:hover { background: var(--v2-pill-bg-hover); }
+      }
+      .tag-wrapper .curated-tag {
+        background: var(--v2-pill-bg);
+        color: var(--text-primary);
+      }
+    }
+
+    .play-video .play-video-info {
+      order: 3;
+      flex: 1 1 100%;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    /* The action bar (one .pv-btn pill class + ordering) now lives in
+       PlayVideo.scss as the default — no v2 overrides needed here.
+       The stats row lives beside the title — see .pv2-title-meta above. */
+    .play-video .info-buttons-row { order: 1; }
+
+    /* ---- Description: a rounded card (expandable), like YouTube ---- */
+    .play-video .description-wrap {
+      order: 3;
+      margin-top: 12px;
+
+      .description-collapsible {
+        background: var(--v2-card-bg);
+        border-radius: var(--v2-radius);
+        padding: 12px 14px;
+      }
+      .description-toggle-btn {
+        margin-top: 8px;
+        font-weight: 600;
+        color: var(--text-primary);
+      }
+    }
+
+    /* ---- Comments: a touch of separation ---- */
+    .play-video .comment-section,
+    .play-video > .top-container > :last-child { margin-top: 16px; }
+
+    /* ---- Right column ("More videos") — tighter, list-like ---- */
+    .right-column .right-column-videos h4 {
+      font-size: 16px;
+      font-weight: 700;
+      margin: 0 0 12px;
+    }
+  }
+}


### PR DESCRIPTION
Reworked the watch page (now the default /watch):
- Player sits flush; bigger title with views/age/payout/votes as one row beside it (desktop) or under the title (mobile); channel row + right-aligned tags; rounded description card.
- One shared .pv-btn pill class for every action button (Vote, Tip, Reshare, Clip, Share, Promote, Playlist, Report, …) — removed the per-button styles and the specificity hacks. Ordered Vote/Tip/Reshare/Clip left, rest right, Report last. Tip gets a gift icon.
- Mobile: the inline action bar and the redundant Clip Video tools-row are hidden (the FAB owns actions); stats show as a row under the title.
- Fix view counter: read from the checker /views (same source as the cards) instead of the dead apiv2 endpoint.

New layout lives behind the watch-v2 class (WatchV2.scss); the button refactor is the default in PlayVideo.scss.