### PR TITLE
feat(interests): point the Interests row at the dedicated /feeds/inte…

### DIFF
--- a/src/page/HomeGrouped.jsx
+++ b/src/page/HomeGrouped.jsx
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom";
 import "./HomeGrouped.scss";
 import CardSkeleton from "../components/Cards/CardSkeleton";
 import Card3 from "../components/Cards/Card3";
-import { FEED_URL, TRENDING_SORTED_URL, FOLLOW_FEED_URL, DISCOVER_FEED_URL, NEW_CONTENT_URL, CHECKER_URL, appendNsfw } from "../utils/config";
+import { FEED_URL, TRENDING_SORTED_URL, FOLLOW_FEED_URL, DISCOVER_FEED_URL, INTERESTS_FEED_URL, NEW_CONTENT_URL, CHECKER_URL, appendNsfw } from "../utils/config";
 import { useContentBatch } from "../hooks/useContentBatch";
 import { useWatchHistory } from "../hooks/useWatchHistory";
 import useViewCounts from "../hooks/useViewCounts";
@@ -66,8 +66,12 @@ const fetchDiscover = async (page = 1) => {
 
 // "Interests" row: ONLY videos whose winning topic is in the user's interests,
 // re-ranked by retention with older ones sprinkled in. Empty with no interests.
+// Uses the DEDICATED /feeds/interests endpoint, which has its own topic-stratified
+// pool. The old `/feeds/discover?interestsOnly=1` filtered the discover pool — a
+// uniform sample of the catalogue — so niche topics ran out after a page or two
+// (science surfaced 29 of its 785 videos). Now every topic has ~25+ pages.
 const fetchInterestsFeed = async (page = 1) => {
-  const res = await axios.get(appendNsfw(`${DISCOVER_FEED_URL}?page=${page}&limit=${PAGE_POOL}&interestsOnly=1${feedParams()}`, useAppStore.getState().showNsfw));
+  const res = await axios.get(appendNsfw(`${INTERESTS_FEED_URL}?page=${page}&limit=${PAGE_POOL}${feedParams()}`, useAppStore.getState().showNsfw));
   return res.data?.videos || [];
 };
 

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -17,6 +17,10 @@ const TRENDING_SORTED_URL = `${CHECKER_URL}/feeds/trendingSorted`;
 const FOLLOW_FEED_URL = `${CHECKER_URL}/feed`;
 // Discovery feed: interest + retention driven, ignores votes/views entirely.
 const DISCOVER_FEED_URL = `${CHECKER_URL}/feeds/discover`;
+// Dedicated interests feed. It has its OWN topic-stratified pool — the old
+// `/feeds/discover?interestsOnly=1` filtered the discover pool, which is a uniform
+// sample of the catalogue, so a single-topic filter starved it (science: 1 page).
+const INTERESTS_FEED_URL = `${CHECKER_URL}/feeds/interests`;
 const NEW_CONTENT_URL = `${CHECKER_URL}/feeds/new`;
 const FIRST_UPLOADS_URL = `${CHECKER_URL}/feeds/firstUploads`;
 const SHORTS_STORIES_URL = `${CHECKER_URL}/shorts/stories`;
@@ -181,6 +185,7 @@ export {
   TRENDING_SORTED_URL,
   FOLLOW_FEED_URL,
   DISCOVER_FEED_URL,
+  INTERESTS_FEED_URL,
   NEW_CONTENT_URL,
   FIRST_UPLOADS_URL,
   SHORTS_STORIES_URL,


### PR DESCRIPTION
…rests

Was /feeds/discover?interestsOnly=1, which filtered the discover pool — a uniform sample of the catalogue — so niche topics ran out after a page or two (science surfaced 29 of its 785 videos). The new endpoint has its own topic-stratified pool, so every topic pages properly (science 1 -> 25 pages).