### PR TITLE
feat: embed on other Hive apps, ad-blocker-proof stats, tiered uploads

### DIFF
--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.45.0',
+    date: '2026-07-07',
+    summary:
+      'Videos you publish now embed and play correctly on other Hive apps like PeakD and Ecency — not just on 3Speak — so your posts look right everywhere they’re seen. Uploads are also a bit more reliable now, preferring the faster upload servers.',
+  },
+  {
     version: '1.44.0',
     date: '2026-07-07',
     summary:

--- a/src/components/CreatorStats/CreatorStats.jsx
+++ b/src/components/CreatorStats/CreatorStats.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo, useRef, useCallback, memo } from 'react';
 import {
   fetchCreatorOverview, fetchCreatorTimeseries, fetchCreatorDemographics, fetchVideoAnalytics,
   fmtDuration, fmtCount, timeAgo, countryFlag, countryName, countryLatLng,
-} from '../../lib/analytics';
+} from '../../lib/creatorStats';
 import BarLoader from '../Loader/BarLoader';
 import VideoStats from './VideoStats';
 import { WORLD_LAND_PATH } from '../../lib/worldMapPath';

--- a/src/components/CreatorStats/VideoStats.jsx
+++ b/src/components/CreatorStats/VideoStats.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
-import { fetchVideoAnalytics, fmtDuration, fmtCount } from '../../lib/analytics';
+import { fetchVideoAnalytics, fmtDuration, fmtCount } from '../../lib/creatorStats';
 import BarLoader from '../Loader/BarLoader';
 import useSeekPreview from '../../hooks/useSeekPreview';
 import './VideoStats.scss';

--- a/src/components/playVideo/PlayVideo.jsx
+++ b/src/components/playVideo/PlayVideo.jsx
@@ -14,7 +14,7 @@ import relativeTime from "dayjs/plugin/relativeTime";
 import BlogContent from "./BlogContent";
 import CommentSection from "./CommentSection";
 import VideoStats from "../CreatorStats/VideoStats";
-import { fetchVideoHasStats } from "../../lib/analytics";
+import { fetchVideoHasStats } from "../../lib/creatorStats";
 import ShareChooserModal from "../Chat/ShareChooserModal";
 import { useAppStore } from '../../lib/store';
 import { estimate, getUersContent, getVotePower } from "../../utils/hiveUtils";

--- a/src/context/EmbedUploadContext.jsx
+++ b/src/context/EmbedUploadContext.jsx
@@ -844,6 +844,18 @@ export function EmbedUploadProvider({ children }) {
         ...tagsPreview.filter(t => !baseTags.includes(t)),
         ...(isNsfw ? ['nsfw'] : []),
       ].filter((t, i, a) => a.indexOf(t) === i);
+
+      // Embed ASSET owner/permlink (…/embed?v=owner/permlink) — this is what the
+      // `video.info` block below carries so peakd/ecency render the player.
+      let embedOwner = user;
+      let embedAssetPermlink = hivePermlink;
+      try {
+        const vParam = new URL(capturedEmbedUrl).searchParams.get('v') || '';
+        const [o, p] = vParam.split('/');
+        if (o) embedOwner = o;
+        if (p) embedAssetPermlink = p;
+      } catch { /* fall back to user / hive permlink */ }
+
       const jsonMetadata = {
         app: '3speak/embed',
         format: 'markdown',
@@ -854,12 +866,32 @@ export function EmbedUploadProvider({ children }) {
         // some renderers choke on. The same field is duplicated inside `video`
         // for legacy 3Speak readers that look for it there.
         ...(thumbnailUrl ? { image: [thumbnailUrl] } : {}),
+        // Top-level `links` array — the Hive-wide convention (peakd, ecency, …)
+        // for cataloguing the URLs in the body. Listing the play.3speak.tv embed
+        // here is what lets other frontends detect and render the 3Speak player
+        // inline (matches the Snapie.io posts). `capturedEmbedUrl` is already the
+        // canonical `https://play.3speak.tv/embed?v=owner/permlink` form that the
+        // body leads with.
+        links: [capturedEmbedUrl],
         video: {
           platform: '3speak',
           url: capturedEmbedUrl,
           reusable: (originalAuthor && originalPermlink) ? true : reusable,
           ...(thumbnailUrl ? { thumbnail: thumbnailUrl } : {}),
           ...(originalAuthor ? { originalAuthor, originalPermlink } : {}),
+          // Legacy 3Speak `info` block. Other Hive frontends (peakd, ecency, …)
+          // render the player by reading video.info.author + video.info.permlink
+          // to build the embed — WITHOUT it they request an EMPTY owner/permlink
+          // and show nothing. Mirrors the schema of classic 3speak.tv posts, and
+          // our own PostView/WatchedView/chatLinks read video.info too.
+          info: {
+            platform: '3speak',
+            author: embedOwner,
+            permlink: embedAssetPermlink,
+            title: title || '',
+            duration: Number(videoDuration) || 0,
+            ...(thumbnailUrl ? { sourceMap: [{ url: thumbnailUrl, type: 'thumbnail' }] } : {}),
+          },
         },
       };
 

--- a/src/lib/creatorStats.js
+++ b/src/lib/creatorStats.js
@@ -1,5 +1,8 @@
-// Creator analytics data layer — talks to the checker's /analytics endpoints
+// Creator stats data layer — talks to the checker's /creator-stats endpoints
 // (watch-duration stats + Hive engagement + GeoLite2 demographics).
+// NOTE: deliberately NOT named "analytics" — ad-blockers/privacy extensions
+// block requests matching that word (filename AND URL path), which broke the
+// whole app for users with such extensions. Keep this name generic.
 import { CHECKER_URL } from '../utils/config';
 
 async function get(path) {
@@ -19,27 +22,27 @@ function qs(username, { days, content } = {}) {
 
 // Totals + metrics + best-performing videos. opts: { days, content }.
 export function fetchCreatorOverview(username, opts) {
-  return get(`/analytics/overview?${qs(username, opts)}`);
+  return get(`/creator-stats/overview?${qs(username, opts)}`);
 }
 
 // Daily watch-time / views trend. opts: { days, content }.
 export function fetchCreatorTimeseries(username, opts) {
-  return get(`/analytics/timeseries?${qs(username, opts)}`);
+  return get(`/creator-stats/timeseries?${qs(username, opts)}`);
 }
 
 // Per-video detail: retention curve + most-replayed buckets + stats.
 export function fetchVideoAnalytics(username, permlink) {
-  return get(`/analytics/video?username=${encodeURIComponent(username)}&permlink=${encodeURIComponent(permlink)}`);
+  return get(`/creator-stats/video?username=${encodeURIComponent(username)}&permlink=${encodeURIComponent(permlink)}`);
 }
 
 // Lightweight check: does this video have any watch records? (gates the Stats button)
 export function fetchVideoHasStats(username, permlink) {
-  return get(`/analytics/has-data?username=${encodeURIComponent(username)}&permlink=${encodeURIComponent(permlink)}`);
+  return get(`/creator-stats/has-data?username=${encodeURIComponent(username)}&permlink=${encodeURIComponent(permlink)}`);
 }
 
 // Viewer demographics (country / device / browser / time-of-day / new-vs-returning).
 export function fetchCreatorDemographics(username, opts) {
-  return get(`/analytics/demographics?${qs(username, opts)}`);
+  return get(`/creator-stats/demographics?${qs(username, opts)}`);
 }
 
 // ── formatting helpers ────────────────────────────────────────────────────

--- a/src/utils/checkLatestVersion.js
+++ b/src/utils/checkLatestVersion.js
@@ -2,12 +2,12 @@ import { toast } from "sonner";
 import { APP_VERSION } from "../version";
 import { APP_VERSION_STORAGE_KEY } from "./appVersion";
 
-// The live site is deployed from the repo's `prod-3speak` branch, whose
-// version.js is the source of truth for the latest released version. We read it
-// raw from GitHub and compare it to the version baked into the running bundle,
-// so a user on a stale (cached) build can be prompted to refresh.
+// The live release lives on the repo's `production` branch, whose version.js is
+// the source of truth for the latest released version. We read it raw from GitHub
+// and compare it to the version baked into the running bundle, so a user on a
+// stale (cached) build can be prompted to refresh.
 const REMOTE_VERSION_URL =
-  "https://raw.githubusercontent.com/Mantequilla-Soft/new-3speak-tv/prod-3speak/src/version.js";
+  "https://raw.githubusercontent.com/Mantequilla-Soft/new-3speak-tv/production/src/version.js";
 
 // "export const APP_VERSION = '1.2.3';" → "1.2.3"
 function parseVersion(text) {
@@ -27,8 +27,8 @@ export function isNewerVersion(a, b) {
   return false;
 }
 
-// Returns the latest version string if GitHub's prod-3speak is newer than the
-// running build, otherwise null (also null on any network error / offline).
+// Returns the latest version string if GitHub's production branch is newer than
+// the running build, otherwise null (also null on any network error / offline).
 export async function fetchNewerVersion() {
   try {
     const res = await fetch(`${REMOTE_VERSION_URL}?t=${Date.now()}`, { cache: "no-store" });
@@ -38,7 +38,7 @@ export async function fetchNewerVersion() {
     let stored = null;
     try { stored = localStorage.getItem(APP_VERSION_STORAGE_KEY); } catch { /* ignore */ }
     console.log(
-      `[version] GitHub (prod-3speak): ${remote} | browser storage: ${stored} | running build: ${APP_VERSION}`
+      `[version] GitHub (production): ${remote} | browser storage: ${stored} | running build: ${APP_VERSION}`
     );
 
     if (remote && isNewerVersion(remote, APP_VERSION)) return remote;
@@ -67,7 +67,7 @@ export async function reloadForUpdate() {
 }
 
 // Upload gate. Call this at the very start of any real upload. If a newer build
-// has been deployed (per the GitHub `prod-3speak` version.js — the same changelog-
+// has been deployed (per the GitHub `production` version.js — the same changelog-
 // driven version check used for the global refresh prompt), it toasts and force-
 // reloads onto the latest build BEFORE the upload runs, then resolves `true` so
 // the caller can bail out. Resolves `false` when the running build is current.

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -61,11 +61,15 @@ const EMBED_API_KEY = import.meta.env.VITE_EMBED_API_KEY || '';
 // least-busy reachable one per upload (see utils/embedEndpoints.js). Leave unset
 // to use the single EMBED_API_URL host. Each host must share the same MongoDB +
 // EMBED_API_KEY so any can serve the post-upload /video/* writes.
-const EMBED_UPLOAD_HOSTS = (import.meta.env.VITE_EMBED_UPLOAD_URLS
-  ? import.meta.env.VITE_EMBED_UPLOAD_URLS.split(/[\s,]+/)
-  : [])
+const parseHosts = (v) => (v ? v.split(/[\s,]+/) : [])
   .map((h) => h.trim().replace(/\/+$/, '').replace(/\/uploads$/, ''))
   .filter(Boolean);
+const EMBED_UPLOAD_HOSTS = parseHosts(import.meta.env.VITE_EMBED_UPLOAD_URLS);
+// Slow / last-resort upload hosts (e.g. the legacy embed.3speak.tv). These are
+// used ONLY when no primary EMBED_UPLOAD_HOSTS host is reachable, so the fast
+// servers (embed2 / embed-okinoko) stay the prominent choice. See
+// utils/embedEndpoints.js.
+const EMBED_UPLOAD_FALLBACK_HOSTS = parseHosts(import.meta.env.VITE_EMBED_UPLOAD_FALLBACK_URLS);
 const EMBED_DEBUG = import.meta.env.VITE_EMBED_DEBUG === 'true';
 const THREESPEAK_AUDIO_API_URL = import.meta.env.VITE_3SPEAK_AUDIO_API_URL || 'https://audio.3speak.tv';
 const THREESPEAK_API_KEY = import.meta.env.VITE_3SPEAK_API_KEY || '';
@@ -169,6 +173,7 @@ export {
   EMBED_UPLOAD_URL,
   EMBED_API_URL,
   EMBED_UPLOAD_HOSTS,
+  EMBED_UPLOAD_FALLBACK_HOSTS,
   EMBED_API_KEY,
   TRANSLATE_API_URL,
   TRENDING_SORTED_URL,

--- a/src/utils/embedEndpoints.js
+++ b/src/utils/embedEndpoints.js
@@ -10,7 +10,7 @@
 // we fall back to probe latency (a saturated host answers slower), then random.
 // The pick NEVER blocks an upload: any failure falls back to the default host.
 
-import { EMBED_UPLOAD_HOSTS, EMBED_API_URL } from './config';
+import { EMBED_UPLOAD_HOSTS, EMBED_UPLOAD_FALLBACK_HOSTS, EMBED_API_URL } from './config';
 
 const PROBE_TIMEOUT_MS = 2500;
 const FULL_DISK_PCT = 3; // treat a host with <3% free disk as unavailable
@@ -46,39 +46,49 @@ async function probe(base) {
   }
 }
 
-/**
- * Choose an embed endpoint. Returns { base, uploadUrl }.
- * Selection order: fewest activeUploads → lowest latency → (fallback) random/first.
- */
-export async function pickEmbedEndpoint() {
-  const hosts = getEmbedHosts();
-  const fallback = { base: hosts[0] || (EMBED_API_URL || '').replace(/\/+$/, ''), get uploadUrl() { return uploadUrlFor(this.base); } };
-
-  // Single host (or none configured) → nothing to choose.
-  if (hosts.length <= 1) return { base: fallback.base, uploadUrl: uploadUrlFor(fallback.base) };
-
-  const results = (await Promise.all(hosts.map(probe))).filter((r) => r.ok);
-  if (!results.length) {
-    // Nothing answered healthily — don't block; use the first configured host.
-    return { base: fallback.base, uploadUrl: uploadUrlFor(fallback.base) };
-  }
-
-  // Pick the least-busy server, but SPREAD across ties. Under light load every
-  // host reports activeUploads: 0, so a deterministic tie-break (e.g. latency)
-  // would always land on the same (closest) host and never use the others.
-  // Candidate pool = the load-reporting hosts at the lowest activeUploads, PLUS
-  // any reachable host that can't report load (older build with the old /health).
-  // Then pick one at random. This means:
-  //   - among reporters, a genuinely busier host is avoided;
-  //   - a healthy non-reporting host still participates (spread to blindly,
-  //     since we can't read its load) instead of being permanently skipped.
+// Among reachable probe results, pick the least-busy server, SPREADING across
+// ties. Under light load every host reports activeUploads: 0, so a deterministic
+// tie-break (e.g. latency) would always land on the same host and never use the
+// others. Candidate pool = load-reporting hosts at the lowest activeUploads, PLUS
+// any reachable host that can't report load (older /health). Then pick at random:
+//   - among reporters, a genuinely busier host is avoided;
+//   - a healthy non-reporting host still participates (spread to blindly).
+// Returns the chosen base, or null when nothing was reachable.
+function chooseFromResults(results) {
+  if (!results.length) return null;
   const reporters = results.filter((r) => r.activeUploads != null);
   let pool = results;
   if (reporters.length) {
     const min = Math.min(...reporters.map((r) => r.activeUploads));
     pool = results.filter((r) => r.activeUploads == null || r.activeUploads === min);
   }
+  return pool[Math.floor(Math.random() * pool.length)].base;
+}
 
-  const chosen = pool[Math.floor(Math.random() * pool.length)].base;
-  return { base: chosen, uploadUrl: uploadUrlFor(chosen) };
+async function probeAndChoose(hosts) {
+  if (!hosts || !hosts.length) return null;
+  const results = (await Promise.all(hosts.map(probe))).filter((r) => r.ok);
+  return chooseFromResults(results);
+}
+
+/**
+ * Choose an embed endpoint. Returns { base, uploadUrl }.
+ * Tiered: prefer a reachable PRIMARY host (embed2 / embed-okinoko — fast, load
+ * spread among them); only drop to the FALLBACK tier (slow legacy embed.3speak.tv)
+ * when NO primary answers healthily. Never blocks: any failure → first configured.
+ */
+export async function pickEmbedEndpoint() {
+  const primary = getEmbedHosts();
+  const fallbackHosts = EMBED_UPLOAD_FALLBACK_HOSTS || [];
+  const ultimate = primary[0] || fallbackHosts[0] || (EMBED_API_URL || '').replace(/\/+$/, '');
+
+  // Fast path: a single primary and no fallback tier → nothing to choose/probe.
+  if (primary.length <= 1 && !fallbackHosts.length) {
+    return { base: ultimate, uploadUrl: uploadUrlFor(ultimate) };
+  }
+
+  let chosen = await probeAndChoose(primary);          // fast tier first
+  if (!chosen) chosen = await probeAndChoose(fallbackHosts); // only if no primary is up
+  const base = chosen || ultimate;
+  return { base, uploadUrl: uploadUrlFor(base) };
 }

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.44.0';
+export const APP_VERSION = '1.45.0';


### PR DESCRIPTION
- Uploader: add legacy video.info (author/permlink/platform/title/duration) + top-level links[] to the post json_metadata so PeakD/Ecency/other Hive frontends render the 3Speak player inline (they build the embed from video.info.author+permlink; without it they requested an empty owner/permlink and showed nothing). The body + video.url already carried play.3speak.tv/embed.
- Rename src/lib/analytics.js → creatorStats.js and the checker paths /analytics/* → /creator-stats/* (frontend side): ad-blockers/privacy extensions block the word "analytics" (filename AND URL), which blanked the dev app and blocked the stats fetches. Nothing fetched is named analytics now.
- Uploads: tier the embed-upload pool — embed2 + embed-okinoko are the primary (load-spread) hosts; the slow legacy embed.3speak.tv is fallback-only (used only when no primary is reachable). New VITE_EMBED_UPLOAD_FALLBACK_URLS.
- Version check reads the `production` branch instead of `prod-3speak`.
- Changelog + APP_VERSION 1.45.0.