### PR TITLE
Chat: private rooms + channel join/leave; version check → prod-3speak

### DIFF
--- a/src/components/Chat/ChatPage.jsx
+++ b/src/components/Chat/ChatPage.jsx
@@ -1,5 +1,5 @@
-import { useState, useRef, useEffect } from 'react'
-import { ArrowLeft, Send, MessageCirclePlus, Loader2, MoreHorizontal, X } from 'lucide-react'
+import { useState, useRef, useEffect, useMemo } from 'react'
+import { ArrowLeft, Send, MessageCirclePlus, Loader2, MoreHorizontal, X, Users, Hash, LogOut } from 'lucide-react'
 import {
   useConversations,
   useChatMessages,
@@ -195,9 +195,262 @@ function NewDmForm() {
   )
 }
 
+// Verify a single handle exists on Hive.
+async function hiveAccountExists(handle) {
+  const accounts = await getAccounts([handle])
+  return (accounts || []).some((a) => a.name === handle)
+}
+
+// Create a private room (group). Mode is forced private for now — no
+// public/private choice is surfaced. Collapsed to a button until opened.
+// Members are entered as chips: type a handle, press space/enter/comma to
+// verify it against Hive and add it; the × removes it.
+function NewRoomForm() {
+  const { createPrivateRoom } = useChat()
+  const [open, setOpen] = useState(false)
+  const [name, setName] = useState('')
+  const [memberInput, setMemberInput] = useState('')
+  const [members, setMembers] = useState([]) // validated Hive handles
+  const [checking, setChecking] = useState(false)
+  const [busy, setBusy] = useState(false)
+
+  const close = () => {
+    setOpen(false)
+    setName('')
+    setMemberInput('')
+    setMembers([])
+  }
+
+  // Validate a token against Hive and, if it exists, add it as a chip.
+  const addMember = async (raw) => {
+    const handle = String(raw || '').trim().replace(/^@/, '').toLowerCase()
+    if (!handle) return
+    if (members.includes(handle)) { setMemberInput(''); return }
+    setChecking(true)
+    try {
+      if (!(await hiveAccountExists(handle))) {
+        toast.error(`@${handle} is not a Hive account.`)
+        return
+      }
+      setMembers((prev) => (prev.includes(handle) ? prev : [...prev, handle]))
+      setMemberInput('')
+    } catch (err) {
+      toast.error(err?.message || 'Could not verify that account.')
+    } finally {
+      setChecking(false)
+    }
+  }
+
+  const removeMember = (handle) =>
+    setMembers((prev) => prev.filter((m) => m !== handle))
+
+  const onMemberKeyDown = (e) => {
+    if (e.key === ' ' || e.key === 'Enter' || e.key === ',') {
+      e.preventDefault()
+      if (memberInput.trim()) addMember(memberInput)
+    } else if (e.key === 'Backspace' && !memberInput && members.length) {
+      removeMember(members[members.length - 1])
+    }
+  }
+
+  // Commit completed tokens on a typed/pasted separator; keep the trailing
+  // fragment in the box.
+  const onMemberChange = (e) => {
+    const v = e.target.value
+    if (/[\s,]/.test(v)) {
+      const parts = v.split(/[\s,]+/)
+      const tail = parts.pop()
+      parts.filter(Boolean).forEach((p) => addMember(p))
+      setMemberInput(tail)
+    } else {
+      setMemberInput(v)
+    }
+  }
+
+  const submit = async (e) => {
+    e.preventDefault()
+    const roomName = name.trim()
+    if (!roomName || busy) return
+    setBusy(true)
+    try {
+      // Fold in any half-typed handle still in the box.
+      const finalMembers = [...members]
+      const tail = memberInput.trim().replace(/^@/, '').toLowerCase()
+      if (tail && !finalMembers.includes(tail)) {
+        if (!(await hiveAccountExists(tail))) {
+          toast.error(`@${tail} is not a Hive account.`)
+          return
+        }
+        finalMembers.push(tail)
+      }
+      await createPrivateRoom({ name: roomName, members: finalMembers })
+      close()
+    } catch (err) {
+      toast.error(err?.message || 'Could not create the room.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!open) {
+    return (
+      <button type="button" className="chat-newroom-toggle" onClick={() => setOpen(true)}>
+        <Users size={16} /> New private room
+      </button>
+    )
+  }
+
+  return (
+    <form className="chat-newroom" onSubmit={submit}>
+      <input
+        type="text"
+        placeholder="Room name…"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        autoFocus
+      />
+      <div className="chat-newroom-members">
+        {members.map((m) => (
+          <span key={m} className="chat-member-chip">
+            @{m}
+            <button type="button" onClick={() => removeMember(m)} aria-label={`Remove @${m}`}>
+              <X size={12} />
+            </button>
+          </span>
+        ))}
+        <input
+          type="text"
+          placeholder={members.length ? 'Add more…' : 'Invite Hive users (optional)…'}
+          value={memberInput}
+          onChange={onMemberChange}
+          onKeyDown={onMemberKeyDown}
+          spellCheck={false}
+          autoCapitalize="none"
+        />
+        {checking && <Loader2 size={14} className="chat-spin" />}
+      </div>
+      <div className="chat-newroom-actions">
+        <button type="button" className="chat-newroom-cancel" onClick={close} disabled={busy}>
+          Cancel
+        </button>
+        <button type="submit" disabled={!name.trim() || busy}>
+          {busy ? <Loader2 size={16} className="chat-spin" /> : 'Create'}
+        </button>
+      </div>
+    </form>
+  )
+}
+
+// Groups live in a separate /groups collection that the /conversations feed
+// doesn't include, so poll them ourselves and merge into the list — otherwise
+// a room you were added to never shows up.
+function useGroups() {
+  const { client, ready } = useChat()
+  const [groups, setGroups] = useState([])
+  useEffect(() => {
+    if (!ready) {
+      setGroups([])
+      return
+    }
+    let alive = true
+    const load = async () => {
+      try {
+        const g = await client.getGroups()
+        if (alive) setGroups(Array.isArray(g) ? g : [])
+      } catch {
+        /* ignore transient poll errors */
+      }
+    }
+    load()
+    const id = setInterval(load, 5000)
+    return () => {
+      alive = false
+      clearInterval(id)
+    }
+  }, [client, ready])
+  return groups
+}
+
+// Browse & join public channels. Collapsed to a button until opened.
+function BrowseChannels() {
+  const { client, joinChannel } = useChat()
+  const [open, setOpen] = useState(false)
+  const [channels, setChannels] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [joining, setJoining] = useState(null)
+
+  useEffect(() => {
+    if (!open) return
+    let alive = true
+    setLoading(true)
+    client
+      .getChannels()
+      .then((c) => { if (alive) setChannels(Array.isArray(c) ? c : []) })
+      .catch(() => { if (alive) setChannels([]) })
+      .finally(() => { if (alive) setLoading(false) })
+    return () => { alive = false }
+  }, [open, client])
+
+  const join = async (ch) => {
+    setJoining(ch._id)
+    try {
+      await joinChannel(ch) // joins, then opens the channel thread
+    } catch (err) {
+      toast.error(err?.message || 'Could not join that channel.')
+    } finally {
+      setJoining(null)
+    }
+  }
+
+  if (!open) {
+    return (
+      <button type="button" className="chat-newroom-toggle" onClick={() => setOpen(true)}>
+        <Hash size={16} /> Browse channels
+      </button>
+    )
+  }
+
+  return (
+    <div className="chat-browse">
+      <div className="chat-browse-head">
+        <span>Public channels</span>
+        <button type="button" onClick={() => setOpen(false)} aria-label="Close channel browser">
+          <X size={14} />
+        </button>
+      </div>
+      {loading && <div className="chat-empty">Loading channels…</div>}
+      {!loading && channels.length === 0 && (
+        <div className="chat-empty">No channels available.</div>
+      )}
+      <ul className="chat-browse-ul">
+        {channels.map((ch) => (
+          <li key={ch._id} className="chat-browse-row">
+            <span className="chat-browse-name"># {ch.name}</span>
+            <button type="button" onClick={() => join(ch)} disabled={joining === ch._id}>
+              {joining === ch._id ? <Loader2 size={14} className="chat-spin" /> : 'Join'}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
 function ConversationList() {
   const { conversations, loading } = useConversations()
   const { openConversation, activeConversation, shareDraft } = useChat()
+  const groups = useGroups()
+
+  // Merge polled groups in, deduped by id (a real /conversations entry — which
+  // carries lastMessage/unread — wins over the bare group record).
+  const merged = useMemo(() => {
+    const byId = new Map()
+    for (const c of conversations) byId.set(c._id, c)
+    for (const g of groups) {
+      if (!byId.has(g._id)) byId.set(g._id, { ...g, type: 'group' })
+    }
+    return Array.from(byId.values())
+  }, [conversations, groups])
 
   return (
     <div className="chat-list">
@@ -205,16 +458,18 @@ function ConversationList() {
         <div className="chat-share-banner">Choose a chat to send to</div>
       )}
       <NewDmForm />
-      {loading && conversations.length === 0 && (
+      <NewRoomForm />
+      <BrowseChannels />
+      {loading && merged.length === 0 && (
         <div className="chat-empty">Loading conversations…</div>
       )}
-      {!loading && conversations.length === 0 && (
+      {!loading && merged.length === 0 && (
         <div className="chat-empty">
           No conversations yet. Start one above by entering a Hive username.
         </div>
       )}
       <ul className="chat-conv-ul">
-        {conversations.map((conv) => {
+        {merged.map((conv) => {
           const title = convTitle(conv)
           const isDm = conv.type === 'dm'
           const active = activeConversation?._id === conv._id
@@ -251,6 +506,37 @@ function ConversationList() {
         })}
       </ul>
     </div>
+  )
+}
+
+// Leave the current room/channel from the thread header (DMs can't be left).
+function LeaveButton({ conv }) {
+  const { leaveConversation, backToList } = useChat()
+  const [busy, setBusy] = useState(false)
+  const kind = conv.type === 'group' ? 'room' : 'channel'
+  const leave = async () => {
+    if (!window.confirm(`Leave this ${kind}?`)) return
+    setBusy(true)
+    try {
+      await leaveConversation(conv)
+      backToList()
+    } catch (err) {
+      toast.error(err?.message || `Could not leave the ${kind}.`)
+    } finally {
+      setBusy(false)
+    }
+  }
+  return (
+    <button
+      type="button"
+      className="chat-thread-leave"
+      onClick={leave}
+      disabled={busy}
+      title={`Leave ${kind}`}
+    >
+      {busy ? <Loader2 size={15} className="chat-spin" /> : <LogOut size={16} />}
+      <span>Leave</span>
+    </button>
   )
 }
 
@@ -427,6 +713,7 @@ function Thread({ conv }) {
         </button>
         <img className="chat-thread-avatar" src={avatar(isDm ? title : conv.owner || 'spknetwork')} alt="" />
         <span className="chat-thread-title">{isDm ? `@${title}` : `# ${title}`}</span>
+        {!isDm && <LeaveButton conv={conv} />}
       </header>
 
       <div className="chat-messages" ref={scrollRef}>

--- a/src/components/Chat/chat.scss
+++ b/src/components/Chat/chat.scss
@@ -203,6 +203,172 @@ $chat-z: 1200;
   }
 }
 
+.chat-newroom-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 9px 12px;
+  border: none;
+  border-bottom: 1px solid var(--border-light);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 13.5px;
+  font-weight: 600;
+  cursor: pointer;
+  &:hover { color: var(--accent-primary); background: var(--bg-tertiary); }
+}
+
+.chat-newroom {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-light);
+
+  > input {
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-light);
+    border-radius: 8px;
+    padding: 8px 10px;
+    color: var(--text-primary);
+    font-size: 13.5px;
+    outline: none;
+    &:focus { border-color: var(--accent-primary); }
+  }
+
+  .chat-newroom-members {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-light);
+    border-radius: 8px;
+    padding: 6px 8px;
+    &:focus-within { border-color: var(--accent-primary); }
+
+    input {
+      flex: 1;
+      min-width: 120px;
+      background: transparent;
+      border: none;
+      padding: 2px 0;
+      color: var(--text-primary);
+      font-size: 13.5px;
+      outline: none;
+    }
+    .chat-spin { color: var(--text-muted); flex-shrink: 0; }
+  }
+
+  .chat-member-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: var(--accent-primary);
+    color: #fff;
+    border-radius: 999px;
+    padding: 3px 5px 3px 9px;
+    font-size: 12.5px;
+    font-weight: 600;
+    white-space: nowrap;
+
+    button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 16px;
+      height: 16px;
+      padding: 0;
+      border: none;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.25);
+      color: #fff;
+      cursor: pointer;
+      &:hover { background: rgba(255, 255, 255, 0.45); }
+    }
+  }
+
+  .chat-newroom-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    button {
+      padding: 7px 14px;
+      border-radius: 8px;
+      border: none;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      &[type='submit'] { background: var(--accent-primary); color: #fff; }
+      &:disabled { opacity: 0.5; cursor: not-allowed; }
+    }
+    .chat-newroom-cancel { background: var(--bg-tertiary); color: var(--text-primary); }
+  }
+}
+
+.chat-browse {
+  border-bottom: 1px solid var(--border-light);
+
+  .chat-browse-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 12px 4px;
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: var(--text-muted);
+    button {
+      display: inline-flex;
+      border: none;
+      background: transparent;
+      color: var(--text-muted);
+      cursor: pointer;
+      &:hover { color: var(--text-primary); }
+    }
+  }
+  .chat-browse-ul { list-style: none; margin: 0; padding: 0 0 6px; max-height: 220px; overflow-y: auto; }
+  .chat-browse-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 6px 12px;
+    .chat-browse-name { font-size: 13.5px; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    button {
+      flex-shrink: 0;
+      padding: 5px 12px;
+      border: none;
+      border-radius: 8px;
+      background: var(--accent-primary);
+      color: #fff;
+      font-size: 12.5px;
+      font-weight: 600;
+      cursor: pointer;
+      &:disabled { opacity: 0.5; cursor: not-allowed; }
+    }
+  }
+}
+
+.chat-thread-leave {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 10px;
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+  &:hover { color: #e05252; border-color: #e05252; }
+  &:disabled { opacity: 0.5; cursor: not-allowed; }
+}
+
 .chat-conv-ul { list-style: none; margin: 0; padding: 0; overflow-y: auto; flex: 1; }
 
 .chat-conv-row {

--- a/src/context/ChatContext.jsx
+++ b/src/context/ChatContext.jsx
@@ -130,6 +130,93 @@ export function ChatProvider({ children }) {
     [client]
   )
 
+  // Create a PRIVATE room (a group) and open it. Mode is forced private for
+  // now — we deliberately don't surface a public/private choice yet. Returns
+  // the new conversation.
+  const createPrivateRoom = useCallback(
+    async ({ name, description = '', members = [] } = {}) => {
+      const roomName = String(name || '').trim()
+      if (!roomName) throw new Error('A room name is required.')
+      const cleanMembers = (members || [])
+        .map((m) => String(m || '').trim().replace(/^@/, '').toLowerCase())
+        .filter(Boolean)
+      const channel = await client.createGroup({
+        name: roomName,
+        description: String(description || '').trim(),
+        isPublic: false,
+        members: cleanMembers,
+      })
+      // Belt-and-suspenders: some backends ignore the create-time `members`
+      // payload, so explicitly add each invitee. Ignore per-member errors
+      // (e.g. "already a member") so one bad add doesn't fail the whole room.
+      let finalChannel = channel
+      for (const m of cleanMembers) {
+        try {
+          finalChannel = (await client.addGroupMember(channel._id, m)) || finalChannel
+        } catch { /* already a member / not supported — ignore */ }
+      }
+      // createGroup resolves to a Channel; normalize to a group Conversation so
+      // the thread view loads the right endpoint and shows a proper header.
+      const conv = {
+        ...finalChannel,
+        type: 'group',
+        name: finalChannel?.name || roomName,
+      }
+      setActiveConversation(conv)
+      return conv
+    },
+    [client]
+  )
+
+  // Join a public channel, then open it. Accepts a channel object (preferred,
+  // so we can open it after) or a bare channel id.
+  const joinChannel = useCallback(
+    async (channelOrId) => {
+      const id = typeof channelOrId === 'string' ? channelOrId : channelOrId?._id
+      if (!id) return
+      await client.joinChannel(id)
+      if (channelOrId && typeof channelOrId === 'object') {
+        const conv = { ...channelOrId, type: 'channel', name: channelOrId.name }
+        setActiveConversation(conv)
+        return conv
+      }
+    },
+    [client]
+  )
+
+  // Leave a channel. If it's the one currently open, drop back to the list.
+  const leaveChannel = useCallback(
+    async (channelOrId) => {
+      const id = typeof channelOrId === 'string' ? channelOrId : channelOrId?._id
+      if (!id) return
+      await client.leaveChannel(id)
+      setActiveConversation((cur) => (cur && cur._id === id ? null : cur))
+    },
+    [client]
+  )
+
+  // Leave a group = remove yourself from its members (the SDK has no group
+  // "leave" endpoint). If it's the one currently open, drop back to the list.
+  const leaveGroup = useCallback(
+    async (groupOrId) => {
+      const id = typeof groupOrId === 'string' ? groupOrId : groupOrId?._id
+      if (!id || !user) return
+      await client.removeGroupMember(id, user)
+      setActiveConversation((cur) => (cur && cur._id === id ? null : cur))
+    },
+    [client, user]
+  )
+
+  // Leave whatever a conversation is — dispatch by type (dm can't be left).
+  const leaveConversation = useCallback(
+    async (conv) => {
+      if (!conv || conv.type === 'dm') return
+      if (conv.type === 'group') return leaveGroup(conv)
+      return leaveChannel(conv)
+    },
+    [leaveGroup, leaveChannel]
+  )
+
   const value = useMemo(
     () => ({
       client,
@@ -142,6 +229,11 @@ export function ChatProvider({ children }) {
       openConversation,
       backToList,
       openDmWith,
+      createPrivateRoom,
+      joinChannel,
+      leaveChannel,
+      leaveGroup,
+      leaveConversation,
       shareDraft,
       setShareDraft,
     }),
@@ -156,6 +248,11 @@ export function ChatProvider({ children }) {
       openConversation,
       backToList,
       openDmWith,
+      createPrivateRoom,
+      joinChannel,
+      leaveChannel,
+      leaveGroup,
+      leaveConversation,
     ]
   )
 

--- a/src/utils/checkLatestVersion.js
+++ b/src/utils/checkLatestVersion.js
@@ -2,12 +2,12 @@ import { toast } from "sonner";
 import { APP_VERSION } from "../version";
 import { APP_VERSION_STORAGE_KEY } from "./appVersion";
 
-// The deployed site is built from the repo's `develop` branch, whose version.js
-// is the source of truth for the latest released version. We read it raw from
-// GitHub and compare it to the version baked into the running bundle, so a user
-// on a stale (cached) build can be prompted to refresh.
+// The live site is deployed from the repo's `prod-3speak` branch, whose
+// version.js is the source of truth for the latest released version. We read it
+// raw from GitHub and compare it to the version baked into the running bundle,
+// so a user on a stale (cached) build can be prompted to refresh.
 const REMOTE_VERSION_URL =
-  "https://raw.githubusercontent.com/Mantequilla-Soft/new-3speak-tv/develop/src/version.js";
+  "https://raw.githubusercontent.com/Mantequilla-Soft/new-3speak-tv/prod-3speak/src/version.js";
 
 // "export const APP_VERSION = '1.2.3';" → "1.2.3"
 function parseVersion(text) {
@@ -27,7 +27,7 @@ export function isNewerVersion(a, b) {
   return false;
 }
 
-// Returns the latest version string if GitHub's develop is newer than the
+// Returns the latest version string if GitHub's prod-3speak is newer than the
 // running build, otherwise null (also null on any network error / offline).
 export async function fetchNewerVersion() {
   try {
@@ -38,7 +38,7 @@ export async function fetchNewerVersion() {
     let stored = null;
     try { stored = localStorage.getItem(APP_VERSION_STORAGE_KEY); } catch { /* ignore */ }
     console.log(
-      `[version] GitHub (develop): ${remote} | browser storage: ${stored} | running build: ${APP_VERSION}`
+      `[version] GitHub (prod-3speak): ${remote} | browser storage: ${stored} | running build: ${APP_VERSION}`
     );
 
     if (remote && isNewerVersion(remote, APP_VERSION)) return remote;
@@ -67,7 +67,7 @@ export async function reloadForUpdate() {
 }
 
 // Upload gate. Call this at the very start of any real upload. If a newer build
-// has been deployed (per the GitHub `develop` version.js — the same changelog-
+// has been deployed (per the GitHub `prod-3speak` version.js — the same changelog-
 // driven version check used for the global refresh prompt), it toasts and force-
 // reloads onto the latest build BEFORE the upload runs, then resolves `true` so
 // the caller can bail out. Resolves `false` when the running build is current.


### PR DESCRIPTION
Two changes from preview:

**Chat: private rooms + channel join/leave**
- Create private rooms (groups) from the chat list, with a chip-based member input that verifies each Hive handle before adding it. Mode is forced private for now.
- Rooms you're a member of now show in the list — the `/conversations` feed omits groups, so we poll `/groups` and merge them in.
- Reliable membership: also `addGroupMember` for each invitee after create, since the create-time `members` payload isn't reliably honoured by the backend.
- Browse & join public channels; leave a room/channel from the thread header.

**Version check → prod-3speak branch**
- The refresh prompt / stale-upload gate now reads `version.js` from the `prod-3speak` branch (what's actually deployed to 3speak.tv) instead of `develop`.