### PR TITLE
docs(changelog): cleaner desktop watch-page layout (v1.36.0)

### DIFF
--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.36.0',
+    date: '2026-06-26',
+    summary:
+      'The video watch page has a cleaner desktop layout: the player sits flush at the top, the title shows views, age, rewards and votes beside it, and all the action buttons (Vote, Tip, Reshare, Clip, Share, Promote, Playlist, Report) are now consistent pill buttons in one tidy row, with the description in a rounded card below.',
+  },
+  {
     version: '1.35.0',
     date: '2026-06-26',
     summary:

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.35.0';
+export const APP_VERSION = '1.36.0';


### PR DESCRIPTION
Add changelog entry + bump APP_VERSION 1.35.0 -> 1.36.0 for the watch-page redesign (flush player, title with inline stats, unified pill action buttons, description card).