### PR TITLE
Feat/multi embed

### DIFF
--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,18 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.38.0',
+    date: '2026-07-04',
+    summary:
+      'Tags are handled more consistently everywhere. The uploader now shows a live tag count and includes the community tag right in your tag list, so the total can never sneak past 10, and it no longer adds hidden “3speak” or “short” tags. The Edit page uses the same limit, and the community tag is shown but can’t be removed.',
+  },
+  {
+    version: '1.37.0',
+    date: '2026-07-04',
+    summary:
+      'You can now edit your own shorts. Open a short you posted and tap Edit to change its description, tags, thumbnail and settings (unlist/re-list, mark adult/NSFW). Unlisted shorts now also show on your own profile with an “Unlisted” badge so you can find and re-list them.',
+  },
+  {
     version: '1.36.0',
     date: '2026-06-26',
     summary:

--- a/src/components/Userprofilepage/UserProfilePage.jsx
+++ b/src/components/Userprofilepage/UserProfilePage.jsx
@@ -168,7 +168,8 @@ const {
 
             // Shorts feed for this user
             const fetchUserShorts = async ({ pageParam = 1 }) => {
-              const data = await fetchUserShortsWithDetails(user, pageParam, 20);
+              // On your own profile, include unlisted shorts (badged) so they can be re-listed.
+              const data = await fetchUserShortsWithDetails(user, pageParam, 20, isOwnProfile);
               return data;
             };
 
@@ -179,7 +180,7 @@ const {
               isFetchingNextPage: isFetchingNextShortsPage,
               isLoading: isShortsLoading,
             } = useInfiniteQuery({
-              queryKey: ["UserShorts", user],
+              queryKey: ["UserShorts", user, isOwnProfile],
               queryFn: fetchUserShorts,
               getNextPageParam: (lastPage) => {
                 if (lastPage?.page < lastPage?.totalPages) {
@@ -205,6 +206,7 @@ const {
                     num_votes: s.stats?.likes || 0,
                   },
                   created_at: s.createdAt,
+                  unlisted: s.unlisted, // Card3 shows the "Unlisted" badge
                 }))
               )
             ), [shortsData?.pages]);

--- a/src/components/embed-studio/EmbedDetails.jsx
+++ b/src/components/embed-studio/EmbedDetails.jsx
@@ -119,6 +119,17 @@ function EmbedDetails() {
   };
 
 
+  // Auto taxonomy tags that we add + show in the list and count toward the
+  // 10-tag limit. Only the community tag is added automatically — no '3speak',
+  // no 'short' (shorts are identified by the embed-video `short` DB field).
+  // The community tag counts so the total can't exceed 10.
+  const communityTag = typeof community === 'string'
+    ? (community || 'hive-181335')
+    : (community?.name || 'hive-181335');
+  const autoTags = fromStories ? ['hive-181335'] : [communityTag];
+  const maxUserTags = Math.max(0, 10 - autoTags.length);
+  const allTags = [...autoTags, ...tagsPreview.filter((t) => !autoTags.includes(t))];
+
   const handleTagChange = (e) => {
     const value = e.target.value.toLowerCase();
 
@@ -127,10 +138,10 @@ function EmbedDetails() {
       .split(/\s+/)
       .filter(Boolean);
 
-    const uniqueTags = [...new Set(tags)];
+    const uniqueTags = [...new Set(tags)].filter((t) => !autoTags.includes(t));
 
-    if (uniqueTags.length > 10) {
-      toast.error("You can add a maximum of 10 tags");
+    if (uniqueTags.length > maxUserTags) {
+      toast.error(`You can add up to ${maxUserTags} tags — the community tag is added automatically.`);
       return;
     }
 
@@ -182,20 +193,30 @@ function EmbedDetails() {
               </div>
 
               <div className="input-group">
-                <label htmlFor="">Tag</label>
+                <label htmlFor="">
+                  Tag
+                  <span
+                    className="tag-count"
+                    style={{ marginLeft: 8, fontSize: 12, color: allTags.length >= 10 ? '#e0a852' : 'var(--text-muted, #888)' }}
+                  >
+                    {allTags.length}/10 tags{!fromStories ? ' · at least 1 required' : ''}
+                  </span>
+                </label>
                 <input type="text" value={tagsInputValue} onChange={handleTagChange} />
 
                 <div className="wrap">
                   <span>Separate multiple tags with </span> <span>Space</span>
                 </div>
-                {/* Show the tags — shorts get the hardcoded shorts taxonomy prepended;
-                    regular video uploads only show what the user actually typed. */}
+                {/* The community (and 'short' for shorts) is added automatically —
+                    shown here as a pinned tag and counted toward the 10-tag limit. */}
                 <div className="preview-tags">
-                  <span>{(fromStories
-                      ? ['3speak', 'hive-181335', 'short', ...tagsPreview.filter(t => !['3speak', 'hive-181335', 'short'].includes(t))]
-                      : tagsPreview
-                    ).map((item, index) => (
-                    <span className="item" key={index} style={{ marginRight: '8px' }}>
+                  <span>{allTags.map((item, index) => (
+                    <span
+                      className={`item${index < autoTags.length ? ' item--auto' : ''}`}
+                      key={index}
+                      style={index < autoTags.length ? { opacity: 0.75, fontStyle: 'italic' } : undefined}
+                      title={index < autoTags.length ? 'Added automatically' : undefined}
+                    >
                       {item}
                     </span>
                   ))}</span>

--- a/src/components/embed-studio/EmbedPreview.jsx
+++ b/src/components/embed-studio/EmbedPreview.jsx
@@ -171,7 +171,7 @@ function EmbedPreview() {
                     {tagsPreview && tagsPreview.length > 0 ? (
                       <span className="ep-tags">
                         {tagsPreview.map((tag, index) => (
-                          <span className="ep-tag" key={index}>#{tag}</span>
+                          <span className="ep-tag" key={index}>{tag}</span>
                         ))}
                       </span>
                     ) : <span className="ep-muted">None</span>}

--- a/src/components/legacy-studio/StudioPage.scss
+++ b/src/components/legacy-studio/StudioPage.scss
@@ -198,6 +198,11 @@
       }
       .preview-tags {
         margin-top: 5px;
+        > span {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 6px;
+        }
         span {
           font-size: 14.45px;
           font-weight: 500;

--- a/src/components/playVideo/EditVideoModal.jsx
+++ b/src/components/playVideo/EditVideoModal.jsx
@@ -98,7 +98,7 @@ function recombinePostBody(header, middle, footer) {
  * @param {string} permlink
  * @param {(changes: { title, body, tags, thumbnail }) => void} onSaved
  */
-export default function EditVideoModal({ isOpen, onClose, author, permlink, onSaved }) {
+export default function EditVideoModal({ isOpen, onClose, author, permlink, onSaved, isShort = false }) {
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [loadError, setLoadError] = useState(null);
@@ -112,6 +112,10 @@ export default function EditVideoModal({ isOpen, onClose, author, permlink, onSa
   const [bodyHeader, setBodyHeader] = useState(''); // 3Speak thumb+link header, rewrite thumb on save
   const [bodyFooter, setBodyFooter] = useState(''); // trailing 3Speak link
   const [tagsInput, setTagsInput] = useState('');
+  // Auto-added taxonomy tags (3speak, the community/category, short) kept aside
+  // so the editable tag count matches the uploader (which validates only the
+  // user's own tags). Re-prepended on save.
+  const [systemTags, setSystemTags] = useState([]);
   const [thumbnailUrl, setThumbnailUrl] = useState('');
   const [thumbUploading, setThumbUploading] = useState(false);
   const thumbInputRef = useRef(null);
@@ -125,6 +129,7 @@ export default function EditVideoModal({ isOpen, onClose, author, permlink, onSa
   const initialListedRef = useRef(true);
   const initialNsfwRef = useRef(false);
   const initialReusableRef = useRef(true);
+  const initialThumbRef = useRef(''); // loaded thumbnail baseline (for dirty check)
 
   // Fetch original post when modal opens
   useEffect(() => {
@@ -169,12 +174,20 @@ export default function EditVideoModal({ isOpen, onClose, author, permlink, onSa
         setBody(middle);
         setBodyHeader(header);
         setBodyFooter(footer);
-        // Strip the canonical `nsfw` tag from the editable tags — it's driven by
-        // the Adult/NSFW toggle instead.
-        const visibleTags = metaTags.filter((t) => String(t).toLowerCase() !== 'nsfw');
         const tagNsfw = metaTags.some((t) => String(t).toLowerCase() === 'nsfw');
-        setTagsInput(visibleTags.join(' '));
+        // Separate the auto-added taxonomy (3speak, community/category, short)
+        // and the nsfw flag from the user's own tags, so the count/limit here
+        // matches the uploader (which validates only the user tags and prepends
+        // the taxonomy). The taxonomy is preserved and re-added on save.
+        const category = String(post.category || '').toLowerCase();
+        const isSystemTag = (t) => {
+          const lc = String(t).toLowerCase();
+          return lc === '3speak' || lc === 'short' || lc === 'nsfw' || lc === category;
+        };
+        setSystemTags(metaTags.filter((t) => isSystemTag(t) && String(t).toLowerCase() !== 'nsfw'));
+        setTagsInput(metaTags.filter((t) => !isSystemTag(t)).join(' '));
         setThumbnailUrl(currentThumb);
+        initialThumbRef.current = currentThumb;
         const metaReusable = meta.video?.reusable !== false;
         setReusable(metaReusable);
         initialReusableRef.current = metaReusable;
@@ -192,6 +205,13 @@ export default function EditVideoModal({ isOpen, onClose, author, permlink, onSa
             setPromotedUntil(doc.promotedUntil || null);
             initialListedRef.current = isListed;
             initialNsfwRef.current = nsfw;
+            // Shorts store their thumbnail on the checker (not the video
+            // sourceMap), so use it as the current thumbnail when none was found
+            // in the post metadata.
+            if (isShort && doc.thumbnail_url) {
+              setThumbnailUrl((prev) => prev || doc.thumbnail_url);
+              if (!initialThumbRef.current) initialThumbRef.current = doc.thumbnail_url;
+            }
           } else if (!cancelled) {
             setIsNsfw(tagNsfw);
             initialNsfwRef.current = tagNsfw;
@@ -219,7 +239,9 @@ export default function EditVideoModal({ isOpen, onClose, author, permlink, onSa
     setBodyHeader('');
     setBodyFooter('');
     setTagsInput('');
+    setSystemTags([]);
     setThumbnailUrl('');
+    initialThumbRef.current = '';
     setLoadError(null);
     setSaving(false);
     setListed(true);
@@ -245,16 +267,25 @@ export default function EditVideoModal({ isOpen, onClose, author, permlink, onSa
 
   // Validation
   const titleLen = title.trim().length;
-  const titleValid = titleLen >= TITLE_MIN && titleLen <= TITLE_MAX;
-  const tagsValid = parsedTags.length > 0 && parsedTags.length <= MAX_TAGS;
+  // Shorts don't require a long title or any user tags (they carry a caption and
+  // the fixed shorts taxonomy) — relax those minimums for shorts.
+  const titleValid = titleLen <= TITLE_MAX && (isShort || titleLen >= TITLE_MIN);
+  // The preserved taxonomy (community, short, …) counts toward the 10-tag limit,
+  // so the user can add up to (10 − taxonomy) of their own — matching the uploader.
+  const userTagLimit = Math.max(1, MAX_TAGS - systemTags.length);
+  const tagsValid = parsedTags.length <= userTagLimit && (isShort || parsedTags.length > 0);
   const bodyValid = body.trim().length > 0;
   const canSave = titleValid && tagsValid && bodyValid && !!original && !saving;
 
-  // Final on-chain tags = visible tags + the canonical `nsfw` tag when marked adult.
+  // Final on-chain tags = preserved taxonomy + the user's tags + the canonical
+  // `nsfw` tag when marked adult (deduped, taxonomy first — same shape the
+  // uploader produces).
   const finalTags = useMemo(() => {
-    const base = parsedTags.filter((t) => t !== 'nsfw');
-    return isNsfw ? [...base, 'nsfw'] : base;
-  }, [parsedTags, isNsfw]);
+    const sys = systemTags.filter((t) => String(t).toLowerCase() !== 'nsfw');
+    const user = parsedTags.filter((t) => t !== 'nsfw');
+    const combined = [...new Set([...sys, ...user])];
+    return isNsfw ? [...combined, 'nsfw'] : combined;
+  }, [systemTags, parsedTags, isNsfw]);
 
   // On-chain content change (needs a Hive broadcast). Includes the nsfw tag.
   const contentDirty = useMemo(() => {
@@ -274,7 +305,7 @@ export default function EditVideoModal({ isOpen, onClose, author, permlink, onSa
       title.trim() !== (original.post.title || '').trim() ||
       body !== origMiddle ||
       finalTags.join(' ') !== origTags.join(' ') ||
-      thumbnailUrl.trim() !== origThumb ||
+      thumbnailUrl.trim() !== (origThumb || initialThumbRef.current || '').trim() ||
       reusable !== origReusable
     );
   }, [original, title, body, finalTags, thumbnailUrl, reusable]);
@@ -494,7 +525,8 @@ export default function EditVideoModal({ isOpen, onClose, author, permlink, onSa
               Upload an image or paste a direct URL. Leave unchanged to keep the current thumbnail.
             </span>
 
-            {/* Title */}
+            {/* Title — hidden for shorts (they use their caption/description). */}
+            {!isShort && <>
             <label className="edit-video-label">Title</label>
             <input
               type="text"
@@ -504,8 +536,9 @@ export default function EditVideoModal({ isOpen, onClose, author, permlink, onSa
               maxLength={TITLE_MAX}
             />
             <span className={`edit-video-hint${!titleValid && title ? ' error' : ''}`}>
-              {titleLen}/{TITLE_MAX} · min {TITLE_MIN}
+              {titleLen}/{TITLE_MAX}{isShort ? '' : ` · min ${TITLE_MIN}`}
             </span>
+            </>}
 
             {/* Tags */}
             <label className="edit-video-label">Tags</label>
@@ -517,10 +550,22 @@ export default function EditVideoModal({ isOpen, onClose, author, permlink, onSa
               placeholder="space-separated"
             />
             <div className="edit-video-tags-preview">
-              {parsedTags.map((t) => <span key={t}>#{t}</span>)}
+              {/* Auto-added taxonomy (community/category) — shown pinned and can't
+                  be removed; it's always preserved on save. */}
+              {systemTags.map((t) => (
+                <span
+                  key={`sys-${t}`}
+                  className="tag--auto"
+                  title="Added automatically — can't be removed"
+                  style={{ opacity: 0.7, fontStyle: 'italic' }}
+                >
+                  {t}
+                </span>
+              ))}
+              {parsedTags.map((t) => <span key={t}>{t}</span>)}
             </div>
             <span className={`edit-video-hint${!tagsValid && parsedTags.length ? ' error' : ''}`}>
-              {parsedTags.length}/{MAX_TAGS} tags · at least 1 required
+              {parsedTags.length}/{userTagLimit} tags{isShort ? '' : ' · at least 1 required'}
             </span>
 
             {/* Body */}
@@ -551,6 +596,7 @@ export default function EditVideoModal({ isOpen, onClose, author, permlink, onSa
                 </span>
               </button>
 
+              {!isShort && (
               <button
                 type="button"
                 role="switch"
@@ -565,6 +611,7 @@ export default function EditVideoModal({ isOpen, onClose, author, permlink, onSa
                   <small>{reusable ? 'Others can create remixes/clips; you are credited as original author.' : 'Others cannot remix or clip this video.'}</small>
                 </span>
               </button>
+              )}
 
               <button
                 type="button"
@@ -581,6 +628,7 @@ export default function EditVideoModal({ isOpen, onClose, author, permlink, onSa
                 </span>
               </button>
 
+              {!isShort && (
               <button
                 type="button"
                 className="evm-promote-btn"
@@ -590,6 +638,7 @@ export default function EditVideoModal({ isOpen, onClose, author, permlink, onSa
                 <Rocket size={16} />
                 {promotedUntil && new Date(promotedUntil).getTime() > Date.now() ? 'Promoted' : 'Promote video'}
               </button>
+              )}
             </div>
 
             <div className="edit-video-actions">

--- a/src/components/playVideo/PlayVideo.jsx
+++ b/src/components/playVideo/PlayVideo.jsx
@@ -1044,6 +1044,7 @@ const PlayVideo = ({ videoDetails, author, permlink, playlistData, onClosePlayli
                     title="Edit video details"
                   >
                     <MdEdit size={16} />
+                    <span>Edit</span>
                   </button>
                 )}
 

--- a/src/context/EmbedUploadContext.jsx
+++ b/src/context/EmbedUploadContext.jsx
@@ -613,13 +613,13 @@ export function EmbedUploadProvider({ children }) {
         : `/watch?v=${user}/${hivePermlink}`;
       postBody += `\n\n---\n▶ [Watch on 3speak.tv](https://3speak.tv${watchPath})`;
 
-      // Tag taxonomy differs by upload type:
-      //   - shorts: forced ['3speak', 'hive-181335', 'short', ...userTags]
-      //   - regular video: ['3speak', communityTag, ...userTags] — uses the actually-
-      //     selected community, no 'short' tag.
+      // Only the community tag is added automatically (no '3speak', no 'short').
+      // Shorts are identified by the embed-video `short` DB field, not a Hive tag.
+      // The community tag is surfaced in the uploader's tag list and counts toward
+      // the 10-tag limit, so the total never exceeds 10.
       const baseTags = fromStories
-        ? ['3speak', 'hive-181335', 'short']
-        : ['3speak', communityTag];
+        ? ['hive-181335']
+        : [communityTag];
       // When marked adult, append the canonical Hive `nsfw` tag so the whole Hive
       // ecosystem (and our hive_tags filter) treats it as NSFW.
       const userTags = [

--- a/src/context/EmbedUploadContext.jsx
+++ b/src/context/EmbedUploadContext.jsx
@@ -31,12 +31,23 @@ function endpointSupportsResume(endpoint) {
 function getConnectionProfile() {
   const c = (typeof navigator !== 'undefined' &&
     (navigator.connection || navigator.mozConnection || navigator.webkitConnection)) || null;
-  if (!c) return { weak: false };
+  // No Network Information API (Firefox/Safari) → we can't measure the link, so
+  // be conservative and treat it as weak. Parallel multi-part uploads strand at
+  // 0% on slow/flaky mobile links, and we'd rather a reliable sequential upload
+  // than an aggressive one that never gets a byte through.
+  if (!c) return { weak: true, effectiveType: 'unknown' };
   const et = String(c.effectiveType || '');
-  const weak = /(slow-2g|2g|3g)/i.test(et) ||
-    (Number.isFinite(c.downlink) && c.downlink > 0 && c.downlink < 1.5) ||
+  const dl = Number(c.downlink);        // Mbps (optimistic estimate)
+  const rtt = Number(c.rtt);            // ms
+  // downlink/effectiveType read optimistically on mobile (a flaky 4G still says
+  // "4g"), so lean toward "weak": anything below 4g, < 3 Mbps, high latency, or
+  // Data Saver on.
+  const weak =
+    /(slow-2g|2g|3g)/i.test(et) ||
+    (Number.isFinite(dl) && dl > 0 && dl < 3) ||
+    (Number.isFinite(rtt) && rtt > 400) ||
     !!c.saveData;
-  return { weak, effectiveType: et, downlink: c.downlink, saveData: !!c.saveData };
+  return { weak, effectiveType: et, downlink: dl, rtt, saveData: !!c.saveData };
 }
 
 const EmbedUploadContext = createContext(null);
@@ -310,10 +321,14 @@ export function EmbedUploadProvider({ children }) {
       // Thin/flaky/metered uplink: small SEQUENTIAL chunks. Each PATCH finishes
       // well inside the server read-timeout, a drop loses little, and we avoid the
       // multi-stream contention that caused the read-timeout/interrupt cascade.
-      chunkSize = 5 * MB; parallelUploads = 1;
-    } else if (sizeBytes > 500 * MB) { chunkSize = 20 * MB; parallelUploads = 3; }
-    else if (sizeBytes > 50 * MB) { chunkSize = 10 * MB; parallelUploads = 3; }
-    else { chunkSize = 5 * MB; parallelUploads = 2; }
+      chunkSize = 4 * MB; parallelUploads = 1;
+    }
+    // Parallel multi-part uploads split the uplink N ways and each part is a
+    // separate upload that can strand — great on a fat pipe, fragile otherwise.
+    // Cap at 2 and keep chunks modest so a stall costs little and resumes fast.
+    else if (sizeBytes > 500 * MB) { chunkSize = 16 * MB; parallelUploads = 2; }
+    else if (sizeBytes > 50 * MB) { chunkSize = 8 * MB; parallelUploads = 2; }
+    else { chunkSize = 5 * MB; parallelUploads = 1; }
 
     // Cross-session resume only on tusd-backed hosts (see endpointSupportsResume).
     const resumable = endpointSupportsResume(uploadEndpoint);

--- a/src/hive-api/hiveApi.js
+++ b/src/hive-api/hiveApi.js
@@ -716,8 +716,9 @@ export async function fetchShortsWithDetails(page = 1, limit = 10, loggedInUser 
    User-specific shorts feed
 ------------------------------ */
 
-export async function fetchUserShortsList(username, page = 1, limit = 20) {
-  const url = appendNsfw(`${USER_SHORTS_API}/${username}?page=${page}&limit=${limit}`, useAppStore.getState().showNsfw);
+export async function fetchUserShortsList(username, page = 1, limit = 20, includeUnlisted = false) {
+  let url = appendNsfw(`${USER_SHORTS_API}/${username}?page=${page}&limit=${limit}`, useAppStore.getState().showNsfw);
+  if (includeUnlisted) url += '&include_unlisted=1';
   const response = await axios.get(url);
 
   // Index results in the same maps so findShortByPermlink works
@@ -731,8 +732,8 @@ export async function fetchUserShortsList(username, page = 1, limit = 20) {
   return response.data;
 }
 
-export async function fetchUserShortsWithDetails(username, page = 1, limit = 20) {
-  const shortsList = await fetchUserShortsList(username, page, limit);
+export async function fetchUserShortsWithDetails(username, page = 1, limit = 20, includeUnlisted = false) {
+  const shortsList = await fetchUserShortsList(username, page, limit, includeUnlisted);
 
   if (!shortsList?.shorts) {
     throw new Error("Failed to fetch user shorts list");
@@ -774,6 +775,7 @@ export async function fetchUserShortsWithDetails(username, page = 1, limit = 20)
       commentsLoaded: false,
       isLiked: false,
       isDisliked: false,
+      unlisted: s.unlisted === true, // owner's own profile can badge + re-list
       _enriched: false,
     };
   });

--- a/src/page/ProfilePage.jsx
+++ b/src/page/ProfilePage.jsx
@@ -317,7 +317,8 @@ function ProfilePage() {
      SHORTS FEED
   =============================== */
   const fetchMyShorts = async ({ pageParam = 1 }) => {
-    const data = await fetchUserShortsWithDetails(user, pageParam, 20);
+    // Own profile: include unlisted shorts (badged) so they can be re-listed.
+    const data = await fetchUserShortsWithDetails(user, pageParam, 20, true);
     return data;
   };
 
@@ -352,6 +353,7 @@ function ProfilePage() {
           num_votes: s.stats?.likes || 0,
         },
         created_at: s.createdAt,
+        unlisted: s.unlisted, // Card3 shows the "Unlisted" badge
       }))
     )
   ), [shortsData?.pages]);

--- a/src/page/Short.jsx
+++ b/src/page/Short.jsx
@@ -30,6 +30,7 @@ import {
   RotateCcw,
   Repeat2,
   WandSparkles,
+  Pencil,
   Moon,
   Lightbulb,
   Sun,
@@ -81,6 +82,7 @@ import { getVotePower, getDynamicProps } from '../utils/hiveUtils';
 import { commentWithAioha, isLoggedIn } from '../hive-api/aioha';
 import AmbientGlow, { useAmbientGlow } from '../components/AmbientGlow/AmbientGlow';
 import EditorModal from '../components/modal/EditorModal';
+import EditVideoModal from '../components/playVideo/EditVideoModal';
 import { notifyMediaPlay, onMediaPlay } from '../utils/mediaCoordinator';
 import HiveAvatar from '../components/HiveAvatar/HiveAvatar';
 
@@ -217,6 +219,7 @@ const VideoShort = () => {
 
   // Editor modal state
   const [showEditorModal, setShowEditorModal] = useState(false);
+  const [isEditShortOpen, setIsEditShortOpen] = useState(false);
   const [editorVideoUrl, setEditorVideoUrl] = useState(null);
   const [editorVideoName, setEditorVideoName] = useState(null);
   const [editorOriginalAuthor, setEditorOriginalAuthor] = useState(null);
@@ -761,10 +764,22 @@ const VideoShort = () => {
     const videoId = currentVid.id;
     (async () => {
       try {
+        // On a deep-link the short arrives without embed_url/hivePermlink, so the
+        // Hive post can't be resolved (embed_url would be "@author/undefined").
+        // Fetch the real embed link from the checker first.
+        let embedUrl = currentVid.embedUrl;
+        let hivePermlink = currentVid.hivePermlink;
+        if (!embedUrl) {
+          try {
+            const d = await fetch(`${import.meta.env.VITE_CHECKER_URL}/videodetails/${currentVid.author}/${currentVid.permlink}`).then(r => (r.ok ? r.json() : {}));
+            if (d?.embed_url) embedUrl = d.embed_url;
+            if (d?.hive_permlink) hivePermlink = d.hive_permlink;
+          } catch { /* ignore */ }
+        }
         const shortItem = {
           owner: currentVid.author,
           permlink: currentVid.permlink,
-          embed_url: currentVid.embedUrl || `@${currentVid.author}/${currentVid.hivePermlink}`,
+          embed_url: embedUrl || `@${currentVid.author}/${hivePermlink}`,
           thumbnail_url: currentVid.thumbnailUrl || '',
           views: currentVid.stats?.views || currentVid.views || 0,
           createdAt: currentVid.createdAt || '',
@@ -785,6 +800,10 @@ const VideoShort = () => {
             reactionChain: enriched.reactionChain || null,
             childReactions: enriched.childReactions || null,
             reusable: enriched.reusable,
+            // Carry the resolved Hive permlink/embed link so the edit button and
+            // its modal work on deep-linked shorts, not just from the profile.
+            hivePermlink: enriched.hivePermlink || hivePermlink,
+            embedUrl: enriched.embedUrl || embedUrl,
             hivePostMissing: enriched.hivePostMissing,
             _enriched: true,
           };
@@ -929,6 +948,27 @@ const VideoShort = () => {
             let actualShort = await hiveApi.findShortByPermlink(sharedVideo.permlink);
             if (!actualShort) {
               actualShort = await hiveApi.findShortByEmbedUrl(sharedVideo.author, sharedVideo.permlink);
+            }
+            // findShort* only scans the shorts feed, so a direct-linked short that
+            // isn't in the feed (or is beyond the scanned pages) isn't found and we
+            // fall back to "@author/<assetId>" — which can't resolve the Hive post
+            // (breaks edit/vote). The checker's /videodetails authoritatively maps
+            // the asset id → embed_url + Hive permlink, so use it as a fallback.
+            if (!actualShort) {
+              try {
+                const d = await fetch(`${import.meta.env.VITE_CHECKER_URL}/videodetails/${sharedVideo.author}/${sharedVideo.permlink}`).then(r => (r.ok ? r.json() : null));
+                if (d && d.owner && d.embed_url) {
+                  actualShort = {
+                    owner: d.owner,
+                    permlink: d.permlink,
+                    embed_url: d.embed_url,
+                    thumbnail_url: d.thumbnail_url || '',
+                    views: d.views || 0,
+                    createdAt: d.createdAt || new Date().toISOString(),
+                    embed_title: d.embed_title || d.hive_title || '',
+                  };
+                }
+              } catch { /* ignore — falls through to the minimal shortItem below */ }
             }
             const shortItem = actualShort || {
               owner: sharedVideo.author,
@@ -2835,6 +2875,15 @@ const VideoShort = () => {
             ) : null;
           })()}
 
+          {/* Edit — own shorts only, and only when there's a Hive post to edit. */}
+          {authenticated && user === currentVideo.author && !currentVideo.hivePostMissing && (
+            <div className="actionItem" onClick={(e) => { e.stopPropagation(); try { playerRef.current?.pause?.(); } catch {} setIsEditShortOpen(true); }}>
+              <div className="actionButton">
+                <Pencil size={24} />
+              </div>
+              <span className="actionLabel">Edit</span>
+            </div>
+          )}
 
         </div>
 
@@ -2844,6 +2893,15 @@ const VideoShort = () => {
           title={currentVideo.title}
           onClose={() => setShareChooserOpen(false)}
           onGeneralShare={handleShare}
+        />
+
+        <EditVideoModal
+          isOpen={isEditShortOpen}
+          onClose={() => setIsEditShortOpen(false)}
+          author={currentVideo.author}
+          permlink={currentVideo.hivePermlink}
+          isShort
+          onSaved={() => setIsEditShortOpen(false)}
         />
 
       </div>

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.36.0';
+export const APP_VERSION = '1.38.0';


### PR DESCRIPTION
This pull request introduces several improvements focused on consistent tag handling and enhanced editing capabilities for shorts and videos. The main changes ensure that auto-added taxonomy tags (like the community tag and "short") are handled uniformly in both the uploader and the edit modal, with clear limits and UI feedback. Additionally, users can now edit their own shorts, including changing descriptions, tags, thumbnails, and settings. Unlisted shorts are now visible on the user's profile with a badge, making them easy to find and re-list.

**Tag Handling Improvements**
- The uploader and edit modal now consistently auto-add the community tag (and "short" for shorts), count these toward the 10-tag limit, and prevent users from exceeding it. The UI displays a live tag count and visually distinguishes auto-added tags, which cannot be removed. Hidden tags like "3speak" and "short" are no longer auto-added except where appropriate. [[1]](diffhunk://#diff-b7876cf3590aba991c7044c8e7aa99b1bb2b1cf1a973d37b42029658276ae5faR122-R132) [[2]](diffhunk://#diff-b7876cf3590aba991c7044c8e7aa99b1bb2b1cf1a973d37b42029658276ae5faL130-R144) [[3]](diffhunk://#diff-b7876cf3590aba991c7044c8e7aa99b1bb2b1cf1a973d37b42029658276ae5faL185-R219) [[4]](diffhunk://#diff-8ed5fb5ad6826fd1440f4c57e1b3714eb31d0b792433f8870db817e4a3767fbaR115-R118) [[5]](diffhunk://#diff-8ed5fb5ad6826fd1440f4c57e1b3714eb31d0b792433f8870db817e4a3767fbaL172-R190) [[6]](diffhunk://#diff-8ed5fb5ad6826fd1440f4c57e1b3714eb31d0b792433f8870db817e4a3767fbaL248-R288) [[7]](diffhunk://#diff-8ed5fb5ad6826fd1440f4c57e1b3714eb31d0b792433f8870db817e4a3767fbaL520-R568)

- The Edit Video modal now separates user tags from system taxonomy tags for accurate validation and display, ensuring the tag count/limit matches the uploader. The final tag list on save always includes the taxonomy tags and "nsfw" if marked adult, deduped and in the correct order. [[1]](diffhunk://#diff-8ed5fb5ad6826fd1440f4c57e1b3714eb31d0b792433f8870db817e4a3767fbaL172-R190) [[2]](diffhunk://#diff-8ed5fb5ad6826fd1440f4c57e1b3714eb31d0b792433f8870db817e4a3767fbaL248-R288) [[3]](diffhunk://#diff-8ed5fb5ad6826fd1440f4c57e1b3714eb31d0b792433f8870db817e4a3767fbaL520-R568)

**Shorts Editing and Profile Enhancements**
- Users can now edit their own shorts, including description, tags, thumbnail, and settings (unlist/re-list, mark as adult/NSFW). The edit modal adapts validation rules for shorts (e.g., no minimum title or tag requirement). [[1]](diffhunk://#diff-8ed5fb5ad6826fd1440f4c57e1b3714eb31d0b792433f8870db817e4a3767fbaL101-R101) [[2]](diffhunk://#diff-8ed5fb5ad6826fd1440f4c57e1b3714eb31d0b792433f8870db817e4a3767fbaL497-R529) [[3]](diffhunk://#diff-8ed5fb5ad6826fd1440f4c57e1b3714eb31d0b792433f8870db817e4a3767fbaL507-R541) [[4]](diffhunk://#diff-8ed5fb5ad6826fd1440f4c57e1b3714eb31d0b792433f8870db817e4a3767fbaR599) [[5]](diffhunk://#diff-8ed5fb5ad6826fd1440f4c57e1b3714eb31d0b792433f8870db817e4a3767fbaR614) [[6]](diffhunk://#diff-8ed5fb5ad6826fd1440f4c57e1b3714eb31d0b792433f8870db817e4a3767fbaR631) [[7]](diffhunk://#diff-8ed5fb5ad6826fd1440f4c57e1b3714eb31d0b792433f8870db817e4a3767fbaR641) [[8]](diffhunk://#diff-654a8c51f9968effcc09dcfead456c46d7634ce851e944d250051fc69a21db56R1047)

- On the user profile page, unlisted shorts are now included in the feed (when viewing your own profile) and are badged as "Unlisted" for easy identification and re-listing. The shorts query and card data structure are updated accordingly. [[1]](diffhunk://#diff-848a3d91488e85372b5372bf0ca901321b6455350263c11e1c8c035cd1ea11aeL171-R172) [[2]](diffhunk://#diff-848a3d91488e85372b5372bf0ca901321b6455350263c11e1c8c035cd1ea11aeL182-R183) [[3]](diffhunk://#diff-848a3d91488e85372b5372bf0ca901321b6455350263c11e1c8c035cd1ea11aeR209)

**UI/UX Improvements**
- The tag input UI in both the uploader and edit modal now shows a live tag count, visually distinguishes auto-added tags, and updates the layout for better readability and feedback. [[1]](diffhunk://#diff-b7876cf3590aba991c7044c8e7aa99b1bb2b1cf1a973d37b42029658276ae5faL185-R219) [[2]](diffhunk://#diff-8f36811861180a90bce050b19c5ceff1c1ecaa9c3cf8552ece085f1074ecf5e9R201-R205) [[3]](diffhunk://#diff-c7c6295c51b7933cde0f77183913bce5036d00465d0bc569b3f43c658d0fd151L174-R174)

**Changelog Updates**
- The `CHANGELOG` is updated with entries for versions 1.37.0 and 1.38.0, summarizing the new features and improvements for end users.

These changes provide a more predictable and user-friendly experience for tag management and video/short editing.