### PR TITLE
Feat/july fun

### DIFF
--- a/src/components/EmergencyScreen/Bootstrap.jsx
+++ b/src/components/EmergencyScreen/Bootstrap.jsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import App from '../../App';
+import EmergencyScreen, { EMERGENCY_MODE } from './EmergencyScreen';
+import { checkPlatformHealth } from '../../utils/healthGate';
+
+// Dev escape hatch: set VITE_DISABLE_HEALTH_GATE=true in .env to skip the
+// /healthz probe entirely and always render the app. Use it for local/dev work
+// so a flaky or unreachable checker never blocks the app behind the maintenance
+// screen. Leave it unset (or false) in the deployed .env.
+const HEALTH_GATE_DISABLED =
+  String(import.meta.env.VITE_DISABLE_HEALTH_GATE).toLowerCase() === 'true';
+
+/**
+ * Load-time maintenance gate. Decides — on the fly, per visit — whether to render
+ * the app or the maintenance takeover:
+ *
+ *   1. EMERGENCY_MODE (compile-time const) → hard override, straight to takeover.
+ *   2. Otherwise ask the checker's /healthz once. While the probe is in flight we
+ *      show a neutral branded splash (no scary copy). Then render <App/> when it
+ *      reports healthy, or the full maintenance screen when it reports down.
+ *
+ * The probe fails OPEN (see healthGate.js): a health-endpoint hiccup shows the
+ * app, never a false outage screen.
+ */
+export default function Bootstrap() {
+  // 'checking' | 'ok' | 'down'
+  const [phase, setPhase] = useState(() => {
+    if (EMERGENCY_MODE) return 'down'; // hard override wins
+    if (HEALTH_GATE_DISABLED) return 'ok'; // dev: skip probe, straight to app
+    return 'checking';
+  });
+
+  useEffect(() => {
+    if (EMERGENCY_MODE || HEALTH_GATE_DISABLED) return; // no probe needed
+    let alive = true;
+    checkPlatformHealth().then(({ healthy }) => {
+      if (alive) setPhase(healthy ? 'ok' : 'down');
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  if (phase === 'checking') return <EmergencyScreen variant="checking" />;
+  if (phase === 'down') return <EmergencyScreen />;
+  return <App />;
+}

--- a/src/components/EmergencyScreen/EmergencyScreen.jsx
+++ b/src/components/EmergencyScreen/EmergencyScreen.jsx
@@ -6,7 +6,7 @@ import { useAppStore } from '../../lib/store';
 // ── EMERGENCY / MAINTENANCE takeover ──────────────────────────────────────────
 // Flip this to `false` (or delete the early-return in App.jsx) to bring the app
 // back once the infrastructure issue is resolved.
-export const EMERGENCY_MODE = true;
+export const EMERGENCY_MODE = false;
 
 /**
  * Full-screen takeover shown INSTEAD of the app while there's an outage: just the

--- a/src/components/EmergencyScreen/EmergencyScreen.jsx
+++ b/src/components/EmergencyScreen/EmergencyScreen.jsx
@@ -4,17 +4,25 @@ import logoDark from '../../assets/image/3S_logodark.png';
 import { useAppStore } from '../../lib/store';
 
 // ── EMERGENCY / MAINTENANCE takeover ──────────────────────────────────────────
-// Flip this to `false` (or delete the early-return in App.jsx) to bring the app
-// back once the infrastructure issue is resolved.
+// HARD override: flip to `true` to force the maintenance screen for everyone,
+// no network round-trip. When `false` (normal), Bootstrap instead decides at
+// load time from the checker's /healthz probe (see utils/healthGate.js) — and
+// ops can force maintenance without any redeploy via the checker's
+// MAINTENANCE_MODE env. So this const is only for a deliberate, baked-in takeover.
 export const EMERGENCY_MODE = false;
 
 /**
- * Full-screen takeover shown INSTEAD of the app while there's an outage: just the
- * 3Speak logo, a short message, and a spinner. Nothing else renders.
+ * Full-screen takeover shown INSTEAD of the app.
+ *
+ * variant="down" (default): 3Speak logo, outage message, Discord link, spinner.
+ * variant="checking": neutral branded splash (logo + spinner only) shown for the
+ *   brief moment the health probe is in flight, so a healthy load never flashes
+ *   the scary "infrastructure issues" copy.
  */
-export default function EmergencyScreen() {
+export default function EmergencyScreen({ variant = 'down' }) {
   const theme = useAppStore((s) => s.theme);
   const isDark = theme !== 'light'; // dark is the default
+  const checking = variant === 'checking';
 
   return (
     <div
@@ -39,6 +47,7 @@ export default function EmergencyScreen() {
         style={{ width: 'min(220px, 62vw)', height: 'auto' }}
       />
 
+      {!checking && (
       <div style={{ maxWidth: '460px' }}>
         <h1 style={{ fontSize: 'clamp(20px, 4.5vw, 27px)', fontWeight: 700, margin: '0 0 12px' }}>
           We&rsquo;re having some infrastructure issues
@@ -55,7 +64,9 @@ export default function EmergencyScreen() {
           Discord to reach us and get live updates &mdash; thanks for your patience.
         </p>
       </div>
+      )}
 
+      {!checking && (
       <a
         href="https://discord.com/invite/NSFS2VGj83"
         target="_blank"
@@ -79,6 +90,7 @@ export default function EmergencyScreen() {
         </svg>
         Join our Discord
       </a>
+      )}
 
       <TailChase size="42" speed="1.75" color="var(--accent-primary, #e0594b)" />
     </div>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -25,8 +25,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux'; // Importing the Provider from react-redux
-import App from './App';
-import EmergencyScreen, { EMERGENCY_MODE } from './components/EmergencyScreen/EmergencyScreen';
+import Bootstrap from './components/EmergencyScreen/Bootstrap';
 import './index.css';
 import store from '../src/redux/Store'; // Importing the Redux store (replace with your store file path)
 import { ToastContainer } from 'react-toastify';
@@ -49,7 +48,7 @@ createRoot(document.getElementById('root')).render(
           <AppProviders>
             <QueryClientProvider client={queryClient}>
               <Provider store={store}> {/* Wrap the app with the Redux Provider */}
-                {EMERGENCY_MODE ? <EmergencyScreen /> : <App />}
+                <Bootstrap />
                 <ToastContainer className="custom-toast-body"/>
               </Provider>
             </QueryClientProvider>

--- a/src/utils/healthGate.js
+++ b/src/utils/healthGate.js
@@ -1,0 +1,30 @@
+// Runtime maintenance gate. On load the app asks the checker's /healthz whether
+// the platform is healthy enough to serve; Bootstrap uses the answer to decide
+// between rendering <App/> and the maintenance <EmergencyScreen/>.
+//
+// Fail-OPEN: any network error, timeout, or non-JSON response resolves to
+// healthy, so a hiccup in the health endpoint itself can never lock users out.
+// We only take over the page when the checker is reachable AND explicitly
+// reports the platform is down (Mongo unreachable, or ops set MAINTENANCE_MODE).
+import { CHECKER_URL } from './config';
+
+export async function checkPlatformHealth(timeoutMs = 2500) {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const res = await fetch(`${CHECKER_URL}/healthz`, {
+      signal: controller.signal,
+      cache: 'no-store',
+    });
+    clearTimeout(timer);
+
+    // /healthz always answers 200; a 5xx here means the checker/proxy itself is
+    // sick, not a deliberate maintenance signal — fail open.
+    if (!res.ok) return { healthy: true, reason: `http ${res.status}` };
+
+    const data = await res.json();
+    return { healthy: data.ok !== false, data };
+  } catch (err) {
+    return { healthy: true, reason: 'unreachable' };
+  }
+}


### PR DESCRIPTION
This pull request introduces a runtime health gate for maintenance mode, replacing the previous hardcoded approach. The app now checks platform health at load time and conditionally renders either the main app or a maintenance screen, with improved handling for both development and production environments. The most important changes are grouped below.

**Maintenance Mode System Overhaul**

* Added a new `Bootstrap` component (`src/components/EmergencyScreen/Bootstrap.jsx`) that determines at runtime whether to render the main app or the maintenance screen by probing `/healthz`, with a dev escape hatch via `.env`.
* Introduced the `checkPlatformHealth` utility (`src/utils/healthGate.js`) to handle the health check logic, including a fail-open strategy to avoid false outages due to network hiccups.
* Updated the main entry point (`src/main.jsx`) to render the new `Bootstrap` component instead of directly toggling based on a static `EMERGENCY_MODE` constant. [[1]](diffhunk://#diff-752aae33033979082689dba3e7f51955013615f0535c21ac94265e067da311edL28-R28) [[2]](diffhunk://#diff-752aae33033979082689dba3e7f51955013615f0535c21ac94265e067da311edL52-R51)

**Emergency Screen Improvements**

* Changed the `EMERGENCY_MODE` constant in `EmergencyScreen.jsx` to default to `false` and clarified its use as a hard override only for deliberate, baked-in maintenance takeovers.
* Enhanced the `EmergencyScreen` component to support a `variant="checking"` state for a neutral splash during health checks, hiding the outage message and Discord link until a real outage is detected. [[1]](diffhunk://#diff-c9f2d0aed29a22b3e45034a44fdea0814505fd1f226b44e04fe13f71f50a808cR50) [[2]](diffhunk://#diff-c9f2d0aed29a22b3e45034a44fdea0814505fd1f226b44e04fe13f71f50a808cR67-R69) [[3]](diffhunk://#diff-c9f2d0aed29a22b3e45034a44fdea0814505fd1f226b44e04fe13f71f50a808cR93)