### PR TITLE
Feat/july fun

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ docs/BACKEND_SCHEDULING_REQUIREMENTS.md
 docs/SCHEDULING_SPEC.md
 internal-docs/server/.env
 .claude/
+
+# Backups of .env — same secrets, and NOT covered by the .env rule above.
+.env.bak*

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.55.0',
+    date: '2026-07-12',
+    summary:
+      'Shorts now also show up between the recommended videos on a watch page, picked to match the topic of the video you\u2019re watching. Don\u2019t want shorts mixed into your lists? Turn off \u201CShorts inside the feeds\u201D in Settings \u2192 Shorts. On the Stories view, the comments panel no longer covers the creators bar and now closes away completely.',
+  },
+  {
     version: '1.54.0',
     date: '2026-07-12',
     summary:

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.54.0',
+    date: '2026-07-12',
+    summary:
+      'Shorts now appear inside the home feeds — a row of them every couple of rows of videos. Discover and Interests show the usual shorts, the Follow Feed shows only shorts from people you follow, and New Content shows the newest first. The Trending tab has been removed.',
+  },
+  {
     version: '1.53.0',
     date: '2026-07-12',
     summary:

--- a/src/components/Cards/Card3.jsx
+++ b/src/components/Cards/Card3.jsx
@@ -21,7 +21,30 @@ import ProfileModal from "../modal/ProfileModal";
 import useHoverPreview from "../../hooks/useHoverPreview";
 
 
-function Card3({ videos = [], loading = false, error = null, getContentForVideo = null, isWatched = null, getViewCount = null, linkPrefix = '/watch', linkQuery = '', shortTimeAgo = true, shortsGrid = false, priority = false }) {
+/**
+ * Splice extra nodes into the card grid after every `every` cards — used by the
+ * Discover tab to drop a shorts rail between video rows.
+ *
+ * The inserted node must span the whole grid (`grid-column: 1 / -1`, see
+ * ShortsRow.scss) or it would just occupy one cell and shove the row out of
+ * alignment. `every` is computed from the LIVE column count, not guessed, so the
+ * rail always lands on a row boundary at any breakpoint.
+ */
+function withInterleave(cards, every, render) {
+  if (!every || every < 1 || typeof render !== 'function') return cards;
+  const out = [];
+  cards.forEach((card, i) => {
+    out.push(card);
+    if ((i + 1) % every === 0 && i + 1 < cards.length) {
+      const slot = (i + 1) / every - 1;
+      const node = render(slot);
+      if (node) out.push(<div className="card-interleave" key={`interleave-${slot}`}>{node}</div>);
+    }
+  });
+  return out;
+}
+
+function Card3({ videos = [], loading = false, error = null, interleaveEvery = 0, renderInterleave = null, getContentForVideo = null, isWatched = null, getViewCount = null, linkPrefix = '/watch', linkQuery = '', shortTimeAgo = true, shortsGrid = false, priority = false }) {
   const navigate = useNavigate();
   const [modalUser, setModalUser] = useState(null);
 
@@ -88,7 +111,7 @@ function Card3({ videos = [], loading = false, error = null, getContentForVideo 
       className={`card-container${shortsGrid ? ' card-container--shorts' : ''}`}
       {...containerProps}
     >
-      {processedVideos.map((video, index) => {
+      {withInterleave(processedVideos.map((video, index) => {
         const postKey = `${video.author?.username || video.author || video.owner}/${
           video.permlink
         }`;
@@ -244,7 +267,7 @@ function Card3({ videos = [], loading = false, error = null, getContentForVideo 
             </div>
           </Link>
         );
-      })}
+      }), interleaveEvery, renderInterleave)}
       {modalUser && (
         <ProfileModal
           username={modalUser}

--- a/src/components/SettingsModal/SettingsModal.jsx
+++ b/src/components/SettingsModal/SettingsModal.jsx
@@ -144,7 +144,7 @@ const TABS = [
  * side menu, now grouped with headers + explanations and compact switches.
  */
 export default function SettingsModal({ isOpen, onClose }) {
-  const { theme, showNsfw, setShowNsfw, toggleTheme, sidebarHidden, setSidebarHidden, homeCardSize, setHomeCardSize, previewEnabled, setPreviewEnabled, shortsCommentBar, setShortsCommentBar, openShortsOnStart, setOpenShortsOnStart, hideWatched, setHideWatched, privateMode, setPrivateMode, simpleFeed, setSimpleFeed } = useAppStore();
+  const { theme, showNsfw, setShowNsfw, toggleTheme, sidebarHidden, setSidebarHidden, homeCardSize, setHomeCardSize, previewEnabled, setPreviewEnabled, shortsCommentBar, setShortsCommentBar, openShortsOnStart, setOpenShortsOnStart, inlineShorts, setInlineShorts, hideWatched, setHideWatched, privateMode, setPrivateMode, simpleFeed, setSimpleFeed } = useAppStore();
   const [tab, setTab] = useState('general');
 
   // Lock background page scroll while the modal is open (restore on close).
@@ -292,6 +292,12 @@ export default function SettingsModal({ isOpen, onClose }) {
               desc="Go straight to Shorts when you open 3Speak, instead of the home feed."
               checked={!!openShortsOnStart}
               onChange={(v) => setOpenShortsOnStart(v)}
+            />
+            <Row
+              title="Shorts inside the feeds"
+              desc="Show rows of shorts between the videos in the home feeds and the recommendations on a watch page. Turn off to keep those lists videos-only."
+              checked={inlineShorts !== false}
+              onChange={(v) => setInlineShorts(v)}
             />
           </div>
         )}

--- a/src/components/ShortsRow/ShortsRow.jsx
+++ b/src/components/ShortsRow/ShortsRow.jsx
@@ -1,0 +1,91 @@
+import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import CardThumbnail from '../Cards/CardThumbnail';
+import { fixVideoThumbnail, fallbackImg } from '../../utils/fixThumbnails';
+import { parseEmbedUrl, bodyToPlaintext } from '../../hive-api/hiveApi';
+import './ShortsRow.scss';
+
+/**
+ * ONE FULL ROW of shorts dropped INTO the video grid every few rows (see
+ * HomeGrouped). It spans the full grid width (`.card-interleave` gets
+ * `grid-column: 1 / -1`), so it reads as its own row between the video rows.
+ *
+ * Not a scroller: the caller measures how many shorts fit at the current width and
+ * hands us exactly that many, plus the column count — so the row fills the width
+ * edge-to-edge with no overflow and no second line.
+ *
+ * No heading and no "see all" — it should read as part of the feed, not as a
+ * separate widget.
+ */
+
+/**
+ * Shorts are posted as Hive COMMENTS, and comments have no title: `hive_title` is
+ * empty for ~7 of 8, and `embed_title` is sometimes the literal string "Comment".
+ * The real caption is the body — same source the shorts viewer uses — so run it
+ * through bodyToPlaintext (strips the embed URL, markdown, HTML, tags) and take
+ * the opening as the title.
+ */
+function shortTitle(s) {
+  const caption = bodyToPlaintext(s.hive_body || '').trim();
+  if (caption) return caption;
+
+  const hive = (s.hive_title || '').trim();
+  if (hive) return hive;
+
+  const embed = (s.embed_title || '').trim();
+  // "Comment" is the placeholder the uploader writes for a comment-type post —
+  // never show it as a title.
+  if (embed && embed.toLowerCase() !== 'comment') return embed;
+
+  return '';
+}
+
+function ShortsRow({ shorts, columns }) {
+  if (!shorts?.length) return null;
+
+  return (
+    <div
+      className="shorts-row"
+      // The column count is computed from the live container width, so the row is
+      // always exactly full. `minmax(0, 1fr)` (not just 1fr) lets the cards shrink
+      // to the track instead of overflowing on a long title.
+      style={{ gridTemplateColumns: `repeat(${columns || shorts.length}, minmax(0, 1fr))` }}
+    >
+      {shorts.map((s) => {
+        // The feed keys a short by its ASSET permlink, but the shorts viewer is
+        // addressed by the HIVE author from embed_url ("@author/permlink").
+        const { author } = parseEmbedUrl(s.embed_url);
+        const finalAuthor = author || s.owner;
+        const title = shortTitle(s);
+
+        return (
+          <Link
+            key={`${finalAuthor}/${s.permlink}`}
+            to={`/shorts?v=${finalAuthor}/${s.permlink}`}
+            className="shorts-row-card"
+            title={title || `@${finalAuthor}`}
+          >
+            <div className="shorts-row-thumb">
+              <CardThumbnail
+                src={fixVideoThumbnail(s, true)}
+                fallback={fallbackImg}
+                alt={title}
+              />
+            </div>
+            <div className="shorts-row-meta">
+              <h2>{title || `@${finalAuthor}`}</h2>
+              <span className="shorts-row-author">@{finalAuthor}</span>
+            </div>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}
+
+ShortsRow.propTypes = {
+  shorts: PropTypes.array,
+  columns: PropTypes.number,
+};
+
+export default ShortsRow;

--- a/src/components/ShortsRow/ShortsRow.scss
+++ b/src/components/ShortsRow/ShortsRow.scss
@@ -1,0 +1,104 @@
+@use "../../mixins.scss" as mix;
+
+/* A shorts rail living INSIDE the video grid.
+   `.card-interleave` is the wrapper Card3 emits, i.e. the actual GRID ITEM — so the
+   column span has to go there. Putting it on `.shorts-row` (a child) would do
+   nothing and the rail would be squeezed into a single cell. */
+.card-interleave {
+  grid-column: 1 / -1;
+  min-width: 0;
+}
+
+/* One full row of shorts — NOT a horizontal scroller. The column count is computed
+   from the live container width (see useShortsPerRow) and passed in as an inline
+   `grid-template-columns`, and the slice handed to this component is exactly that
+   many shorts. So the row always fills the width edge-to-edge with no overflow and
+   no second line. */
+.shorts-row {
+  display: grid;
+  gap: 16px;              /* matches the video grid's column gap */
+  margin: 2px 0 6px;
+  min-width: 0;
+
+  @include mix.respond(phone) {
+    gap: 10px;
+  }
+}
+
+/* Same card treatment as Card3's `.card` (background, radius, shadow, hover lift)
+   — only the thumbnail aspect ratio differs (9:16 instead of 16:9). */
+.shorts-row-card {
+  min-width: 0;           /* let the 1fr track shrink the card, don't overflow */
+  text-decoration: none;
+  color: inherit;
+
+  background-color: var(--card-bg);
+  border-radius: 12px;
+  box-shadow: var(--card-shadow);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  overflow: hidden;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+
+  @include mix.respond(phone) {
+    border-radius: 8px;
+  }
+
+  /* Guarded to hover-capable devices so it doesn't stick on a mobile tap. */
+  @media (hover: hover) {
+    &:hover {
+      transform: scale(1.015);
+      box-shadow: 0 6px 18px rgba(0, 0, 0, 0.1);
+    }
+    [data-theme="dark"] &:hover {
+      background-color: #242424;
+      box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
+    }
+  }
+}
+
+.shorts-row-thumb {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 9 / 16;   /* the one thing that differs from a video card */
+  overflow: hidden;
+  background: var(--skeleton-bg, rgba(150, 150, 150, 0.14));
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+}
+
+.shorts-row-meta {
+  padding: 6px 8px 8px;
+
+  /* Mirrors the video card's title type. */
+  h2 {
+    font-size: 12.95px;
+    font-weight: 400;
+    color: var(--text-primary);
+    margin: 0 0 3px;
+    line-height: 1.3;
+
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  @include mix.respond(phone) {
+    padding: 5px 6px 6px;
+    h2 { font-size: 12px; }
+  }
+}
+
+.shorts-row-author {
+  font-size: 12px;
+  color: var(--text-secondary, #9aa);
+
+  @include mix.respond(phone) { font-size: 11px; }
+}

--- a/src/components/ShortsStories/ShortsStories.scss
+++ b/src/components/ShortsStories/ShortsStories.scss
@@ -36,16 +36,19 @@
     }
   }
 
-  // Compact variant (for shorts player context)
+  // Compact variant (for shorts player context).
+  //
+  // Deliberately has NO background: this variant is used BOTH for the desktop bar
+  // (which sits on the page, where a dark scrim looked like a stray grey strip in
+  // light theme) and for the mobile overlay (which sits ON the video). Everything
+  // that needs to be white-on-video is scoped to the mobile overlay in
+  // ShortsStoryFeed.scss instead of being hardcoded here.
   &--compact {
     margin-bottom: 0;
     padding-top: 2px;
     padding-bottom: 4px;
     padding-left: 10px;
     padding-right: 10px;
-    background: rgba(0, 0, 0, 0.4);
-    backdrop-filter: blur(8px);
-    border-radius: 0 0 12px 12px;
 
     .stories-row,
     .stories-skeleton-row {
@@ -82,22 +85,11 @@
 
     .story-username {
       font-size: 10px;
-      color: #fff;
-      background: rgba(0, 0, 0, 0.5);
-      border-radius: 4px;
-      padding: 1px 4px;
     }
 
     .stories-scroll-btn {
       width: 26px;
       height: 26px;
-      background: rgba(255, 255, 255, 0.15);
-      border-color: rgba(255, 255, 255, 0.2);
-      color: #fff;
-
-      &:hover {
-        background: var(--accent-primary);
-      }
     }
   }
 
@@ -190,15 +182,17 @@
       transform: scale(0.97);
     }
 
-    // Active creator highlight — replaces the followed/unfollowed border
+    // Active creator highlight — replaces the followed/unfollowed border.
+    // Theme-aware: a neutral glow reads on both light and dark. (The mobile overlay
+    // re-whitens this, since it sits on the video.)
     &--active {
       .story-avatar-wrap {
-        border-color: rgba(255, 255, 255, 0.85) !important;
-        box-shadow: 0 0 8px rgba(255, 255, 255, 0.35), 0 0 16px rgba(255, 255, 255, 0.12);
+        border-color: var(--text-primary) !important;
+        box-shadow: 0 0 8px rgba(128, 128, 128, 0.35), 0 0 16px rgba(128, 128, 128, 0.12);
       }
 
       .story-username {
-        color: #fff;
+        color: var(--text-primary);
         font-weight: 600;
       }
     }

--- a/src/hive-api/hiveApi.js
+++ b/src/hive-api/hiveApi.js
@@ -130,7 +130,7 @@ export async function getSubscriptions(account) {
  * Convert hive_body (markdown/HTML) to clean plaintext for display as caption.
  * Strips URLs, HTML tags, markdown syntax, and collapses whitespace.
  */
-function bodyToPlaintext(body) {
+export function bodyToPlaintext(body) {
   if (!body) return "";
   // Preserve markdown links [text](url) by replacing them with placeholders before HTML conversion
   const links = [];

--- a/src/hooks/useGridMetrics.js
+++ b/src/hooks/useGridMetrics.js
@@ -1,0 +1,102 @@
+import { useLayoutEffect, useState } from 'react';
+
+/**
+ * Measurement hooks for dropping full-width shorts rails INTO a Card3 grid.
+ *
+ * Shared by the home feed and the watch page's recommendation list. Both hooks
+ * take a ref to a wrapper that CONTAINS a `.card-container` (what Card3 renders)
+ * and observe it live.
+ *
+ * Two deliberate choices, both learned the hard way:
+ *
+ *  - useLayoutEffect, NOT useEffect: it runs after the DOM is written but BEFORE
+ *    the browser paints, so a rail lands in the SAME paint as the grid instead of
+ *    appearing a beat later and shoving the grid down.
+ *
+ *  - Observe the ROOT (always mounted) and re-query `.card-container` on every
+ *    measure — never resolve it once. The grid mounts asynchronously (panels show
+ *    skeletons until their data is in) and that mount doesn't necessarily change
+ *    these hooks' deps. Resolving once meant bailing out while the skeletons were
+ *    up and never re-measuring when the grid finally arrived, so the rails only
+ *    appeared after a tab switch forced a re-run.
+ *
+ * A hidden container (`display: none`) measures 0 and both hooks return 0 — which
+ * is what we want on the watch page, where the desktop and mobile recommendation
+ * lists are both mounted and CSS picks one.
+ */
+
+function observeRoot(root, measure) {
+  const cleanups = [];
+  if (typeof ResizeObserver !== 'undefined') {
+    const ro = new ResizeObserver(measure);
+    ro.observe(root);                                       // width changes → re-measure
+    cleanups.push(() => ro.disconnect());
+  }
+  if (typeof MutationObserver !== 'undefined') {
+    const mo = new MutationObserver(measure);
+    mo.observe(root, { childList: true, subtree: true });   // grid mounts → measure
+    cleanups.push(() => mo.disconnect());
+  }
+  return () => cleanups.forEach((fn) => fn());
+}
+
+/**
+ * How many columns the card grid is CURRENTLY rendering. The grid is
+ * `repeat(auto-fill, minmax(...))`, so the count is decided by the browser at the
+ * live width — we can't infer it from a breakpoint. Read it back off the computed
+ * style, so "every N rows" means N REAL rows.
+ */
+export function useGridColumns(rootRef, deps) {
+  const [cols, setCols] = useState(0);
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    if (!root) return undefined;
+
+    const measure = () => {
+      const grid = root.querySelector('.card-container');
+      if (!grid) { setCols((p) => (p === 0 ? p : 0)); return; }
+      const tpl = getComputedStyle(grid).gridTemplateColumns || '';
+      // "220px 220px 220px" -> 3. `none` (not yet laid out) -> 0.
+      const n = tpl === 'none' ? 0 : tpl.split(/\s+/).filter(Boolean).length;
+      setCols((prev) => (prev === n ? prev : n));
+    };
+    measure();
+    return observeRoot(root, measure);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rootRef, deps]);
+  return cols;
+}
+
+// Shorts card sizing. The rail is a full row (not a scroller), so the caller must
+// hand it EXACTLY as many shorts as fit — one too many and it wraps to a second
+// line, one too few and the row comes up short.
+const SHORT_MIN_W = 150;        // desktop minimum card width
+const SHORT_MIN_W_PHONE = 104;  // phones fit ~3 across instead of 2
+const SHORT_GAP = 16;
+const SHORT_GAP_PHONE = 10;
+
+/** How many shorts fit across the grid at its CURRENT width. */
+export function useShortsPerRow(rootRef, deps) {
+  const [n, setN] = useState(0);
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    if (!root) return undefined;
+
+    const measure = () => {
+      const grid = root.querySelector('.card-container');
+      const w = grid?.clientWidth || 0;
+      if (!w) { setN((p) => (p === 0 ? p : 0)); return; }
+      const phone = window.matchMedia('(max-width: 600px)').matches;
+      const min = phone ? SHORT_MIN_W_PHONE : SHORT_MIN_W;
+      const gap = phone ? SHORT_GAP_PHONE : SHORT_GAP;
+      // How many `min`-wide cards + gaps fit in w. The tracks are 1fr, so whatever
+      // fits then stretches to fill the width exactly.
+      const fit = Math.max(2, Math.floor((w + gap) / (min + gap)));
+      setN((prev) => (prev === fit ? prev : fit));
+    };
+    measure();
+    return observeRoot(root, measure);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rootRef, deps]);
+  return n;
+}

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -52,6 +52,11 @@ export const useAppStore = create(
       // space and the comments panel is a tap away.
       shortsCommentBar: false,
       setShortsCommentBar: (val) => a[0]({ shortsCommentBar: !!(typeof val === 'function' ? val(a[1]().shortsCommentBar) : val) }),
+      // Shorts rails interleaved into the video feeds and the watch page's
+      // recommendations. ON by default; turning it off skips the shorts request
+      // entirely, it doesn't just hide the rows.
+      inlineShorts: true,
+      setInlineShorts: (val) => a[0]({ inlineShorts: !!(typeof val === 'function' ? val(a[1]().inlineShorts) : val) }),
       // Land on /shorts instead of the home feed when 3Speak is opened. Off by default.
       openShortsOnStart: false,
       setOpenShortsOnStart: (val) => a[0]({ openShortsOnStart: !!(typeof val === 'function' ? val(a[1]().openShortsOnStart) : val) }),
@@ -97,6 +102,7 @@ export const useAppStore = create(
         shortsFeedMode: state.shortsFeedMode,
         shortsCommentBar: state.shortsCommentBar,
         openShortsOnStart: state.openShortsOnStart,
+        inlineShorts: state.inlineShorts,
         hideWatched: state.hideWatched,
         privateMode: state.privateMode,
         simpleFeed: state.simpleFeed,

--- a/src/lib/videoData.js
+++ b/src/lib/videoData.js
@@ -165,15 +165,21 @@ export async function fetchTrendingFeed(limit = 20) {
 
 // Sidebar recommendations for a watch page: biased toward the current video's
 // topic, the user's interests, and the same creator (see /feeds/related).
+//
+// Returns `currentTopic` alongside the videos — the winning topic the checker
+// resolved for THIS video. The recommended-shorts rail reuses it to ask for shorts
+// about the same thing, so that costs no extra round trip.
+const EMPTY_RELATED = { videos: [], currentTopic: null };
+
 export async function fetchRelatedFeed(author, permlink, limit = 24) {
-  if (!author || !permlink || author === 'unknown') return [];
+  if (!author || !permlink || author === 'unknown') return EMPTY_RELATED;
   try {
     const r = await fetch(
       `${CHECKER_URL}/feeds/related/${encodeURIComponent(author)}/${encodeURIComponent(permlink)}?limit=${limit}${feedParams()}`
     );
     const j = await r.json();
-    return j?.videos || [];
-  } catch (_) { return []; }
+    return { videos: j?.videos || [], currentTopic: j?.currentTopic || null };
+  } catch (_) { return EMPTY_RELATED; }
 }
 
 export async function fetchAuthorVideos(author, limit = 10) {

--- a/src/page/HomeGrouped.jsx
+++ b/src/page/HomeGrouped.jsx
@@ -14,6 +14,8 @@ import { getFeedSeed, regenerateFeedSeed } from "../utils/feedSeed";
 import ShortsStories from "../components/ShortsStories/ShortsStories";
 import OpenPodsLiveStrip from "../components/OpenPod/OpenPodsLiveStrip";
 import PullToRefresh from "../components/PullToRefresh/PullToRefresh";
+import ShortsRow from "../components/ShortsRow/ShortsRow";
+import { SHORTS_API_URL } from "../utils/config";
 import { TrendingIcon, NewContentIcon } from "../components/FeedIcons";
 import { Rocket, Compass, Sparkles, GripVertical } from "lucide-react";
 
@@ -75,9 +77,32 @@ const fetchInterestsFeed = async (page = 1) => {
   return res.data?.videos || [];
 };
 
-const fetchTrending = async (page = 1) => {
-  const res = await axios.get(appendNsfw(`${TRENDING_SORTED_URL}?page=${page}&limit=${PAGE_MAIN}${feedParams()}`, useAppStore.getState().showNsfw));
-  return res.data?.videos || [];
+
+// Shorts sprinkled between the Discover rows. Paginated, and pulled in as the feed
+// grows, so the rails keep coming instead of stopping at a fixed count. Each rail
+// takes the NEXT slice, so no short repeats down the page.
+const SHORTS_PAGE = 60;       // per request
+
+// Shorts params. NOT feedParams(): that appends `&chrono=1` when "simple feeds" is
+// on, and the New rail also needs chrono — express would then parse `chrono` as the
+// ARRAY ['1','1'] and `req.query.chrono === '1'` would be false, silently disabling
+// it. So build the params here and emit chrono exactly once.
+const shortsParams = (mode) => {
+  const st = useAppStore.getState();
+  let p = `&seed=${getFeedSeed()}`;
+  if (Array.isArray(st.interests) && st.interests.length) p += `&interests=${encodeURIComponent(st.interests.join(','))}`;
+  if (st.user) {
+    p += `&currentuser=${encodeURIComponent(st.user)}`;
+    p += `&hidewatched=${st.hideWatched ? '1' : '0'}`;
+    if (mode === 'follow') p += `&followedby=${encodeURIComponent(st.user)}`;
+  }
+  if (mode === 'chrono' || st.simpleFeed) p += '&chrono=1';
+  return p;
+};
+
+const fetchFeedShorts = async (mode, page = 1) => {
+  const res = await axios.get(appendNsfw(`${SHORTS_API_URL}?page=${page}&limit=${SHORTS_PAGE}${shortsParams(mode)}`, useAppStore.getState().showNsfw));
+  return res.data?.shorts || [];
 };
 
 const fetchPromoted = async () => {
@@ -119,7 +144,6 @@ const iconsByTitle = {
   "Home Feed": <TrendingIcon />,
   "Follow Feed": <TrendingIcon />,
   "New Content": <NewContentIcon />,
-  "Trending": <TrendingIcon />,
   "Promoted": <Rocket size={16} />,
   "Discover": <Compass size={16} />,
   "Interests": <Sparkles size={16} />,
@@ -145,6 +169,75 @@ const applyTabOrder = (sections, order) => {
   for (const s of sections) if (bySection.has(s.key)) out.push(s);
   return out;
 };
+
+// How many columns the card grid is CURRENTLY rendering. The grid is
+// `repeat(auto-fill, minmax(...))`, so the count is decided by the browser at the
+// live viewport width — we can't infer it from a breakpoint. Read it back off the
+// computed style and re-read on resize, so "every 2 rows" means 2 REAL rows.
+function useGridColumns(rootRef, deps) {
+  const [cols, setCols] = useState(0);
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return undefined;
+    const grid = root.querySelector('.card-container');
+    if (!grid) return undefined;
+    const measure = () => {
+      const tpl = getComputedStyle(grid).gridTemplateColumns || '';
+      // "220px 220px 220px" -> 3. `none` (not yet laid out) -> 0.
+      const n = tpl === 'none' ? 0 : tpl.split(/\s+/).filter(Boolean).length;
+      setCols((prev) => (prev === n ? prev : n));
+    };
+    measure();
+    if (typeof ResizeObserver === 'undefined') return undefined;
+    const ro = new ResizeObserver(measure);
+    ro.observe(grid);
+    return () => ro.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rootRef, deps]);
+  return cols;
+}
+
+// How many shorts fit across the grid at the CURRENT width. The rail is a full row
+// (not a scroller), so we must hand it exactly this many — one too many and it
+// wraps to a second line, one too few and the row is short.
+//
+// Measured off the live container rather than guessed from a breakpoint, and
+// re-measured on resize, so it always matches what the browser is actually doing.
+const SHORT_MIN_W = 150;        // desktop minimum card width
+const SHORT_MIN_W_PHONE = 104;  // phones fit ~3 across instead of 2
+const SHORT_GAP = 16;
+const SHORT_GAP_PHONE = 10;
+
+function useShortsPerRow(rootRef, deps) {
+  const [n, setN] = useState(0);
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return undefined;
+    const grid = root.querySelector('.card-container');
+    if (!grid) return undefined;
+    const measure = () => {
+      const w = grid.clientWidth;
+      if (!w) return;
+      const phone = window.matchMedia('(max-width: 600px)').matches;
+      const min = phone ? SHORT_MIN_W_PHONE : SHORT_MIN_W;
+      const gap = phone ? SHORT_GAP_PHONE : SHORT_GAP;
+      // How many `min`-wide cards + gaps fit in w. The tracks are 1fr, so whatever
+      // fits then stretches to fill the width exactly.
+      const fit = Math.floor((w + gap) / (min + gap));
+      setN((prev) => {
+        const next = Math.max(2, fit);
+        return prev === next ? prev : next;
+      });
+    };
+    measure();
+    if (typeof ResizeObserver === 'undefined') return undefined;
+    const ro = new ResizeObserver(measure);
+    ro.observe(grid);
+    return () => ro.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rootRef, deps]);
+  return n;
+}
 
 // Bottom-of-list sentinel — fires onLoadMore when it scrolls into view (600px
 // early) so the next page is fetched before the user hits the actual end.
@@ -247,14 +340,6 @@ const HomeGrouped = () => {
   });
   const interestsData = useMemo(() => deduplicateVideos(interestsQ.data?.pages.flat() || []), [interestsQ.data]);
 
-  const trendingQ = useInfiniteQuery({
-    queryKey: ["trending-grouped", showNsfw, hideWatched, user, simpleFeed],
-    queryFn: ({ pageParam }) => fetchTrending(pageParam),
-    getNextPageParam: nextPage(),
-    enabled: authenticated,
-    ...INF,
-  });
-  const trendingData = useMemo(() => deduplicateVideos(trendingQ.data?.pages.flat() || []), [trendingQ.data]);
 
   const newQ = useInfiniteQuery({
     queryKey: ["newcontent-grouped", showNsfw, user],
@@ -267,7 +352,6 @@ const HomeGrouped = () => {
   const homeLoading = homeQ.isLoading;
   const discoverLoading = discoverQ.isLoading;
   const interestsLoading = interestsQ.isLoading;
-  const trendingLoading = trendingQ.isLoading;
   const newContentLoading = newQ.isLoading;
 
   // Promoted videos — prefixed onto EVERY feed below (no dedicated tab any more).
@@ -299,7 +383,6 @@ const HomeGrouped = () => {
     baseSections.splice(2, 0, { key: 'interests', title: 'Interests', videos: leadWithPromoted(interestsData), isLoading: interestsLoading, priority: true });
   }
   if (authenticated) {
-    baseSections.push({ key: 'trending', title: 'Trending', videos: leadWithPromoted(trendingData), linkTo: '/trend', isLoading: trendingLoading });
   }
   // A saved tabOrder may still list the retired 'promoted' key — applyTabOrder skips
   // keys with no matching section, so old orders degrade cleanly.
@@ -327,6 +410,48 @@ const HomeGrouped = () => {
     [activeVideos, visibleKeys],
   );
 
+  // Which shorts feed the active tab's rails draw from:
+  //   discover / interests → the ranked shorts feed (same source for both)
+  //   home (Follow Feed)   → only creators you follow  (?followedby=)
+  //   new                  → newest-first, no retention (?chrono=1)
+  // Logged-out has no follow list, so the Home Feed gets no rails.
+  const shortsMode = useMemo(() => {
+    const k = activeSection?.key;
+    if (k === 'discover' || k === 'interests') return 'ranked';
+    if (k === 'home' && authenticated && user) return 'follow';
+    if (k === 'new') return 'chrono';
+    return null;
+  }, [activeSection?.key, authenticated, user]);
+
+  const shortsQ = useInfiniteQuery({
+    queryKey: ["feed-shorts", shortsMode, user || null, showNsfw],
+    queryFn: ({ pageParam = 1 }) => fetchFeedShorts(shortsMode, pageParam),
+    initialPageParam: 1,
+    getNextPageParam: nextPage(),
+    enabled: !!shortsMode,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+  });
+  const feedShorts = useMemo(() => (shortsQ.data?.pages || []).flat(), [shortsQ.data]);
+
+  // Live column count of the card grid — drives "a shorts rail every 2 rows".
+  const gridCols = useGridColumns(panelRef, `${activeSection?.key}:${activeVideos.length}`);
+  // Shorts per rail = however many fit across right now.
+  const shortsPerRow = useShortsPerRow(panelRef, `${activeSection?.key}:${activeVideos.length}`);
+
+  // Keep the shorts supply ahead of the rails. As the Discover feed pages in, more
+  // rails are needed; without this the rails would simply stop once the first batch
+  // ran out. Fetch the next shorts page whenever we're short of what the current
+  // card count will ask for.
+  const railsNeeded = gridCols > 0 ? Math.floor(activeVideos.length / (gridCols * 2)) : 0;
+  const shortsNeeded = railsNeeded * (shortsPerRow || 1);
+  useEffect(() => {
+    if (!shortsMode) return;
+    if (feedShorts.length >= shortsNeeded) return;
+    if (!shortsQ.hasNextPage || shortsQ.isFetchingNextPage) return;
+    shortsQ.fetchNextPage();
+  }, [shortsMode, shortsNeeded, feedShorts.length, shortsQ.hasNextPage, shortsQ.isFetchingNextPage]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const { getContentForVideo } = useContentBatch(visibleVideos);
   const { isWatched } = useWatchHistory(visibleVideos);
   const { getViewCount } = useViewCounts(visibleVideos);
@@ -339,7 +464,6 @@ const HomeGrouped = () => {
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: ["discover-grouped"] }),
       queryClient.invalidateQueries({ queryKey: ["interests-grouped"] }),
-      queryClient.invalidateQueries({ queryKey: ["trending-grouped"] }),
       queryClient.invalidateQueries({ queryKey: ["newcontent-grouped"] }),
     ]);
   }, [queryClient, authenticated, user]);
@@ -430,7 +554,21 @@ const HomeGrouped = () => {
   }, [tabSections, drag]);
 
   // Infinite query backing each paginated section (promoted isn't paginated).
-  const queryByKey = { home: homeQ, discover: discoverQ, interests: interestsQ, trending: trendingQ, new: newQ };
+  const queryByKey = { home: homeQ, discover: discoverQ, interests: interestsQ, new: newQ };
+
+  // Slot N gets shorts [N*SIZE, (N+1)*SIZE). Returns null once we run out, which
+  // stops the interleaving rather than repeating the same shorts down the page.
+  // The shorts feed is split into consecutive sections of `shortsPerRow`, and slot N
+  // takes section N — so each rail is one exactly-full row and no short repeats down
+  // the page. A partial trailing section is dropped rather than rendering a ragged
+  // half-row; returning null just stops the interleaving there.
+  const renderShortsRail = useCallback((slot) => {
+    if (!shortsPerRow) return null;
+    const start = slot * shortsPerRow;
+    const slice = feedShorts.slice(start, start + shortsPerRow);
+    if (slice.length < shortsPerRow) return null; // don't render a short row
+    return <ShortsRow shorts={slice} columns={shortsPerRow} />;
+  }, [feedShorts, shortsPerRow]);
 
   const renderPanel = (s) => {
     if (!s) return null;
@@ -450,6 +588,12 @@ const HomeGrouped = () => {
           isWatched={isWatched}
           getViewCount={getViewCount}
           priority={s.priority}
+          /* A shorts rail after every 2 REAL rows of videos, on any feed that has a
+             shorts source (see shortsMode). `gridCols` is measured from the live
+             grid, so this lands on a row boundary at every breakpoint (2 cols on
+             mobile, 4-5 on desktop). 0 until measured → no interleave, no jump. */
+          interleaveEvery={shortsMode && s.key === activeSection?.key && gridCols > 0 ? gridCols * 2 : 0}
+          renderInterleave={shortsMode && s.key === activeSection?.key ? renderShortsRail : null}
         />
         {q && (
           <InfiniteSentinel

--- a/src/page/HomeGrouped.jsx
+++ b/src/page/HomeGrouped.jsx
@@ -15,6 +15,7 @@ import ShortsStories from "../components/ShortsStories/ShortsStories";
 import OpenPodsLiveStrip from "../components/OpenPod/OpenPodsLiveStrip";
 import PullToRefresh from "../components/PullToRefresh/PullToRefresh";
 import ShortsRow from "../components/ShortsRow/ShortsRow";
+import { useGridColumns, useShortsPerRow } from "../hooks/useGridMetrics";
 import { SHORTS_API_URL } from "../utils/config";
 import { TrendingIcon, NewContentIcon } from "../components/FeedIcons";
 import { Rocket, Compass, Sparkles, GripVertical } from "lucide-react";
@@ -87,9 +88,15 @@ const SHORTS_PAGE = 60;       // per request
 // on, and the New rail also needs chrono — express would then parse `chrono` as the
 // ARRAY ['1','1'] and `req.query.chrono === '1'` would be false, silently disabling
 // it. So build the params here and emit chrono exactly once.
-const shortsParams = (mode) => {
+// Discover and Interests both draw from the RANKED shorts feed, so without this
+// they'd share a seed and show the identical shorts. Offset the session seed per
+// section so each feed gets its own shuffle (mulberry32 diverges completely for any
+// distinct integer seed). Irrelevant for `new` (date-sorted), harmless there.
+const SHORTS_SEED_OFFSET = { discover: 0, interests: 7919, home: 15733, new: 24917 };
+
+const shortsParams = (mode, sectionKey) => {
   const st = useAppStore.getState();
-  let p = `&seed=${getFeedSeed()}`;
+  let p = `&seed=${getFeedSeed() + (SHORTS_SEED_OFFSET[sectionKey] || 0)}`;
   if (Array.isArray(st.interests) && st.interests.length) p += `&interests=${encodeURIComponent(st.interests.join(','))}`;
   if (st.user) {
     p += `&currentuser=${encodeURIComponent(st.user)}`;
@@ -100,9 +107,28 @@ const shortsParams = (mode) => {
   return p;
 };
 
-const fetchFeedShorts = async (mode, page = 1) => {
-  const res = await axios.get(appendNsfw(`${SHORTS_API_URL}?page=${page}&limit=${SHORTS_PAGE}${shortsParams(mode)}`, useAppStore.getState().showNsfw));
-  return res.data?.shorts || [];
+// A different SEED only reshuffles the same shorts — the shorts ranking is
+// recency-dominated, so the newest float to the top of both feeds regardless. To
+// make Interests show genuinely DIFFERENT shorts from Discover, start it a page in.
+const SHORTS_PAGE_OFFSET = { discover: 0, interests: 1, home: 0, new: 0 };
+
+const fetchFeedShorts = async (mode, sectionKey, page = 1) => {
+  const offset = SHORTS_PAGE_OFFSET[sectionKey] || 0;
+  const url = (p) => appendNsfw(
+    `${SHORTS_API_URL}?page=${p}&limit=${SHORTS_PAGE}${shortsParams(mode, sectionKey)}`,
+    useAppStore.getState().showNsfw,
+  );
+
+  const res = await axios.get(url(page + offset));
+  const shorts = res.data?.shorts || [];
+
+  // A small shorts pool may not HAVE the offset page. Rather than leaving the feed
+  // with no rails at all, fall back to the un-offset page.
+  if (!shorts.length && offset && page === 1) {
+    const fb = await axios.get(url(page));
+    return fb.data?.shorts || [];
+  }
+  return shorts;
 };
 
 const fetchPromoted = async () => {
@@ -169,75 +195,6 @@ const applyTabOrder = (sections, order) => {
   for (const s of sections) if (bySection.has(s.key)) out.push(s);
   return out;
 };
-
-// How many columns the card grid is CURRENTLY rendering. The grid is
-// `repeat(auto-fill, minmax(...))`, so the count is decided by the browser at the
-// live viewport width — we can't infer it from a breakpoint. Read it back off the
-// computed style and re-read on resize, so "every 2 rows" means 2 REAL rows.
-function useGridColumns(rootRef, deps) {
-  const [cols, setCols] = useState(0);
-  useEffect(() => {
-    const root = rootRef.current;
-    if (!root) return undefined;
-    const grid = root.querySelector('.card-container');
-    if (!grid) return undefined;
-    const measure = () => {
-      const tpl = getComputedStyle(grid).gridTemplateColumns || '';
-      // "220px 220px 220px" -> 3. `none` (not yet laid out) -> 0.
-      const n = tpl === 'none' ? 0 : tpl.split(/\s+/).filter(Boolean).length;
-      setCols((prev) => (prev === n ? prev : n));
-    };
-    measure();
-    if (typeof ResizeObserver === 'undefined') return undefined;
-    const ro = new ResizeObserver(measure);
-    ro.observe(grid);
-    return () => ro.disconnect();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rootRef, deps]);
-  return cols;
-}
-
-// How many shorts fit across the grid at the CURRENT width. The rail is a full row
-// (not a scroller), so we must hand it exactly this many — one too many and it
-// wraps to a second line, one too few and the row is short.
-//
-// Measured off the live container rather than guessed from a breakpoint, and
-// re-measured on resize, so it always matches what the browser is actually doing.
-const SHORT_MIN_W = 150;        // desktop minimum card width
-const SHORT_MIN_W_PHONE = 104;  // phones fit ~3 across instead of 2
-const SHORT_GAP = 16;
-const SHORT_GAP_PHONE = 10;
-
-function useShortsPerRow(rootRef, deps) {
-  const [n, setN] = useState(0);
-  useEffect(() => {
-    const root = rootRef.current;
-    if (!root) return undefined;
-    const grid = root.querySelector('.card-container');
-    if (!grid) return undefined;
-    const measure = () => {
-      const w = grid.clientWidth;
-      if (!w) return;
-      const phone = window.matchMedia('(max-width: 600px)').matches;
-      const min = phone ? SHORT_MIN_W_PHONE : SHORT_MIN_W;
-      const gap = phone ? SHORT_GAP_PHONE : SHORT_GAP;
-      // How many `min`-wide cards + gaps fit in w. The tracks are 1fr, so whatever
-      // fits then stretches to fill the width exactly.
-      const fit = Math.floor((w + gap) / (min + gap));
-      setN((prev) => {
-        const next = Math.max(2, fit);
-        return prev === next ? prev : next;
-      });
-    };
-    measure();
-    if (typeof ResizeObserver === 'undefined') return undefined;
-    const ro = new ResizeObserver(measure);
-    ro.observe(grid);
-    return () => ro.disconnect();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rootRef, deps]);
-  return n;
-}
 
 // Bottom-of-list sentinel — fires onLoadMore when it scrolls into view (600px
 // early) so the next page is fetched before the user hits the actual end.
@@ -415,20 +372,32 @@ const HomeGrouped = () => {
   //   home (Follow Feed)   → only creators you follow  (?followedby=)
   //   new                  → newest-first, no retention (?chrono=1)
   // Logged-out has no follow list, so the Home Feed gets no rails.
+  // null = no shorts rails in this section. That single value already gates the
+  // query (`enabled`), the "wait for shorts before painting" check and the
+  // interleave props — so the Settings toggle just feeds into it, and turning it off
+  // skips the shorts request entirely rather than fetching and hiding.
+  const inlineShorts = useAppStore((st) => st.inlineShorts);
   const shortsMode = useMemo(() => {
+    if (inlineShorts === false) return null;
     const k = activeSection?.key;
     if (k === 'discover' || k === 'interests') return 'ranked';
     if (k === 'home' && authenticated && user) return 'follow';
     if (k === 'new') return 'chrono';
     return null;
-  }, [activeSection?.key, authenticated, user]);
+  }, [inlineShorts, activeSection?.key, authenticated, user]);
 
+  const shortsSectionKey = activeSection?.key || null;
   const shortsQ = useInfiniteQuery({
-    queryKey: ["feed-shorts", shortsMode, user || null, showNsfw],
-    queryFn: ({ pageParam = 1 }) => fetchFeedShorts(shortsMode, pageParam),
+    // Keyed by SECTION, not just mode: discover and interests share the 'ranked'
+    // source but must not share a cache entry, or they'd render the same shorts.
+    queryKey: ["feed-shorts", shortsSectionKey, shortsMode, user || null, showNsfw],
+    queryFn: ({ pageParam = 1 }) => fetchFeedShorts(shortsMode, shortsSectionKey, pageParam),
     initialPageParam: 1,
     getNextPageParam: nextPage(),
     enabled: !!shortsMode,
+    // The panel waits for this (see renderPanel), so don't let a failing shorts
+    // request sit on retries and strand the whole feed on skeletons.
+    retry: 1,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
   });
@@ -572,7 +541,14 @@ const HomeGrouped = () => {
 
   const renderPanel = (s) => {
     if (!s) return null;
-    if (s.isLoading && (!s.videos || s.videos.length === 0)) {
+    // Wait for the shorts too, not just the videos. Otherwise the grid paints first
+    // and the rails drop in a beat later, shoving everything down. The shorts feed
+    // is actually the FASTER of the two (~0.23s vs 0.3-0.8s), so this costs nothing
+    // in practice — and `retry: 1` means a failing one can't hold the feed hostage.
+    const waitingForShorts = !!shortsMode
+      && s.key === activeSection?.key
+      && shortsQ.isLoading;
+    if (waitingForShorts || (s.isLoading && (!s.videos || s.videos.length === 0))) {
       return <div className="home-tab-skeletons">{Array.from({ length: 12 }).map((_, i) => <CardSkeleton key={i} />)}</div>;
     }
     if (!s.videos || s.videos.length === 0) {

--- a/src/page/Short.scss
+++ b/src/page/Short.scss
@@ -1764,7 +1764,10 @@
     border-left: 1px solid var(--border-color);
     display: flex;
     flex-direction: column;
-    transform: translateX(100%);
+    // `translateX(100%)` slides it by its OWN WIDTH only — but the panel sits at
+    // `right: 5rem`, so its right edge starts 5rem inside the viewport and 5rem of it
+    // stayed on screen as a strip after closing. Clear the offset too.
+    transform: translateX(calc(100% + 5rem));
     transition: transform 0.3s ease;
     z-index: 150;
 

--- a/src/page/ShortsStoryFeed.jsx
+++ b/src/page/ShortsStoryFeed.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef, useMemo } from "react";
+import { useState, useCallback, useEffect, useLayoutEffect, useRef, useMemo } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import ShortsStories, { useShortsStories } from "../components/ShortsStories/ShortsStories";
 import VideoShort from "./Short";
@@ -29,6 +29,48 @@ const ShortsStoryFeed = () => {
   creatorsRef.current = creators;
   const feedUserRef = useRef(feedUser);
   feedUserRef.current = feedUser;
+
+  // The comments panel is `position: fixed` and full-height, so it would run UNDER
+  // the stories bar. Publish the bar's real bottom edge (viewport coords — exactly
+  // what a fixed element's `top` wants) as a CSS var and let the panel start there.
+  //
+  // The var goes on <html>, NOT on this page's root: Short.jsx portals the panel to
+  // <body> (so it can render above the nav), which puts it OUTSIDE this subtree — a
+  // var set here would never reach it. Same reason the CSS rule has to match from
+  // `body:has(.shorts-story-feed)` rather than from inside `.shorts-story-feed`.
+  //
+  // Measured, not hardcoded: the bar's height depends on avatar size, the username
+  // line and the theme's font metrics, and it differs between breakpoints.
+  const rootRef = useRef(null);
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    if (!root) return undefined;
+
+    const measure = () => {
+      const bar = root.querySelector(":scope > .shorts-stories");
+      // Hidden (mobile) or not yet mounted → 0, and the panel keeps its own top.
+      const bottom = bar && bar.offsetParent !== null ? bar.getBoundingClientRect().bottom : 0;
+      document.documentElement.style.setProperty("--stories-bar-bottom", `${Math.round(bottom)}px`);
+    };
+    measure();
+
+    const cleanups = [];
+    if (typeof ResizeObserver !== "undefined") {
+      const ro = new ResizeObserver(measure);
+      ro.observe(root);
+      cleanups.push(() => ro.disconnect());
+    }
+    if (typeof MutationObserver !== "undefined") {
+      const mo = new MutationObserver(measure);
+      mo.observe(root, { childList: true, subtree: true }); // stories load in async
+      cleanups.push(() => mo.disconnect());
+    }
+    return () => {
+      cleanups.forEach((fn) => fn());
+      // It's a global now — don't leave it behind for /shorts or /watch.
+      document.documentElement.style.removeProperty("--stories-bar-bottom");
+    };
+  }, []);
 
   // Swipe animation state
   const [swipeDir, setSwipeDir] = useState(null); // 'left' | 'right' | null
@@ -136,6 +178,7 @@ const ShortsStoryFeed = () => {
   return (
     <div
       className="shorts-story-feed"
+      ref={rootRef}
       onTouchStart={onTouchStart}
       onTouchEnd={onTouchEnd}
     >

--- a/src/page/ShortsStoryFeed.scss
+++ b/src/page/ShortsStoryFeed.scss
@@ -25,6 +25,8 @@
     }
   }
 
+
+
   &__player {
     flex: 1;
     min-height: 0;
@@ -122,8 +124,25 @@
           }
         }
 
+        // White-on-video: this overlay sits ON the short, so it needs the contrast
+        // the (now theme-aware) compact variant no longer hardcodes.
         .story-username {
           font-size: 9px;
+          color: #fff;
+          background: rgba(0, 0, 0, 0.5);
+          border-radius: 4px;
+          padding: 1px 4px;
+        }
+
+        .story-item--active {
+          .story-avatar-wrap {
+            border-color: rgba(255, 255, 255, 0.85) !important;
+            box-shadow: 0 0 8px rgba(255, 255, 255, 0.35), 0 0 16px rgba(255, 255, 255, 0.12);
+          }
+
+          .story-username {
+            color: #fff;
+          }
         }
 
         .stories-scroll-btn {
@@ -180,5 +199,28 @@
   100% {
     transform: translateX(0);
     opacity: 1;
+  }
+}
+
+// The comments panel is `position: fixed; top: 0; height: 100vh` (Short.scss), so on
+// the stories page it ran straight under the stories bar.
+//
+// It CANNOT be reached from inside `.shorts-story-feed`: Short.jsx portals it to
+// <body> (`.short-main.shorts-comments-portal`) so it can paint above the nav, which
+// takes it out of this page's subtree entirely. Hence matching from `body:has(...)`
+// — scoped to "the stories page is currently mounted" — and hence the CSS var living
+// on <html> instead of on the page root.
+//
+// `--stories-bar-bottom` is the bar's measured bottom edge in VIEWPORT coords, which
+// is exactly what a fixed element's `top` takes — no arithmetic against the nav
+// height needed. It falls back to 0px (= the panel's original full-height behaviour)
+// whenever the bar is hidden or not yet measured.
+//
+// Only above the mobile breakpoint: under 768px the panel is a bottom sheet
+// (`top: auto`) and the desktop bar is hidden, so there is nothing to clear.
+@media (min-width: 769px) {
+  body:has(.shorts-story-feed) .shorts-comments-portal .commentsPanel {
+    top: var(--stories-bar-bottom, 0px);
+    height: calc(100vh - var(--stories-bar-bottom, 0px));
   }
 }

--- a/src/page/Watch.jsx
+++ b/src/page/Watch.jsx
@@ -12,7 +12,10 @@ import BarLoader from '../components/Loader/BarLoader';
 import { useAppStore } from '../lib/store';
 import { recordWatch, batchCheckWatched } from '../utils/watchHistory';
 import { Client } from '@hiveio/dhive';
-import { HIVE_API_NODES, PLAYER_URL } from '../utils/config';
+import { HIVE_API_NODES, PLAYER_URL, SHORTS_API_URL, appendNsfw } from '../utils/config';
+import ShortsRow from '../components/ShortsRow/ShortsRow';
+import { useGridColumns, useShortsPerRow } from '../hooks/useGridMetrics';
+import { getFeedSeed } from '../utils/feedSeed';
 import ReactionPlayer from '../components/ReactionPlayer/ReactionPlayer';
 import { MdVideocam, MdChatBubble } from 'react-icons/md';
 import { batchGetReputations, LOW_REP_THRESHOLD } from '../utils/reputation';
@@ -26,6 +29,19 @@ import useSubtitles from '../hooks/useSubtitles';
 import useWatchDuration from '../hooks/useWatchDuration';
 import { fetchScheduledPost, getScheduledEmbedRef } from '../utils/scheduledPosts';
 import EditScheduledModal from '../components/modal/EditScheduledModal';
+
+// Stable identity so `related?.videos || EMPTY_LIST` doesn't hand a NEW [] to the
+// memo on every render.
+const EMPTY_LIST = [];
+
+// A shorts rail every N rows of recommendations. The sidebar is a ONE-column grid,
+// so N here is literally "every N recommended videos" — 3 keeps the rail present
+// without letting it out-number the videos it's sitting between.
+const WATCH_ROWS_PER_SHORTS_RAIL = 3;
+const WATCH_SHORTS_LIMIT = 30;
+// Keeps the watch rail from being the same shorts, in the same order, as the home
+// feed's rails within one session.
+const WATCH_SHORTS_SEED_OFFSET = 4231;
 
 // Build the videoDetails shape PlayVideo expects from a checker scheduled-post
 // doc (the post isn't on Hive yet, so there are no stats/payout/votes).
@@ -98,7 +114,7 @@ function Watch({ v2 = false }) {
   const [searchParams] = useSearchParams();
   const location = useLocation();
   const navigate = useNavigate();
-  const { user, watchHistoryEnabled, setMiniPlayer, clearMiniPlayer } = useAppStore();
+  const { user, watchHistoryEnabled, setMiniPlayer, clearMiniPlayer, showNsfw, inlineShorts } = useAppStore();
   const v = searchParams.get('v'); // Extract the "v" query parameter
   const playlistId = searchParams.get('playlist');
   const posParam = searchParams.get('pos');
@@ -955,12 +971,66 @@ function Watch({ v2 = false }) {
   // Suggestion feeds from the checker (items already match the Card3 shape).
   // The related feed is topic/interest/creator-aware (see /feeds/related); it's
   // keyed by the current video so it re-pulls when you navigate to a new one.
-  const { data: relatedItems = [], isLoading: relatedLoading } = useQuery({
+  const { data: related, isLoading: relatedLoading } = useQuery({
     queryKey: ['watch-related', author, permlink],
     queryFn: () => fetchRelatedFeed(author, permlink, 24),
     enabled: !!author && author !== 'unknown' && !!permlink,
     staleTime: 5 * 60 * 1000,
   });
+  const relatedItems = related?.videos || EMPTY_LIST;
+  // The topic the checker resolved for THIS video — reused by the shorts rail below.
+  const currentTopic = related?.currentTopic || null;
+  // Recommended SHORTS, interleaved into the recommendation list the same way the
+  // home feed does it. Biased to the current video's topic via `?topic=` — a BOOST
+  // on the checker, not a filter, so a narrow topic still returns a full rail
+  // instead of an empty one.
+  //
+  // Gated on the related query so we ask ONCE, with the topic already known,
+  // rather than firing a topic-less request and refetching a moment later.
+  const { data: relatedShorts = EMPTY_LIST } = useQuery({
+    queryKey: ['watch-related-shorts', currentTopic, showNsfw],
+    queryFn: async () => {
+      const topicParam = currentTopic ? `&topic=${encodeURIComponent(currentTopic)}` : '';
+      const url = appendNsfw(
+        `${SHORTS_API_URL}?page=1&limit=${WATCH_SHORTS_LIMIT}&seed=${getFeedSeed() + WATCH_SHORTS_SEED_OFFSET}${topicParam}`,
+        showNsfw,
+      );
+      const r = await fetch(url);
+      const j = await r.json();
+      return j?.shorts || EMPTY_LIST;
+    },
+    // Off in Settings → never requested (not fetched-then-hidden).
+    enabled: inlineShorts !== false && !relatedLoading && !!permlink,
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+
+  // The desktop sidebar list and the mobile list are BOTH mounted (CSS picks one),
+  // so each needs its own measurement — a hidden container measures 0 and simply
+  // renders no rails, which is exactly what we want.
+  const desktopRecRef = useRef(null);
+  const mobileRecRef = useRef(null);
+  const desktopCols = useGridColumns(desktopRecRef, relatedShorts.length);
+  const desktopPerRow = useShortsPerRow(desktopRecRef, relatedShorts.length);
+  const mobileCols = useGridColumns(mobileRecRef, relatedShorts.length);
+  const mobilePerRow = useShortsPerRow(mobileRecRef, relatedShorts.length);
+
+  // One rail per slot, each a fresh slice — never a PARTIAL row: the tracks are 1fr
+  // and stretch to fill, so a short slice would render as a few over-wide cards.
+  const renderDesktopRail = useCallback((slot) => {
+    if (!desktopPerRow) return null;
+    const slice = relatedShorts.slice(slot * desktopPerRow, slot * desktopPerRow + desktopPerRow);
+    if (slice.length < desktopPerRow) return null;
+    return <ShortsRow shorts={slice} columns={desktopPerRow} />;
+  }, [relatedShorts, desktopPerRow]);
+
+  const renderMobileRail = useCallback((slot) => {
+    if (!mobilePerRow) return null;
+    const slice = relatedShorts.slice(slot * mobilePerRow, slot * mobilePerRow + mobilePerRow);
+    if (slice.length < mobilePerRow) return null;
+    return <ShortsRow shorts={slice} columns={mobilePerRow} />;
+  }, [relatedShorts, mobilePerRow]);
+
   // Plain trending is only a fallback when the related feed is thin.
   const { data: trendingItems = [], isLoading: trendingLoading } = useQuery({
     queryKey: ['watch-trending'],
@@ -1336,17 +1406,29 @@ function Watch({ v2 = false }) {
         )}
 
         {suggestedVideos.length > 0 && (
-          <div className="right-column-videos">
+          <div className="right-column-videos" ref={desktopRecRef}>
             <h4>More videos</h4>
-            <Card3 videos={suggestedVideos} loading={false} shortTimeAgo={false} />
+            <Card3
+              videos={suggestedVideos}
+              loading={false}
+              shortTimeAgo={false}
+              interleaveEvery={desktopCols > 0 && relatedShorts.length ? desktopCols * WATCH_ROWS_PER_SHORTS_RAIL : 0}
+              renderInterleave={relatedShorts.length ? renderDesktopRail : null}
+            />
           </div>
         )}
       </div>
 
       {suggestedVideos.length > 0 && (
-        <div className="mobile-recommended">
+        <div className="mobile-recommended" ref={mobileRecRef}>
           <h4>More videos</h4>
-          <Card3 videos={suggestedVideos.slice(0, 12)} loading={false} shortTimeAgo={false} />
+          <Card3
+            videos={suggestedVideos.slice(0, 12)}
+            loading={false}
+            shortTimeAgo={false}
+            interleaveEvery={mobileCols > 0 && relatedShorts.length ? mobileCols * WATCH_ROWS_PER_SHORTS_RAIL : 0}
+            renderInterleave={relatedShorts.length ? renderMobileRail : null}
+          />
         </div>
       )}
 

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.54.0';
+export const APP_VERSION = '1.55.0';

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.53.0';
+export const APP_VERSION = '1.54.0';


### PR DESCRIPTION
This pull request introduces a new feature that interleaves full-width "Shorts" rails into video grids on the home feed and watch page, making Shorts more discoverable and integrated into the main browsing experience. Users can now control this behavior via a new setting, and the implementation includes reusable measurement hooks and a new Shorts row component. Additional UI and code improvements are included for maintainability and theme consistency.

**Shorts Integration into Video Feeds:**
- Added a new `ShortsRow` component (`ShortsRow.jsx`, `ShortsRow.scss`) that displays a full row of Shorts inside the video grid, matching the current grid width and adapting responsively. [[1]](diffhunk://#diff-55bbc50716180dde2e694b29ce89c4aeec34542c164785dbdbe1efb76f7c7395R1-R91) [[2]](diffhunk://#diff-a679c635eee33fd0b64ae05d3fc5599fbdfa66bd1fe319212103e795a9f762f8R1-R104)
- Enhanced the `Card3` component to support interleaving custom nodes (such as Shorts rows) after every N cards, using the new `withInterleave` utility function and new props (`interleaveEvery`, `renderInterleave`). [[1]](diffhunk://#diff-6ae7ad9f53a84c22304bfcdf83c50291913cbf8416e58c0dcc6e1627e6105d85L24-R47) [[2]](diffhunk://#diff-6ae7ad9f53a84c22304bfcdf83c50291913cbf8416e58c0dcc6e1627e6105d85L91-R114) [[3]](diffhunk://#diff-6ae7ad9f53a84c22304bfcdf83c50291913cbf8416e58c0dcc6e1627e6105d85L247-R270)

**User Controls and Settings:**
- Introduced a new setting "Shorts inside the feeds" in the `SettingsModal`, allowing users to toggle the appearance of Shorts rows in feeds and recommendations. This is wired to a new `inlineShorts` property in the app store. [[1]](diffhunk://#diff-4ce32d79e4f131eb0281aa501f7a4ddcbee6140ab18c5e5d318a7c5574728001L147-R147) [[2]](diffhunk://#diff-4ce32d79e4f131eb0281aa501f7a4ddcbee6140ab18c5e5d318a7c5574728001R296-R301) [[3]](diffhunk://#diff-fb22c95a502cae93ba1418946e8c3ecf35676cde6f5fd8c665df3c9ec7853d9eR55-R59) [[4]](diffhunk://#diff-fb22c95a502cae93ba1418946e8c3ecf35676cde6f5fd8c665df3c9ec7853d9eR105)

**Measurement Utilities:**
- Added `useGridColumns` and `useShortsPerRow` hooks in `useGridMetrics.js` to dynamically measure the grid and determine how many Shorts fit per row, ensuring proper layout at any screen size.

**Data and API Improvements:**
- Updated the related videos API (`fetchRelatedFeed` in `videoData.js`) to return the current topic along with videos, enabling topic-matched Shorts recommendations without extra requests.
- Exported `bodyToPlaintext` from `hiveApi.js` for use in Shorts captions, ensuring clean, readable titles.

**UI/UX and Theme Consistency:**
- Improved the appearance of the Shorts stories bar for better theme compatibility and removed unnecessary backgrounds and color overrides. [[1]](diffhunk://#diff-67960c67dfb4cba092e37e4b27be79e46bc9e41baa6d0306473f1eef09a4f2c6L39-L48) [[2]](diffhunk://#diff-67960c67dfb4cba092e37e4b27be79e46bc9e41baa6d0306473f1eef09a4f2c6L85-L100) [[3]](diffhunk://#diff-67960c67dfb4cba092e37e4b27be79e46bc9e41baa6d0306473f1eef09a4f2c6L193-R195)

**Changelog Updates:**
- Documented the new Shorts-in-feed features and UI improvements in the `CHANGELOG`.