### PR TITLE
Feat/july fun

### DIFF
--- a/src/components/Communities/CommunityPage.jsx
+++ b/src/components/Communities/CommunityPage.jsx
@@ -5,6 +5,7 @@ import { Client } from "@hiveio/dhive";
 import "./CommunityPage.scss";
 import axios from "axios";
 import { FEED_URL, HIVE_API_NODES } from '../../utils/config'
+import { feedParams } from '../../utils/feedParams'
 import { useInfiniteQuery } from "@tanstack/react-query";
 import Card3 from "../Cards/Card3";
 import CardSkeleton from "../Cards/CardSkeleton";
@@ -49,7 +50,9 @@ function CommunityPage() {
     // query supplies 0-indexed pageParam.
     const page = (Number(pageParam) || 0) + 1;
     const variant = trend ? 'trending' : 'new';
-    const url = `${FEED_URL}/feeds/community/${id}/${variant}?page=${page}&limit=${LIMIT}`;
+    // Community "trending" tab re-ranks by interests + retention and can hide seen
+    // videos; the "new" tab stays purely chronological (no params).
+    const url = `${FEED_URL}/feeds/community/${id}/${variant}?page=${page}&limit=${LIMIT}${trend ? feedParams() : ''}`;
 
     const res = await axios.get(url);
     // Checker returns {videos: [...]}; legacy /apiv2 returned {trends: [...]}

--- a/src/components/Communities/CommunityPage.jsx
+++ b/src/components/Communities/CommunityPage.jsx
@@ -15,6 +15,7 @@ import HiveMarkdown from "../HiveMarkdown/HiveMarkdown";
 import { useContentBatch } from "../../hooks/useContentBatch";
 import { useWatchHistory } from "../../hooks/useWatchHistory";
 import useViewCounts from "../../hooks/useViewCounts";
+import { useAppStore } from "../../lib/store";
 
 // Hive client
 const client = getHiveClient();
@@ -23,6 +24,8 @@ function CommunityPage() {
   const { communityName: id } = useParams();
   const [dataMain, setDataMain] = useState(null);
   const [trend, setTrend] = useState(false); // false = new (default), true = trending
+  const hideWatched = useAppStore(s => s.hideWatched);
+  const feedUser = useAppStore(s => s.user);
 
   // Fetch community info
   const fetchCommunityData = async (id) => {
@@ -68,7 +71,7 @@ function CommunityPage() {
   isLoading,
   isError,
 } = useInfiniteQuery({
-  queryKey: ["communityFeed", id, trend],
+  queryKey: ["communityFeed", id, trend, hideWatched, feedUser],
   queryFn: fetchVideos,
   getNextPageParam: (lastPage, allPages) => {
     // 🧠 Stop fetching if we already got one batch (no real pagination)

--- a/src/components/Feed/Feed.jsx
+++ b/src/components/Feed/Feed.jsx
@@ -6,7 +6,8 @@ import { has3SpeakPostAuth } from '../../utils/hiveUtils';
 import { useAppStore } from '../../lib/store';
 import CardSkeleton from "../Cards/CardSkeleton"
 import axios from "axios"
-import { FEED_URL, FOLLOW_FEED_URL, appendNsfw } from '../../utils/config'
+import { FEED_URL, FOLLOW_FEED_URL, TRENDING_SORTED_URL, appendNsfw } from '../../utils/config'
+import { feedParams } from '../../utils/feedParams'
 import { useInfiniteQuery } from "@tanstack/react-query"
 import Card3 from "../Cards/Card3"
 import { useContentBatch } from "../../hooks/useContentBatch"
@@ -19,19 +20,17 @@ const FOLLOW_LIMIT = 50;
 
 const fetchFollowFeedVideos = async ({ pageParam = 1 }, username) => {
   const st = useAppStore.getState();
-  let url = appendNsfw(`${FOLLOW_FEED_URL}/${username}?page=${pageParam}&limit=${FOLLOW_LIMIT}`, st.showNsfw);
-  // "Hide watched" → let the checker skip videos this user already watched.
-  if (st.hideWatched && st.user) url += `&currentuser=${encodeURIComponent(st.user)}`;
+  // interests re-rank + hide-watched (when on) via the shared params.
+  const url = appendNsfw(`${FOLLOW_FEED_URL}/${username}?page=${pageParam}&limit=${FOLLOW_LIMIT}${feedParams()}`, st.showNsfw);
   const res = await axios.get(url);
   return res.data;
 };
 
 const fetchHomeVideos = async ({ pageParam = 0 }) => {
-  // checker's /feeds/trending is 1-based (`?page=1,2,...`) and returns
-  // `{success, feed, page, limit, total, totalPages, videos: [...]}`. Our
-  // infinite-query supplies pageParam 0,1,2…, so bump it by 1 here.
+  // Anonymous home: use the algo-aligned trendingSorted feed (retention + interests)
+  // instead of the legacy `trending`-flag endpoint. 1-based paging, {…,videos:[…]}.
   const page = (Number(pageParam) || 0) + 1;
-  const url = `${FEED_URL}/feeds/trending?page=${page}`;
+  const url = `${TRENDING_SORTED_URL}?page=${page}&limit=${FOLLOW_LIMIT}${feedParams()}`;
   const res = await axios.get(url);
   // Fall back through the older shapes in case FEED_URL is ever pointed back
   // at legacy.3speak.tv — keeps the consumer agnostic to either response.

--- a/src/components/SettingsModal/SettingsModal.jsx
+++ b/src/components/SettingsModal/SettingsModal.jsx
@@ -129,7 +129,7 @@ function Row({ title, desc, checked, onChange }) {
  * side menu, now grouped with headers + explanations and compact switches.
  */
 export default function SettingsModal({ isOpen, onClose }) {
-  const { theme, showNsfw, setShowNsfw, toggleTheme, sidebarHidden, setSidebarHidden, homeCardSize, setHomeCardSize, previewEnabled, setPreviewEnabled, hideWatched, setHideWatched } = useAppStore();
+  const { theme, showNsfw, setShowNsfw, toggleTheme, sidebarHidden, setSidebarHidden, homeCardSize, setHomeCardSize, previewEnabled, setPreviewEnabled, hideWatched, setHideWatched, privateMode, setPrivateMode } = useAppStore();
   const [tab, setTab] = useState('general');
   if (!isOpen) return null;
 
@@ -238,6 +238,12 @@ export default function SettingsModal({ isOpen, onClose }) {
                 desc="Leave out videos you've already watched from the home, trending and recommended feeds."
                 checked={!!hideWatched}
                 onChange={(v) => setHideWatched(v)}
+              />
+              <Row
+                title="Private mode"
+                desc="Don't record your IP address with watch statistics — only an anonymous per-browser id is used. Turning this on means your views won't appear in creators' country stats."
+                checked={!!privateMode}
+                onChange={(v) => setPrivateMode(v)}
               />
             </div>
 

--- a/src/hooks/useWatchDuration.js
+++ b/src/hooks/useWatchDuration.js
@@ -1,5 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { PLAYER_URL } from '../utils/config';
+import { getViewerId } from '../utils/viewerId';
+import { useAppStore } from '../lib/store';
 
 /**
  * Drives the snapievideoplayer watch-duration heartbeat against the player
@@ -86,7 +88,7 @@ export default function useWatchDuration({ api, author, permlink, playerState, e
           const res = await fetch(`${PLAYER_URL}/api/watch/start`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ owner, permlink: vPermlink, type, duration, position: posRef.current, source: '3speak' }),
+            body: JSON.stringify({ owner, permlink: vPermlink, type, duration, position: posRef.current, source: '3speak', viewerId: getViewerId(), private: !!useAppStore.getState().privateMode }),
           });
           if (!res.ok) continue;                       // 404 for the wrong collection → try the next
           const data = await res.json().catch(() => null);

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -45,6 +45,11 @@ export const useAppStore = create(
       // Hide videos the user has already watched from discovery feeds (default ON).
       hideWatched: true,
       setHideWatched: (val) => a[0]({ hideWatched: typeof val === 'function' ? val(a[1]().hideWatched) : val }),
+      // Private mode: when ON, watch-duration tracking sends only the pseudonymous
+      // viewer id and the server does NOT record the IP (so no country demographics
+      // for this viewer). Default OFF.
+      privateMode: false,
+      setPrivateMode: (val) => a[0]({ privateMode: typeof val === 'function' ? val(a[1]().privateMode) : val }),
       // Set on startup to the previous app version when the user upgraded (null = first
       // visit or no change). A future changelog / "what's new" prompt reads this.
       // Deliberately NOT persisted — recomputed each load by checkAppVersion().
@@ -73,6 +78,7 @@ export const useAppStore = create(
         previewEnabled: state.previewEnabled,
         interests: state.interests,
         hideWatched: state.hideWatched,
+        privateMode: state.privateMode,
       }),
     }
   )

--- a/src/page/Discover.jsx
+++ b/src/page/Discover.jsx
@@ -86,6 +86,8 @@ function saveState(state) {
 
 const Discover = () => {
   const showNsfw = useAppStore(s => s.showNsfw);
+  const hideWatched = useAppStore(s => s.hideWatched);
+  const feedUser = useAppStore(s => s.user);
   const saved = useRef(loadState());
   const [searchTerm, setSearchTerm] = useState(() => saved.current?.searchTerm || '');
   const [debouncedTerm, setDebouncedTerm] = useState(() => saved.current?.searchTerm?.trim() || '');
@@ -146,7 +148,7 @@ const Discover = () => {
     isLoading,
     isError,
   } = useInfiniteQuery({
-    queryKey: ["trending", showNsfw],
+    queryKey: ["trending", showNsfw, hideWatched, feedUser],
     queryFn: fetchVideos,
     getNextPageParam: (lastPage) => {
       if (!lastPage || lastPage.page >= lastPage.totalPages) return undefined;

--- a/src/page/Discover.jsx
+++ b/src/page/Discover.jsx
@@ -5,6 +5,7 @@ import { useInfiniteQuery, useQuery, useQueryClient } from "@tanstack/react-quer
 import axios from "axios";
 import Card3 from "../components/Cards/Card3";
 import { TRENDING_SORTED_URL, CHECKER_URL, appendNsfw } from '../utils/config';
+import { feedParams } from '../utils/feedParams';
 import { useAppStore } from "../lib/store";
 import { useContentBatch } from "../hooks/useContentBatch";
 import { useWatchHistory } from "../hooks/useWatchHistory";
@@ -35,7 +36,7 @@ const DATE_PRESETS = [
 ];
 
 const fetchVideos = async ({ pageParam = 1 }) => {
-  const url = appendNsfw(`${TRENDING_SORTED_URL}?page=${pageParam}&limit=${LIMIT}`, useAppStore.getState().showNsfw);
+  const url = appendNsfw(`${TRENDING_SORTED_URL}?page=${pageParam}&limit=${LIMIT}${feedParams()}`, useAppStore.getState().showNsfw);
   const res = await axios.get(url);
   return res.data;
 };

--- a/src/page/FirstUploads.jsx
+++ b/src/page/FirstUploads.jsx
@@ -4,6 +4,7 @@ import CardSkeleton from "../components/Cards/CardSkeleton";
 import axios from 'axios'
 import Card3 from '../components/Cards/Card3';
 import { FIRST_UPLOADS_URL } from '../utils/config';
+import { feedParams } from '../utils/feedParams';
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import { useContentBatch } from '../hooks/useContentBatch';
 import { useWatchHistory } from '../hooks/useWatchHistory';
@@ -15,7 +16,7 @@ const fetchVideos = async ({ pageParam = 1 }) => {
   // Checker /feeds/firstUploads is page-based (1,2,…) and returns
   // {success, feed, page, limit, total, totalPages, videos:[…]} — unwrap to
   // the array so the rest of this component keeps working as before.
-  const res = await axios.get(`${FIRST_UPLOADS_URL}?page=${pageParam}&limit=50`);
+  const res = await axios.get(`${FIRST_UPLOADS_URL}?page=${pageParam}&limit=50${feedParams()}`);
   return res.data.videos || [];
 };
 

--- a/src/page/FirstUploads.jsx
+++ b/src/page/FirstUploads.jsx
@@ -5,6 +5,7 @@ import axios from 'axios'
 import Card3 from '../components/Cards/Card3';
 import { FIRST_UPLOADS_URL } from '../utils/config';
 import { feedParams } from '../utils/feedParams';
+import { useAppStore } from '../lib/store';
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import { useContentBatch } from '../hooks/useContentBatch';
 import { useWatchHistory } from '../hooks/useWatchHistory';
@@ -22,6 +23,8 @@ const fetchVideos = async ({ pageParam = 1 }) => {
 
 const FirstUploads = () => {
   const queryClient = useQueryClient();
+  const hideWatched = useAppStore(s => s.hideWatched);
+  const user = useAppStore(s => s.user);
 
   const {
     data,
@@ -31,7 +34,7 @@ const FirstUploads = () => {
     isLoading,
     isError,
   } = useInfiniteQuery({
-    queryKey: ["firstupload"],
+    queryKey: ["firstupload", hideWatched, user],
     queryFn: fetchVideos,
     getNextPageParam: (lastPage, allPages) =>
       lastPage.length === 0 ? undefined : allPages.length + 1,

--- a/src/page/FollowFeed.jsx
+++ b/src/page/FollowFeed.jsx
@@ -5,6 +5,7 @@ import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import Card3 from "../components/Cards/Card3";
 import { FOLLOW_FEED_URL, appendNsfw } from "../utils/config";
+import { feedParams } from "../utils/feedParams";
 import { useContentBatch } from "../hooks/useContentBatch";
 import { useWatchHistory } from "../hooks/useWatchHistory";
 import useViewCounts from "../hooks/useViewCounts";
@@ -16,10 +17,8 @@ const LIMIT = 50;
 
 const fetchVideos = async ({ pageParam = 1 }, username) => {
   const st = useAppStore.getState();
-  let url = appendNsfw(`${FOLLOW_FEED_URL}/${username}?page=${pageParam}&limit=${LIMIT}`, st.showNsfw);
-  // "Hide watched" → let the checker skip videos this user already watched
-  // (same currentuser filter the trending / grouped feeds use).
-  if (st.hideWatched && st.user) url += `&currentuser=${encodeURIComponent(st.user)}`;
+  // interests re-rank + hide-watched (when the setting is on) via the shared params.
+  const url = appendNsfw(`${FOLLOW_FEED_URL}/${username}?page=${pageParam}&limit=${LIMIT}${feedParams()}`, st.showNsfw);
   const res = await axios.get(url);
   return res.data;
 };

--- a/src/page/Short.jsx
+++ b/src/page/Short.jsx
@@ -65,6 +65,7 @@ const HiveIcon = ({ size = 24, className = '' }) => (
 );
 import hiveApi, { regenerateShortsSeed, consumePreloadedShorts, hasShortsPreloaded, preloadShorts, fetchUserShortsWithDetails } from '../hive-api/hiveApi';
 import { useAppStore } from '../lib/store';
+import { getViewerId } from '../utils/viewerId';
 import { recordWatch } from '../utils/watchHistory';
 import { recordReshare, getResharesForVideo, deleteReshare } from '../utils/reshares';
 import axios from 'axios';
@@ -178,7 +179,7 @@ async function startShortWatch(video, watchRef, duration, position) {
       const res = await fetch(`${PLAYER_URL}/api/watch/start`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ owner: video.author, permlink, type, duration: duration || undefined, position: position || 0, source: '3speak' }),
+        body: JSON.stringify({ owner: video.author, permlink, type, duration: duration || undefined, position: position || 0, source: '3speak', viewerId: getViewerId(), private: !!useAppStore.getState().privateMode }),
       });
       if (!res.ok) continue;                          // 404 for the wrong collection → try next
       const data = await res.json().catch(() => null);

--- a/src/page/TagFeed.jsx
+++ b/src/page/TagFeed.jsx
@@ -5,6 +5,8 @@ import axios from 'axios';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import Card3 from '../components/Cards/Card3';
 import { TAG_FEED_URL } from '../utils/config';
+import { feedParams } from '../utils/feedParams';
+import { useAppStore } from '../lib/store';
 import { useContentBatch } from '../hooks/useContentBatch';
 import { useWatchHistory } from '../hooks/useWatchHistory';
 import useViewCounts from '../hooks/useViewCounts';
@@ -22,6 +24,8 @@ function TagFeed() {
   const [activeTab, setActiveTab] = useState('videos');
   const [dateFilter, setDateFilter] = useState('all');
   const [currentPage, setCurrentPage] = useState(1);
+  const hideWatched = useAppStore(s => s.hideWatched);
+  const feedUser = useAppStore(s => s.user);
 
   const since = useMemo(() => getSinceTimestamp(dateFilter), [dateFilter]);
 
@@ -49,9 +53,9 @@ function TagFeed() {
 
   // Always pass type — avoids the expensive merged "all" path on the backend
   const { data, isLoading, isFetching, isError } = useQuery({
-    queryKey: ['tagFeed', tag, activeTab, since, currentPage],
+    queryKey: ['tagFeed', tag, activeTab, since, currentPage, hideWatched, feedUser],
     queryFn: async () => {
-      let url = `${TAG_FEED_URL}/videos/tag/${tag}?page=${currentPage}&limit=${LIMIT}&type=${activeTab}`;
+      let url = `${TAG_FEED_URL}/videos/tag/${tag}?page=${currentPage}&limit=${LIMIT}&type=${activeTab}${feedParams()}`;
       if (since) url += `&since=${since}`;
       const res = await axios.get(url);
       return res.data;

--- a/src/page/Trend.jsx
+++ b/src/page/Trend.jsx
@@ -23,6 +23,8 @@ const fetchVideos = async ({ pageParam = 1 }) => {
 
 const Trend = () => {
   const showNsfw = useAppStore(s => s.showNsfw);
+  const hideWatched = useAppStore(s => s.hideWatched);
+  const user = useAppStore(s => s.user);
   const queryClient = useQueryClient();
 
   const {
@@ -33,7 +35,7 @@ const Trend = () => {
     isLoading,
     isError,
   } = useInfiniteQuery({
-    queryKey: ["trending", showNsfw],
+    queryKey: ["trending", showNsfw, hideWatched, user],
     queryFn: fetchVideos,
     getNextPageParam: (lastPage) => {
       if (!lastPage || lastPage.page >= lastPage.totalPages) return undefined;

--- a/src/page/Trend.jsx
+++ b/src/page/Trend.jsx
@@ -5,6 +5,7 @@ import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import Card3 from "../components/Cards/Card3";
 import { TRENDING_SORTED_URL, appendNsfw } from '../utils/config';
+import { feedParams } from '../utils/feedParams';
 import { useAppStore } from '../lib/store';
 import { useContentBatch } from "../hooks/useContentBatch";
 import { useWatchHistory } from "../hooks/useWatchHistory";
@@ -15,7 +16,7 @@ import { TrendingIcon } from "../components/FeedIcons";
 const LIMIT = 50;
 
 const fetchVideos = async ({ pageParam = 1 }) => {
-  const url = appendNsfw(`${TRENDING_SORTED_URL}?page=${pageParam}&limit=${LIMIT}`, useAppStore.getState().showNsfw);
+  const url = appendNsfw(`${TRENDING_SORTED_URL}?page=${pageParam}&limit=${LIMIT}${feedParams()}`, useAppStore.getState().showNsfw);
   const res = await axios.get(url);
   return res.data;
 };

--- a/src/utils/feedParams.js
+++ b/src/utils/feedParams.js
@@ -1,0 +1,22 @@
+import { useAppStore } from '../lib/store';
+
+/**
+ * Shared feed query params for every checker-backed discovery feed, so they all
+ * behave the same way:
+ *   - `interests=` — the user's selected interests (re-ranks matching videos up)
+ *   - `currentuser=` — only when "Hide watched" is on (server drops seen videos)
+ *
+ * Returns a string like "&interests=a,b&currentuser=bob" (leading `&`), or "" when
+ * neither applies — so it can be appended straight onto a feed URL. The checker
+ * treats both as optional, so this is always safe to include.
+ *
+ * NOT used on the "new videos" feed, which must stay purely chronological.
+ */
+export function feedParams() {
+  const st = useAppStore.getState();
+  let p = '';
+  const list = st.interests;
+  if (Array.isArray(list) && list.length) p += `&interests=${encodeURIComponent(list.join(','))}`;
+  if (st.hideWatched && st.user) p += `&currentuser=${encodeURIComponent(st.user)}`;
+  return p;
+}

--- a/src/utils/viewerId.js
+++ b/src/utils/viewerId.js
@@ -1,0 +1,29 @@
+/**
+ * Stable, pseudonymous per-browser viewer id for watch-duration tracking.
+ *
+ * Generated once on first visit and persisted, so the same browser counts as ONE
+ * viewer across visits — which is what "distinct viewers" / "new vs returning"
+ * need. It's more privacy-preserving than an IP (no cross-site meaning, not tied
+ * to your network/location) AND more accurate (an IP is shared across a household
+ * / behind NAT). It's sent on every watch session:
+ *   - Private Mode ON  → the server stores ONLY this id and drops the IP entirely.
+ *   - Private Mode OFF → sent alongside the IP; the id is the viewer key, the IP is
+ *     kept just for coarse country demographics.
+ */
+const KEY = '3speak_viewer_id';
+
+export function getViewerId() {
+  try {
+    let id = localStorage.getItem(KEY);
+    if (!id) {
+      const rnd = (typeof crypto !== 'undefined' && crypto.randomUUID)
+        ? crypto.randomUUID()
+        : `${Date.now().toString(36)}${Math.random().toString(36).slice(2)}${Math.random().toString(36).slice(2)}`;
+      id = String(rnd).replace(/[^a-zA-Z0-9]/g, '').slice(0, 40);
+      localStorage.setItem(KEY, id);
+    }
+    return id;
+  } catch {
+    return null; // private-browsing with storage disabled → server falls back to IP
+  }
+}


### PR DESCRIPTION
This pull request introduces a new "Private mode" feature, which allows users to prevent their IP address from being recorded with watch statistics, and ensures only an anonymous per-browser ID is sent. Additionally, it unifies and centralizes feed query parameters (such as "hide watched" and user interests) across all major video and discovery feeds by using a shared `feedParams()` utility. This makes feed behavior more consistent and ensures settings like "hide watched" are always respected. Query keys for React Query are also updated to include relevant user state, enabling proper cache invalidation when these settings change.

**Private mode and watch tracking:**

* Added a "Private mode" toggle to the `SettingsModal`, storing its state in the central `useAppStore` and exposing `privateMode` and `setPrivateMode` methods. [[1]](diffhunk://#diff-4ce32d79e4f131eb0281aa501f7a4ddcbee6140ab18c5e5d318a7c5574728001L132-R132) [[2]](diffhunk://#diff-4ce32d79e4f131eb0281aa501f7a4ddcbee6140ab18c5e5d318a7c5574728001R242-R247) [[3]](diffhunk://#diff-fb22c95a502cae93ba1418946e8c3ecf35676cde6f5fd8c665df3c9ec7853d9eR48-R52)
* Updated watch duration tracking (`useWatchDuration.js` and Shorts player) to send the `viewerId` and the `private` flag to the backend, so the server can avoid recording the user's IP address when private mode is enabled. [[1]](diffhunk://#diff-2eded800ede19351bdfba52477799bf3d8dc2c4a8d879de137b85064870f4c25R3-R4) [[2]](diffhunk://#diff-2eded800ede19351bdfba52477799bf3d8dc2c4a8d879de137b85064870f4c25L89-R91) [[3]](diffhunk://#diff-a1ff528d089628426201fb81fc069f11164bcfabaa1309bc7c969998646668bdL181-R182)

**Feed query parameter unification:**

* Introduced the `feedParams()` utility and applied it to all major feed endpoints (trending, follow, community, first uploads, tag feeds, etc.), ensuring parameters like "hide watched" and user interests are consistently included. [[1]](diffhunk://#diff-b1808a78014227434f811f4cfd86506213996fcb2fbe0022b3c96e9a43357b32L52-R58) [[2]](diffhunk://#diff-76f6f503be08883ba4c19058f9b21eb3d8365ba7eea3a3d50d3fe1af2984bb08L22-R33) [[3]](diffhunk://#diff-ef4485af80a101a77ccfb57b47f3f6a098c21bc00a2054aa1dfee924cbc9c5baL38-R39) [[4]](diffhunk://#diff-cc0c82ab94d20ac5c933c4a8d728964ae94b8bd64b1ebe1025d4e7326d255509L18-R27) [[5]](diffhunk://#diff-14889e28d584858c29c8e2ec64ca7986434bd9ad7dfbc6e7b702d295e3093ceaL19-R21) [[6]](diffhunk://#diff-70b8ee9857444bd031fe72620a61153f53da0b10f1d5e4096c9f5a7d8d037a8dL52-R58)

**React Query cache key improvements:**

* Updated all relevant React Query `queryKey`s to include `hideWatched`, `feedUser`, or `user` so that feed results are properly invalidated and refetched when user settings change. [[1]](diffhunk://#diff-b1808a78014227434f811f4cfd86506213996fcb2fbe0022b3c96e9a43357b32L68-R74) [[2]](diffhunk://#diff-ef4485af80a101a77ccfb57b47f3f6a098c21bc00a2054aa1dfee924cbc9c5baL148-R151) [[3]](diffhunk://#diff-cc0c82ab94d20ac5c933c4a8d728964ae94b8bd64b1ebe1025d4e7326d255509L33-R37) [[4]](diffhunk://#diff-70b8ee9857444bd031fe72620a61153f53da0b10f1d5e4096c9f5a7d8d037a8dL52-R58)

**State management enhancements:**

* Extended `useAppStore` to persist and expose the new `privateMode` state, and ensured selectors and serialization include it. [[1]](diffhunk://#diff-fb22c95a502cae93ba1418946e8c3ecf35676cde6f5fd8c665df3c9ec7853d9eR48-R52) [[2]](diffhunk://#diff-fb22c95a502cae93ba1418946e8c3ecf35676cde6f5fd8c665df3c9ec7853d9eR81)

**Codebase consistency:**

* Updated imports and feed function signatures across all affected files to use the new centralized utilities and state. [[1]](diffhunk://#diff-b1808a78014227434f811f4cfd86506213996fcb2fbe0022b3c96e9a43357b32R8) [[2]](diffhunk://#diff-b1808a78014227434f811f4cfd86506213996fcb2fbe0022b3c96e9a43357b32R18) [[3]](diffhunk://#diff-76f6f503be08883ba4c19058f9b21eb3d8365ba7eea3a3d50d3fe1af2984bb08L9-R10) [[4]](diffhunk://#diff-ef4485af80a101a77ccfb57b47f3f6a098c21bc00a2054aa1dfee924cbc9c5baR8) [[5]](diffhunk://#diff-cc0c82ab94d20ac5c933c4a8d728964ae94b8bd64b1ebe1025d4e7326d255509R7-R8) [[6]](diffhunk://#diff-14889e28d584858c29c8e2ec64ca7986434bd9ad7dfbc6e7b702d295e3093ceaR8) [[7]](diffhunk://#diff-70b8ee9857444bd031fe72620a61153f53da0b10f1d5e4096c9f5a7d8d037a8dR8-R9) [[8]](diffhunk://#diff-a1ff528d089628426201fb81fc069f11164bcfabaa1309bc7c969998646668bdR68)

These changes collectively improve user privacy, ensure consistent feed behavior, and make the codebase easier to maintain.