### PR TITLE
Feat/july fun

### DIFF
--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.56.0',
+    date: '2026-07-15',
+    summary:
+      'Playback polish, especially for older videos: a new 3Speak loading animation while a video starts up, plus smoother, steadier playback.',
+  },
+  {
     version: '1.55.0',
     date: '2026-07-12',
     summary:

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.57.0',
+    date: '2026-07-16',
+    summary:
+      'New Community tab on creator profiles: post short written updates ("snaps") to your followers, with tags, images and links. Community posts also show up between the videos in your home feeds, where you can like, comment, and follow the creator right there. Discover and New Content show the latest from everyone; your Interests and Follow Feed show posts from the people you follow.',
+  },
+  {
     version: '1.56.0',
     date: '2026-07-15',
     summary:

--- a/src/components/Cards/Card3.jsx
+++ b/src/components/Cards/Card3.jsx
@@ -31,21 +31,27 @@ import useHoverPreview from "../../hooks/useHoverPreview";
  * alignment. `every` is computed from the LIVE column count, not guessed, so the
  * rail always lands on a row boundary at any breakpoint.
  */
-function withInterleave(cards, every, render) {
-  if (!every || every < 1 || typeof render !== 'function') return cards;
+// Supports MULTIPLE full-width interleave streams (e.g. shorts rails + community
+// posts), each `{ every, render, key }`. Both can land after the same card.
+function withInterleave(cards, channels) {
+  const active = (channels || []).filter((c) => c && c.every >= 1 && typeof c.render === 'function');
+  if (!active.length) return cards;
   const out = [];
   cards.forEach((card, i) => {
     out.push(card);
-    if ((i + 1) % every === 0 && i + 1 < cards.length) {
-      const slot = (i + 1) / every - 1;
-      const node = render(slot);
-      if (node) out.push(<div className="card-interleave" key={`interleave-${slot}`}>{node}</div>);
-    }
+    const n = i + 1;
+    if (n >= cards.length) return; // never append after the last card
+    active.forEach((ch) => {
+      if (n % ch.every !== 0) return;
+      const slot = n / ch.every - 1;
+      const node = ch.render(slot);
+      if (node) out.push(<div className="card-interleave" key={`${ch.key || 'il'}-${slot}`}>{node}</div>);
+    });
   });
   return out;
 }
 
-function Card3({ videos = [], loading = false, error = null, interleaveEvery = 0, renderInterleave = null, getContentForVideo = null, isWatched = null, getViewCount = null, linkPrefix = '/watch', linkQuery = '', shortTimeAgo = true, shortsGrid = false, priority = false, hideWatched = false, watchedVersion = 0 }) {
+function Card3({ videos = [], loading = false, error = null, interleaveEvery = 0, renderInterleave = null, communityEvery = 0, renderCommunity = null, getContentForVideo = null, isWatched = null, getViewCount = null, linkPrefix = '/watch', linkQuery = '', shortTimeAgo = true, shortsGrid = false, priority = false, hideWatched = false, watchedVersion = 0 }) {
   const navigate = useNavigate();
   const [modalUser, setModalUser] = useState(null);
 
@@ -288,7 +294,10 @@ function Card3({ videos = [], loading = false, error = null, interleaveEvery = 0
             </div>
           </Link>
         );
-      }), interleaveEvery, renderInterleave)}
+      }), [
+        { every: interleaveEvery, render: renderInterleave, key: 'shorts' },
+        { every: communityEvery, render: renderCommunity, key: 'community' },
+      ])}
       {modalUser && (
         <ProfileModal
           username={modalUser}

--- a/src/components/CreatorStats/CreatorStats.jsx
+++ b/src/components/CreatorStats/CreatorStats.jsx
@@ -374,21 +374,39 @@ export default function CreatorStats({ user }) {
                   ))}
                 </div>
                 <div className="cs-list">
-                {list.map((v, i) => (
-                  <button
-                    key={v.permlink}
-                    className={`cs-item${selected?.permlink === v.permlink ? ' selected' : ''}`}
-                    onClick={() => setSelected(selected?.permlink === v.permlink ? null : v)}
-                  >
-                    <span className="cs-rank">{i + 1}</span>
-                    <img className="cs-item-thumb" src={v.thumbnail} alt="" loading="lazy" />
-                    <span className="cs-item-info">
-                      <span className="cs-item-title">{v.short ? '⏱ ' : ''}{v.title || v.permlink}</span>
-                      {v.created && <span className="cs-item-date">{timeAgo(v.created)}</span>}
-                    </span>
-                    <span className="cs-item-metric">{sortDef.fmt(v[sort])}</span>
-                  </button>
-                ))}
+                {list.map((v, i) => {
+                  const toggle = () => setSelected(selected?.permlink === v.permlink ? null : v);
+                  // Clicking the TITLE opens the video/short in a new tab; clicking the
+                  // rest of the row shows its analytics below.
+                  const watchUrl = `/${v.short ? 'shorts' : 'watch'}?v=${user}/${v.permlink}`;
+                  return (
+                    <div
+                      key={v.permlink}
+                      className={`cs-item${selected?.permlink === v.permlink ? ' selected' : ''}`}
+                      role="button"
+                      tabIndex={0}
+                      onClick={toggle}
+                      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle(); } }}
+                    >
+                      <span className="cs-rank">{i + 1}</span>
+                      <img className="cs-item-thumb" src={v.thumbnail} alt="" loading="lazy" />
+                      <span className="cs-item-info">
+                        <a
+                          className="cs-item-title"
+                          href={watchUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                          title="Open the video in a new tab"
+                        >
+                          {v.short ? '⏱ ' : ''}{v.title || v.permlink}
+                        </a>
+                        {v.created && <span className="cs-item-date">{timeAgo(v.created)}</span>}
+                      </span>
+                      <span className="cs-item-metric">{sortDef.fmt(v[sort])}</span>
+                    </div>
+                  );
+                })}
                 </div>
               </div>
 

--- a/src/components/CreatorStats/CreatorStats.scss
+++ b/src/components/CreatorStats/CreatorStats.scss
@@ -113,6 +113,10 @@
     .cs-item-title {
       font-size: 13.5px; font-weight: 600; color: var(--text-primary, #111);
       overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+      // It's a link now (opens the video in a new tab) — keep the row look, add a
+      // hover affordance so it's clear the title itself is clickable.
+      text-decoration: none; display: block; width: fit-content; max-width: 100%;
+      &:hover { color: var(--accent-primary, #e53935); text-decoration: underline; }
     }
     .cs-item-date { font-size: 11.5px; color: var(--text-muted, #999); }
     .cs-item-metric { font-size: 13.5px; font-weight: 800; color: var(--text-primary, #111); }

--- a/src/components/Userprofilepage/CommunitySnaps.jsx
+++ b/src/components/Userprofilepage/CommunitySnaps.jsx
@@ -1,11 +1,16 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { toast } from 'sonner';
 import { BiCommentDetail } from 'react-icons/bi';
-import { fetchSnaps, SNAP_TAG } from '../../lib/snaps';
+import { MdMoreVert } from 'react-icons/md';
+import {
+  fetchSnaps, SNAP_TAG, recordSnapInteraction,
+  hideSnap, unhideSnap, hideSnapCreator, unhideSnapCreator,
+} from '../../lib/snaps';
 import { getHiveRenderer } from '../../lib/hiveRenderer';
 import { getHiveClient } from '../../utils/hiveNode';
 import { getVotePower, getDynamicProps } from '../../utils/hiveUtils';
@@ -188,7 +193,70 @@ function SnapComments({ owner, permlink, onCommented }) {
   );
 }
 
-function SnapCard({ snap }) {
+// Card3-style ⋮ menu, but hides go to the SNAP hide list only (not video hides).
+function SnapOptionsMenu({ owner, permlink, onHidden }) {
+  const user = useAppStore((s) => s.user);
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState({ top: 0, left: 0 });
+  const btnRef = useRef(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const close = () => setOpen(false);
+    window.addEventListener('scroll', close, true);
+    window.addEventListener('resize', close);
+    document.addEventListener('keydown', close);
+    return () => {
+      window.removeEventListener('scroll', close, true);
+      window.removeEventListener('resize', close);
+      document.removeEventListener('keydown', close);
+    };
+  }, [open]);
+
+  if (!user) return null;
+
+  const toggle = () => {
+    const r = btnRef.current?.getBoundingClientRect();
+    if (r) setPos({ top: r.bottom + 4, left: Math.min(r.left - 150, window.innerWidth - 220) });
+    setOpen((v) => !v);
+  };
+  const hidePost = async () => {
+    setOpen(false);
+    onHidden?.();
+    try {
+      await hideSnap(user, owner, permlink);
+      toast('Post hidden', { action: { label: 'Undo', onClick: () => unhideSnap(user, owner, permlink).catch(() => {}) } });
+    } catch { toast.error('Could not hide the post'); }
+  };
+  const hideCreator = async () => {
+    setOpen(false);
+    onHidden?.();
+    try {
+      await hideSnapCreator(user, owner);
+      toast(`Hiding @${owner}'s community posts`, { action: { label: 'Undo', onClick: () => unhideSnapCreator(user, owner).catch(() => {}) } });
+    } catch { toast.error('Could not hide the creator'); }
+  };
+
+  return (
+    <>
+      <button ref={btnRef} type="button" className="snap-menu-btn" onClick={toggle} aria-label="Post options">
+        <MdMoreVert />
+      </button>
+      {open && createPortal(
+        <>
+          <div className="snap-menu-backdrop" onClick={() => setOpen(false)} />
+          <div className="snap-menu" style={{ top: pos.top, left: pos.left }}>
+            <button type="button" onClick={hidePost}>Not interested</button>
+            <button type="button" onClick={hideCreator}>Don’t show this creator</button>
+          </div>
+        </>,
+        document.body,
+      )}
+    </>
+  );
+}
+
+export function SnapCard({ snap, feedMode = false, onRemove }) {
   const user = useAppStore((s) => s.user);
   const client = getHiveClient();
   const [showComments, setShowComments] = useState(false);
@@ -234,6 +302,9 @@ function SnapCard({ snap }) {
   return (
     <article className="snap-card">
       <div className="snap-card-head">
+        {/* In the home feed the snap is from any creator, so name them; on a profile
+            Community tab it's always that profile, so we omit it. */}
+        {feedMode && <Link to={`/p/${snap.owner}`} className="snap-author">@{snap.owner}</Link>}
         <a
           className="snap-time"
           href={`https://peakd.com/@${snap.owner}/${snap.permlink}`}
@@ -243,6 +314,9 @@ function SnapCard({ snap }) {
         >
           {hiveTime(snap.created)}
         </a>
+        {feedMode && (
+          <SnapOptionsMenu owner={snap.owner} permlink={snap.permlink} onHidden={() => onRemove?.(snap)} />
+        )}
       </div>
 
       <SnapBody body={snap.body} />
@@ -270,7 +344,7 @@ function SnapCard({ snap }) {
               setAccountData={setAccountData}
               cachedDynamicProps={voteData?.dynProps || null}
               setActiveTooltipPermlink={() => {}}
-              onVoteSuccess={() => refetch()}
+              onVoteSuccess={() => { refetch(); recordSnapInteraction(user, snap.owner, snap.permlink); }}
               enableViewerTag={false}
               postCreatedAt={snap.created}
             />
@@ -287,7 +361,11 @@ function SnapCard({ snap }) {
       </div>
 
       {showComments && (
-        <SnapComments owner={snap.owner} permlink={snap.permlink} onCommented={() => refetch()} />
+        <SnapComments
+          owner={snap.owner}
+          permlink={snap.permlink}
+          onCommented={() => { refetch(); recordSnapInteraction(user, snap.owner, snap.permlink); }}
+        />
       )}
     </article>
   );

--- a/src/components/Userprofilepage/CommunitySnaps.jsx
+++ b/src/components/Userprofilepage/CommunitySnaps.jsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
-import { fetchSnaps } from '../../lib/snaps';
+import { fetchSnaps, SNAP_TAG } from '../../lib/snaps';
 import { getHiveRenderer } from '../../lib/hiveRenderer';
 import SnapComposer from './SnapComposer';
 import BarLoader from '../Loader/BarLoader';
@@ -25,7 +25,7 @@ function SnapBody({ body }) {
 
 function SnapCard({ snap }) {
   const when = snap.created ? dayjs(snap.created).fromNow() : '';
-  const tags = (snap.tags || []).filter((t) => t && t !== 'nsfw');
+  const tags = (snap.tags || []).filter((t) => t && t !== 'nsfw' && t !== SNAP_TAG);
   return (
     <article className="snap-card">
       <div className="snap-card-head">
@@ -89,7 +89,7 @@ export default function CommunitySnaps({ user, canPost = false }) {
         <BarLoader />
       ) : snaps.length === 0 ? (
         <div className="snap-empty">
-          {canPost ? 'No snaps yet — share your first update above.' : 'No snaps here yet.'}
+          {canPost ? 'No community posts yet — share your first update above.' : 'No community posts yet.'}
         </div>
       ) : (
         <div className="snap-list">

--- a/src/components/Userprofilepage/CommunitySnaps.jsx
+++ b/src/components/Userprofilepage/CommunitySnaps.jsx
@@ -1,0 +1,103 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import { fetchSnaps } from '../../lib/snaps';
+import { getHiveRenderer } from '../../lib/hiveRenderer';
+import SnapComposer from './SnapComposer';
+import BarLoader from '../Loader/BarLoader';
+import './CommunitySnaps.scss';
+
+dayjs.extend(relativeTime);
+
+function SnapBody({ body }) {
+  const [html, setHtml] = useState('');
+  useEffect(() => {
+    let alive = true;
+    getHiveRenderer()
+      .then((render) => { if (alive) { try { setHtml(render(body || '')); } catch { setHtml(''); } } })
+      .catch(() => { if (alive) setHtml(''); });
+    return () => { alive = false; };
+  }, [body]);
+  return <div className="snap-body markdown-body" dangerouslySetInnerHTML={{ __html: html }} />;
+}
+
+function SnapCard({ snap }) {
+  const when = snap.created ? dayjs(snap.created).fromNow() : '';
+  const tags = (snap.tags || []).filter((t) => t && t !== 'nsfw');
+  return (
+    <article className="snap-card">
+      <div className="snap-card-head">
+        <Link to={`/p/${snap.owner}`} className="snap-author">@{snap.owner}</Link>
+        <a
+          className="snap-time"
+          href={`https://peakd.com/@${snap.owner}/${snap.permlink}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          title="View on Hive"
+        >
+          {when}
+        </a>
+      </div>
+      <SnapBody body={snap.body} />
+      {tags.length > 0 && (
+        <div className="snap-tags">
+          {tags.map((t) => (
+            <Link key={t} to={`/t/${t}`} className="snap-tag">#{t}</Link>
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}
+
+/**
+ * The profile's "Community" tab. Everyone sees the owner's snaps; only the owner
+ * (canPost) gets the composer. Newly posted snaps are shown optimistically and then
+ * reconciled once the checker has indexed the on-chain post.
+ */
+export default function CommunitySnaps({ user, canPost = false }) {
+  const [optimistic, setOptimistic] = useState([]);
+
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ['community-snaps', user],
+    queryFn: () => fetchSnaps(user),
+    enabled: !!user,
+    staleTime: 30_000,
+  });
+
+  const snaps = useMemo(() => {
+    const fetched = data?.snaps || [];
+    const seen = new Set(fetched.map((s) => s.permlink));
+    const extra = optimistic.filter((s) => s.owner === user && !seen.has(s.permlink));
+    return [...extra, ...fetched];
+  }, [data?.snaps, optimistic, user]);
+
+  const onPosted = (snap) => {
+    setOptimistic((prev) => [snap, ...prev.filter((s) => s.permlink !== snap.permlink)]);
+    // The checker indexes the on-chain post a few seconds later — reconcile then.
+    setTimeout(() => refetch(), 4000);
+    setTimeout(() => refetch(), 12000);
+  };
+
+  return (
+    <div className="community-snaps">
+      {canPost && <SnapComposer onPosted={onPosted} />}
+
+      {isLoading && snaps.length === 0 ? (
+        <BarLoader />
+      ) : snaps.length === 0 ? (
+        <div className="snap-empty">
+          {canPost ? 'No snaps yet — share your first update above.' : 'No snaps here yet.'}
+        </div>
+      ) : (
+        <div className="snap-list">
+          {snaps.map((s) => (
+            <SnapCard key={s._id || `${s.owner}/${s.permlink}`} snap={s} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Userprofilepage/CommunitySnaps.jsx
+++ b/src/components/Userprofilepage/CommunitySnaps.jsx
@@ -302,9 +302,13 @@ export function SnapCard({ snap, feedMode = false, onRemove }) {
   return (
     <article className="snap-card">
       <div className="snap-card-head">
-        {/* In the home feed the snap is from any creator, so name them; on a profile
+        {/* In the home feed the snap is from any creator, so title it; on a profile
             Community tab it's always that profile, so we omit it. */}
-        {feedMode && <Link to={`/p/${snap.owner}`} className="snap-author">@{snap.owner}</Link>}
+        {feedMode && (
+          <span className="snap-feed-title">
+            Community snap by <Link to={`/p/${snap.owner}`} className="snap-author">@{snap.owner}</Link>
+          </span>
+        )}
         <a
           className="snap-time"
           href={`https://peakd.com/@${snap.owner}/${snap.permlink}`}

--- a/src/components/Userprofilepage/CommunitySnaps.jsx
+++ b/src/components/Userprofilepage/CommunitySnaps.jsx
@@ -1,18 +1,31 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import { toast } from 'sonner';
+import { BiUpvote, BiSolidUpvote, BiCommentDetail } from 'react-icons/bi';
 import { fetchSnaps, SNAP_TAG } from '../../lib/snaps';
 import { getHiveRenderer } from '../../lib/hiveRenderer';
+import { getHiveClient } from '../../utils/hiveNode';
+import { voteWithAioha, commentWithAioha } from '../../hive-api/aioha';
+import { useAppStore } from '../../lib/store';
 import SnapComposer from './SnapComposer';
 import BarLoader from '../Loader/BarLoader';
 import './CommunitySnaps.scss';
 
 dayjs.extend(relativeTime);
 
+const hiveTime = (t) => (t ? dayjs(/Z$/.test(String(t)) ? t : `${t}Z`).fromNow() : '');
+
+// Body with "read more" — a very long snap is capped at ~10% of the viewport height
+// until expanded.
 function SnapBody({ body }) {
   const [html, setHtml] = useState('');
+  const [expanded, setExpanded] = useState(false);
+  const [overflowing, setOverflowing] = useState(false);
+  const ref = useRef(null);
+
   useEffect(() => {
     let alive = true;
     getHiveRenderer()
@@ -20,16 +33,153 @@ function SnapBody({ body }) {
       .catch(() => { if (alive) setHtml(''); });
     return () => { alive = false; };
   }, [body]);
-  return <div className="snap-body markdown-body" dangerouslySetInnerHTML={{ __html: html }} />;
+
+  useEffect(() => {
+    const el = ref.current;
+    if (el && !expanded) setOverflowing(el.scrollHeight > el.clientHeight + 4);
+  }, [html, expanded]);
+
+  return (
+    <div className="snap-body-wrap">
+      <div
+        ref={ref}
+        className={`snap-body markdown-body${expanded ? ' expanded' : ''}`}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+      {overflowing && !expanded && (
+        <button type="button" className="snap-readmore" onClick={() => setExpanded(true)}>Read more</button>
+      )}
+    </div>
+  );
+}
+
+function SnapComment({ comment }) {
+  const [html, setHtml] = useState('');
+  useEffect(() => {
+    let alive = true;
+    getHiveRenderer().then((render) => { if (alive) { try { setHtml(render(comment.body || '')); } catch { setHtml(''); } } });
+    return () => { alive = false; };
+  }, [comment.body]);
+  return (
+    <li className="snap-comment">
+      <div className="snap-comment-head">
+        <Link to={`/p/${comment.author}`} className="snap-comment-author">@{comment.author}</Link>
+        <span className="snap-comment-time">{hiveTime(comment.created)}</span>
+      </div>
+      <div className="snap-comment-body markdown-body" dangerouslySetInnerHTML={{ __html: html }} />
+    </li>
+  );
+}
+
+function SnapComments({ owner, permlink, onCommented }) {
+  const user = useAppStore((s) => s.user);
+  const client = getHiveClient();
+  const [reply, setReply] = useState('');
+  const [posting, setPosting] = useState(false);
+
+  const { data: comments = [], isLoading, refetch } = useQuery({
+    queryKey: ['snap-comments', owner, permlink],
+    queryFn: async () => {
+      const replies = await client.call('condenser_api', 'get_content_replies', [owner, permlink]);
+      return (replies || []).sort((a, b) => new Date(a.created) - new Date(b.created));
+    },
+    staleTime: 30_000,
+  });
+
+  const handleReply = async () => {
+    if (!user) { toast.error('Log in to comment'); return; }
+    const text = reply.trim();
+    if (!text) return;
+    setPosting(true);
+    try {
+      const rp = `re-${permlink}-${Date.now() % 1000000}`.toLowerCase().replace(/[^a-z0-9-]/g, '').slice(0, 250);
+      await commentWithAioha(owner, permlink, rp, '', text, { app: '3speak/snap', format: 'markdown' }, null);
+      toast.success('Comment posted!');
+      setReply('');
+      setTimeout(() => { refetch(); onCommented?.(); }, 3000);
+    } catch (e) {
+      toast.error(e?.message || 'Could not post the comment');
+    } finally {
+      setPosting(false);
+    }
+  };
+
+  return (
+    <div className="snap-comments">
+      {user && (
+        <div className="snap-reply-box">
+          <textarea
+            placeholder="Write a comment…"
+            value={reply}
+            onChange={(e) => setReply(e.target.value)}
+            rows={2}
+          />
+          <button type="button" onClick={handleReply} disabled={posting || !reply.trim()}>
+            {posting ? 'Posting…' : 'Reply'}
+          </button>
+        </div>
+      )}
+      {isLoading ? (
+        <div className="snap-comments-status">Loading comments…</div>
+      ) : comments.length === 0 ? (
+        <div className="snap-comments-status">No comments yet.</div>
+      ) : (
+        <ul className="snap-comment-list">
+          {comments.map((c) => <SnapComment key={`${c.author}/${c.permlink}`} comment={c} />)}
+        </ul>
+      )}
+    </div>
+  );
 }
 
 function SnapCard({ snap }) {
-  const when = snap.created ? dayjs(snap.created).fromNow() : '';
+  const user = useAppStore((s) => s.user);
+  const client = getHiveClient();
+  const [showComments, setShowComments] = useState(false);
+  const [voting, setVoting] = useState(false);
+  const [optimistic, setOptimistic] = useState(null); // { votes, voted }
+
+  // Live votes/comment counts from the chain (the checker only stores the text).
+  const { data: meta, refetch } = useQuery({
+    queryKey: ['snap-meta', snap.owner, snap.permlink],
+    queryFn: async () => {
+      const post = await client.call('condenser_api', 'get_content', [snap.owner, snap.permlink]);
+      const av = post?.active_votes || [];
+      return {
+        votes: av.filter((v) => Number(v.percent) > 0).length,
+        comments: post?.children ?? 0,
+        voted: !!user && av.some((v) => v.voter === user && Number(v.percent) > 0),
+      };
+    },
+    staleTime: 60_000,
+  });
+
+  const votes = optimistic?.votes ?? meta?.votes ?? 0;
+  const voted = optimistic?.voted ?? meta?.voted ?? false;
+  const comments = meta?.comments ?? 0;
+
+  const handleVote = async () => {
+    if (!user) { toast.error('Log in to vote'); return; }
+    if (voted || voting) return;
+    setVoting(true);
+    setOptimistic({ votes: votes + 1, voted: true });
+    try {
+      await voteWithAioha(snap.owner, snap.permlink, 10000);
+      toast.success('Upvoted!');
+      setTimeout(() => refetch(), 3000);
+    } catch (e) {
+      setOptimistic(null);
+      toast.error(e?.message || 'Vote failed');
+    } finally {
+      setVoting(false);
+    }
+  };
+
   const tags = (snap.tags || []).filter((t) => t && t !== 'nsfw' && t !== SNAP_TAG);
+
   return (
     <article className="snap-card">
       <div className="snap-card-head">
-        <Link to={`/p/${snap.owner}`} className="snap-author">@{snap.owner}</Link>
         <a
           className="snap-time"
           href={`https://peakd.com/@${snap.owner}/${snap.permlink}`}
@@ -37,16 +187,41 @@ function SnapCard({ snap }) {
           rel="noopener noreferrer"
           title="View on Hive"
         >
-          {when}
+          {hiveTime(snap.created)}
         </a>
       </div>
+
       <SnapBody body={snap.body} />
+
       {tags.length > 0 && (
         <div className="snap-tags">
-          {tags.map((t) => (
-            <Link key={t} to={`/t/${t}`} className="snap-tag">{t}</Link>
-          ))}
+          {tags.map((t) => <Link key={t} to={`/t/${t}`} className="snap-tag">{t}</Link>)}
         </div>
+      )}
+
+      <div className="snap-actions">
+        <button
+          type="button"
+          className={`snap-action${voted ? ' voted' : ''}`}
+          onClick={handleVote}
+          disabled={voting || voted}
+          title={voted ? 'Upvoted' : 'Upvote'}
+        >
+          {voted ? <BiSolidUpvote /> : <BiUpvote />}
+          {votes > 0 && <span>{votes}</span>}
+        </button>
+        <button
+          type="button"
+          className={`snap-action${showComments ? ' active' : ''}`}
+          onClick={() => setShowComments((v) => !v)}
+        >
+          <BiCommentDetail />
+          <span>{comments > 0 ? comments : ''} {showComments ? 'Hide' : 'Comments'}</span>
+        </button>
+      </div>
+
+      {showComments && (
+        <SnapComments owner={snap.owner} permlink={snap.permlink} onCommented={() => refetch()} />
       )}
     </article>
   );
@@ -54,8 +229,7 @@ function SnapCard({ snap }) {
 
 /**
  * The profile's "Community" tab. Everyone sees the owner's snaps; only the owner
- * (canPost) gets the composer. Newly posted snaps are shown optimistically and then
- * reconciled once the checker has indexed the on-chain post.
+ * (canPost) gets the composer.
  */
 export default function CommunitySnaps({ user, canPost = false }) {
   const [optimistic, setOptimistic] = useState([]);
@@ -76,7 +250,6 @@ export default function CommunitySnaps({ user, canPost = false }) {
 
   const onPosted = (snap) => {
     setOptimistic((prev) => [snap, ...prev.filter((s) => s.permlink !== snap.permlink)]);
-    // The checker indexes the on-chain post a few seconds later — reconcile then.
     setTimeout(() => refetch(), 4000);
     setTimeout(() => refetch(), 12000);
   };
@@ -93,9 +266,7 @@ export default function CommunitySnaps({ user, canPost = false }) {
         </div>
       ) : (
         <div className="snap-list">
-          {snaps.map((s) => (
-            <SnapCard key={s._id || `${s.owner}/${s.permlink}`} snap={s} />
-          ))}
+          {snaps.map((s) => <SnapCard key={s._id || `${s.owner}/${s.permlink}`} snap={s} />)}
         </div>
       )}
     </div>

--- a/src/components/Userprofilepage/CommunitySnaps.jsx
+++ b/src/components/Userprofilepage/CommunitySnaps.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
@@ -299,6 +299,7 @@ function SnapCard({ snap }) {
  */
 export default function CommunitySnaps({ user, canPost = false }) {
   const [optimistic, setOptimistic] = useState([]);
+  const queryClient = useQueryClient();
 
   const { data, isLoading, refetch } = useQuery({
     queryKey: ['community-snaps', user],
@@ -317,7 +318,11 @@ export default function CommunitySnaps({ user, canPost = false }) {
   const onPosted = (snap) => {
     setOptimistic((prev) => [snap, ...prev.filter((s) => s.permlink !== snap.permlink)]);
     setTimeout(() => refetch(), 4000);
-    setTimeout(() => refetch(), 12000);
+    setTimeout(() => {
+      refetch();
+      // Refresh the tab-header count once the checker has indexed it.
+      queryClient.invalidateQueries({ queryKey: ['community-snaps-count', user] });
+    }, 12000);
   };
 
   return (

--- a/src/components/Userprofilepage/CommunitySnaps.jsx
+++ b/src/components/Userprofilepage/CommunitySnaps.jsx
@@ -8,6 +8,7 @@ import { BiCommentDetail } from 'react-icons/bi';
 import { fetchSnaps, SNAP_TAG } from '../../lib/snaps';
 import { getHiveRenderer } from '../../lib/hiveRenderer';
 import { getHiveClient } from '../../utils/hiveNode';
+import { getVotePower, getDynamicProps } from '../../utils/hiveUtils';
 import { commentWithAioha } from '../../hive-api/aioha';
 import { useAppStore } from '../../lib/store';
 import SnapComposer from './SnapComposer';
@@ -45,7 +46,7 @@ function SnapBody({ body }) {
     const measure = () => {
       const el = ref.current;
       // scrollHeight is the full content height regardless of the max-height clamp.
-      if (el) setOverflowing(el.scrollHeight > window.innerHeight * 0.1 + 8);
+      if (el) setOverflowing(el.scrollHeight > window.innerHeight * 0.33 + 8);
     };
     measure();
     window.addEventListener('resize', measure);
@@ -198,6 +199,19 @@ function SnapCard({ snap }) {
   const [voteValue, setVoteValue] = useState('0.00');
   const [accountData, setAccountData] = useState(null);
 
+  // Pre-fetch the viewer's vote power + chain props (shared across all cards via the
+  // query key) so the vote dialog gets its fast path — otherwise it flips `initializing`
+  // and re-renders the estimate back to the stale value until the slider moves.
+  const { data: voteData } = useQuery({
+    queryKey: ['snap-vote-data', user],
+    queryFn: async () => {
+      const [acctRes, dyn] = await Promise.all([getVotePower(user), getDynamicProps()]);
+      return { account: acctRes?.account || null, dynProps: dyn || null };
+    },
+    enabled: !!user,
+    staleTime: 5 * 60_000,
+  });
+
   const { data: meta, refetch } = useQuery({
     queryKey: ['snap-meta', snap.owner, snap.permlink],
     queryFn: async () => {
@@ -252,8 +266,9 @@ function SnapCard({ snap }) {
               setWeight={setWeight}
               voteValue={voteValue}
               setVoteValue={setVoteValue}
-              accountData={accountData}
+              accountData={voteData?.account || accountData}
               setAccountData={setAccountData}
+              cachedDynamicProps={voteData?.dynProps || null}
               setActiveTooltipPermlink={() => {}}
               onVoteSuccess={() => refetch()}
               enableViewerTag={false}

--- a/src/components/Userprofilepage/CommunitySnaps.jsx
+++ b/src/components/Userprofilepage/CommunitySnaps.jsx
@@ -4,13 +4,15 @@ import { Link } from 'react-router-dom';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { toast } from 'sonner';
-import { BiUpvote, BiSolidUpvote, BiCommentDetail } from 'react-icons/bi';
+import { BiCommentDetail } from 'react-icons/bi';
 import { fetchSnaps, SNAP_TAG } from '../../lib/snaps';
 import { getHiveRenderer } from '../../lib/hiveRenderer';
 import { getHiveClient } from '../../utils/hiveNode';
-import { voteWithAioha, commentWithAioha } from '../../hive-api/aioha';
+import { commentWithAioha } from '../../hive-api/aioha';
 import { useAppStore } from '../../lib/store';
 import SnapComposer from './SnapComposer';
+import UpvoteCount from '../UpvoteCount/UpvoteCount';
+import CommentVoteTooltip from '../tooltip/CommentVoteTooltip';
 import BarLoader from '../Loader/BarLoader';
 import './CommunitySnaps.scss';
 
@@ -18,8 +20,13 @@ dayjs.extend(relativeTime);
 
 const hiveTime = (t) => (t ? dayjs(/Z$/.test(String(t)) ? t : `${t}Z`).fromNow() : '');
 
-// Body with "read more" — a very long snap is capped at ~10% of the viewport height
-// until expanded.
+async function fetchReplies(author, permlink) {
+  const replies = await getHiveClient().call('condenser_api', 'get_content_replies', [author, permlink]);
+  return (replies || []).sort((a, b) => new Date(a.created) - new Date(b.created));
+}
+
+// Body with "read more"/"show less" — a very long snap is capped at ~10% of the
+// viewport, but only when it actually overflows (no fade on short posts).
 function SnapBody({ body }) {
   const [html, setHtml] = useState('');
   const [expanded, setExpanded] = useState(false);
@@ -35,68 +42,50 @@ function SnapBody({ body }) {
   }, [body]);
 
   useEffect(() => {
-    const el = ref.current;
-    if (el && !expanded) setOverflowing(el.scrollHeight > el.clientHeight + 4);
-  }, [html, expanded]);
+    const measure = () => {
+      const el = ref.current;
+      // scrollHeight is the full content height regardless of the max-height clamp.
+      if (el) setOverflowing(el.scrollHeight > window.innerHeight * 0.1 + 8);
+    };
+    measure();
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
+  }, [html]);
 
+  const clamped = overflowing && !expanded;
   return (
     <div className="snap-body-wrap">
       <div
         ref={ref}
-        className={`snap-body markdown-body${expanded ? ' expanded' : ''}`}
+        className={`snap-body markdown-body${clamped ? ' clamped' : ''}`}
         dangerouslySetInnerHTML={{ __html: html }}
       />
-      {overflowing && !expanded && (
-        <button type="button" className="snap-readmore" onClick={() => setExpanded(true)}>Read more</button>
+      {overflowing && (
+        <button type="button" className="snap-readmore" onClick={() => setExpanded((e) => !e)}>
+          {expanded ? 'Show less' : 'Read more'}
+        </button>
       )}
     </div>
   );
 }
 
-function SnapComment({ comment }) {
-  const [html, setHtml] = useState('');
-  useEffect(() => {
-    let alive = true;
-    getHiveRenderer().then((render) => { if (alive) { try { setHtml(render(comment.body || '')); } catch { setHtml(''); } } });
-    return () => { alive = false; };
-  }, [comment.body]);
-  return (
-    <li className="snap-comment">
-      <div className="snap-comment-head">
-        <Link to={`/p/${comment.author}`} className="snap-comment-author">@{comment.author}</Link>
-        <span className="snap-comment-time">{hiveTime(comment.created)}</span>
-      </div>
-      <div className="snap-comment-body markdown-body" dangerouslySetInnerHTML={{ __html: html }} />
-    </li>
-  );
-}
-
-function SnapComments({ owner, permlink, onCommented }) {
+// Reply composer — reused for the snap itself and for any comment (nested replies).
+function ReplyBox({ parentAuthor, parentPermlink, onPosted, autoFocus = false }) {
   const user = useAppStore((s) => s.user);
-  const client = getHiveClient();
   const [reply, setReply] = useState('');
   const [posting, setPosting] = useState(false);
+  if (!user) return null;
 
-  const { data: comments = [], isLoading, refetch } = useQuery({
-    queryKey: ['snap-comments', owner, permlink],
-    queryFn: async () => {
-      const replies = await client.call('condenser_api', 'get_content_replies', [owner, permlink]);
-      return (replies || []).sort((a, b) => new Date(a.created) - new Date(b.created));
-    },
-    staleTime: 30_000,
-  });
-
-  const handleReply = async () => {
-    if (!user) { toast.error('Log in to comment'); return; }
+  const submit = async () => {
     const text = reply.trim();
     if (!text) return;
     setPosting(true);
     try {
-      const rp = `re-${permlink}-${Date.now() % 1000000}`.toLowerCase().replace(/[^a-z0-9-]/g, '').slice(0, 250);
-      await commentWithAioha(owner, permlink, rp, '', text, { app: '3speak/snap', format: 'markdown' }, null);
+      const rp = `re-${parentPermlink}-${Date.now() % 1000000}`.toLowerCase().replace(/[^a-z0-9-]/g, '').slice(0, 250);
+      await commentWithAioha(parentAuthor, parentPermlink, rp, '', text, { app: '3speak/snap', format: 'markdown' }, null);
       toast.success('Comment posted!');
       setReply('');
-      setTimeout(() => { refetch(); onCommented?.(); }, 3000);
+      setTimeout(() => onPosted?.(), 3000);
     } catch (e) {
       toast.error(e?.message || 'Could not post the comment');
     } finally {
@@ -105,20 +94,86 @@ function SnapComments({ owner, permlink, onCommented }) {
   };
 
   return (
-    <div className="snap-comments">
-      {user && (
-        <div className="snap-reply-box">
-          <textarea
-            placeholder="Write a comment…"
-            value={reply}
-            onChange={(e) => setReply(e.target.value)}
-            rows={2}
-          />
-          <button type="button" onClick={handleReply} disabled={posting || !reply.trim()}>
-            {posting ? 'Posting…' : 'Reply'}
+    <div className="snap-reply-box">
+      <textarea
+        placeholder="Write a comment…"
+        value={reply}
+        onChange={(e) => setReply(e.target.value)}
+        rows={2}
+        autoFocus={autoFocus}
+      />
+      <button type="button" onClick={submit} disabled={posting || !reply.trim()}>
+        {posting ? 'Posting…' : 'Reply'}
+      </button>
+    </div>
+  );
+}
+
+// A single comment — recursive, so replies-on-replies work.
+function SnapComment({ comment }) {
+  const user = useAppStore((s) => s.user);
+  const [html, setHtml] = useState('');
+  const [replying, setReplying] = useState(false);
+  const [showReplies, setShowReplies] = useState(false);
+  const childCount = comment.children ?? 0;
+
+  useEffect(() => {
+    let alive = true;
+    getHiveRenderer().then((render) => { if (alive) { try { setHtml(render(comment.body || '')); } catch { setHtml(''); } } });
+    return () => { alive = false; };
+  }, [comment.body]);
+
+  const { data: children = [], refetch } = useQuery({
+    queryKey: ['snap-replies', comment.author, comment.permlink],
+    queryFn: () => fetchReplies(comment.author, comment.permlink),
+    enabled: showReplies,
+    staleTime: 30_000,
+  });
+
+  return (
+    <li className="snap-comment">
+      <div className="snap-comment-head">
+        <Link to={`/p/${comment.author}`} className="snap-comment-author">@{comment.author}</Link>
+        <span className="snap-comment-time">{hiveTime(comment.created)}</span>
+      </div>
+      <div className="snap-comment-body markdown-body" dangerouslySetInnerHTML={{ __html: html }} />
+      <div className="snap-comment-actions">
+        {user && (
+          <button type="button" onClick={() => setReplying((v) => !v)}>{replying ? 'Cancel' : 'Reply'}</button>
+        )}
+        {childCount > 0 && (
+          <button type="button" onClick={() => setShowReplies((v) => !v)}>
+            {showReplies ? 'Hide replies' : `${childCount} ${childCount > 1 ? 'replies' : 'reply'}`}
           </button>
-        </div>
+        )}
+      </div>
+      {replying && (
+        <ReplyBox
+          parentAuthor={comment.author}
+          parentPermlink={comment.permlink}
+          autoFocus
+          onPosted={() => { setReplying(false); setShowReplies(true); refetch(); }}
+        />
       )}
+      {showReplies && children.length > 0 && (
+        <ul className="snap-comment-list nested">
+          {children.map((c) => <SnapComment key={`${c.author}/${c.permlink}`} comment={c} />)}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+function SnapComments({ owner, permlink, onCommented }) {
+  const { data: comments = [], isLoading, refetch } = useQuery({
+    queryKey: ['snap-comments', owner, permlink],
+    queryFn: () => fetchReplies(owner, permlink),
+    staleTime: 30_000,
+  });
+
+  return (
+    <div className="snap-comments">
+      <ReplyBox parentAuthor={owner} parentPermlink={permlink} onPosted={() => { refetch(); onCommented?.(); }} />
       {isLoading ? (
         <div className="snap-comments-status">Loading comments…</div>
       ) : comments.length === 0 ? (
@@ -136,10 +191,13 @@ function SnapCard({ snap }) {
   const user = useAppStore((s) => s.user);
   const client = getHiveClient();
   const [showComments, setShowComments] = useState(false);
-  const [voting, setVoting] = useState(false);
-  const [optimistic, setOptimistic] = useState(null); // { votes, voted }
 
-  // Live votes/comment counts from the chain (the checker only stores the text).
+  // Vote-dialog state (the reused CommentVoteTooltip owns the actual vote).
+  const [showVote, setShowVote] = useState(false);
+  const [weight, setWeight] = useState(100);
+  const [voteValue, setVoteValue] = useState('0.00');
+  const [accountData, setAccountData] = useState(null);
+
   const { data: meta, refetch } = useQuery({
     queryKey: ['snap-meta', snap.owner, snap.permlink],
     queryFn: async () => {
@@ -154,27 +212,9 @@ function SnapCard({ snap }) {
     staleTime: 60_000,
   });
 
-  const votes = optimistic?.votes ?? meta?.votes ?? 0;
-  const voted = optimistic?.voted ?? meta?.voted ?? false;
+  const votes = meta?.votes ?? 0;
+  const voted = meta?.voted ?? false;
   const comments = meta?.comments ?? 0;
-
-  const handleVote = async () => {
-    if (!user) { toast.error('Log in to vote'); return; }
-    if (voted || voting) return;
-    setVoting(true);
-    setOptimistic({ votes: votes + 1, voted: true });
-    try {
-      await voteWithAioha(snap.owner, snap.permlink, 10000);
-      toast.success('Upvoted!');
-      setTimeout(() => refetch(), 3000);
-    } catch (e) {
-      setOptimistic(null);
-      toast.error(e?.message || 'Vote failed');
-    } finally {
-      setVoting(false);
-    }
-  };
-
   const tags = (snap.tags || []).filter((t) => t && t !== 'nsfw' && t !== SNAP_TAG);
 
   return (
@@ -200,23 +240,34 @@ function SnapCard({ snap }) {
       )}
 
       <div className="snap-actions">
-        <button
-          type="button"
-          className={`snap-action${voted ? ' voted' : ''}`}
-          onClick={handleVote}
-          disabled={voting || voted}
-          title={voted ? 'Upvoted' : 'Upvote'}
-        >
-          {voted ? <BiSolidUpvote /> : <BiUpvote />}
-          {votes > 0 && <span>{votes}</span>}
-        </button>
+        <div className="snap-vote">
+          <UpvoteCount count={votes} voted={voted} onClick={() => setShowVote((v) => !v)} size={13} />
+          {showVote && (
+            <CommentVoteTooltip
+              author={snap.owner}
+              permlink={snap.permlink}
+              showTooltip={showVote}
+              setShowTooltip={setShowVote}
+              weight={weight}
+              setWeight={setWeight}
+              voteValue={voteValue}
+              setVoteValue={setVoteValue}
+              accountData={accountData}
+              setAccountData={setAccountData}
+              setActiveTooltipPermlink={() => {}}
+              onVoteSuccess={() => refetch()}
+              enableViewerTag={false}
+              postCreatedAt={snap.created}
+            />
+          )}
+        </div>
         <button
           type="button"
           className={`snap-action${showComments ? ' active' : ''}`}
           onClick={() => setShowComments((v) => !v)}
         >
           <BiCommentDetail />
-          <span>{comments > 0 ? comments : ''} {showComments ? 'Hide' : 'Comments'}</span>
+          <span>{comments}</span>
         </button>
       </div>
 

--- a/src/components/Userprofilepage/CommunitySnaps.jsx
+++ b/src/components/Userprofilepage/CommunitySnaps.jsx
@@ -18,6 +18,7 @@ import { commentWithAioha } from '../../hive-api/aioha';
 import { useAppStore } from '../../lib/store';
 import SnapComposer from './SnapComposer';
 import UpvoteCount from '../UpvoteCount/UpvoteCount';
+import AuthorBadge from '../AuthorBadge/AuthorBadge';
 import CommentVoteTooltip from '../tooltip/CommentVoteTooltip';
 import BarLoader from '../Loader/BarLoader';
 import './CommunitySnaps.scss';
@@ -31,9 +32,10 @@ async function fetchReplies(author, permlink) {
   return (replies || []).sort((a, b) => new Date(a.created) - new Date(b.created));
 }
 
-// Body with "read more"/"show less" — a very long snap is capped at ~10% of the
-// viewport, but only when it actually overflows (no fade on short posts).
-function SnapBody({ body }) {
+// Body with "read more"/"show less" — a very long snap is capped at a fraction of
+// the viewport (`maxVh`), but only when it actually overflows (no fade on short
+// posts). The feed uses a tighter cap than the profile tab.
+function SnapBody({ body, maxVh = 0.33 }) {
   const [html, setHtml] = useState('');
   const [expanded, setExpanded] = useState(false);
   const [overflowing, setOverflowing] = useState(false);
@@ -51,12 +53,12 @@ function SnapBody({ body }) {
     const measure = () => {
       const el = ref.current;
       // scrollHeight is the full content height regardless of the max-height clamp.
-      if (el) setOverflowing(el.scrollHeight > window.innerHeight * 0.33 + 8);
+      if (el) setOverflowing(el.scrollHeight > window.innerHeight * maxVh + 8);
     };
     measure();
     window.addEventListener('resize', measure);
     return () => window.removeEventListener('resize', measure);
-  }, [html]);
+  }, [html, maxVh]);
 
   const clamped = overflowing && !expanded;
   return (
@@ -64,6 +66,7 @@ function SnapBody({ body }) {
       <div
         ref={ref}
         className={`snap-body markdown-body${clamped ? ' clamped' : ''}`}
+        style={{ '--snap-clamp': `${maxVh * 100}vh` }}
         dangerouslySetInnerHTML={{ __html: html }}
       />
       {overflowing && (
@@ -301,29 +304,27 @@ export function SnapCard({ snap, feedMode = false, onRemove }) {
 
   return (
     <article className="snap-card">
-      <div className="snap-card-head">
-        {/* In the home feed the snap is from any creator, so title it; on a profile
-            Community tab it's always that profile, so we omit it. */}
+      <div className={`snap-card-head${feedMode ? ' snap-card-head--feed' : ''}`}>
+        {/* In the home feed the snap is from any creator — show the author badge so
+            the viewer can follow them right there; on a profile Community tab it's
+            always that profile, so we omit it. */}
         {feedMode && (
-          <span className="snap-feed-title">
-            Community snap by <Link to={`/p/${snap.owner}`} className="snap-author">@{snap.owner}</Link>
-          </span>
+          <AuthorBadge author={snap.owner} showFollow compact tabHint="community" />
         )}
-        <a
+        {feedMode && <span className="snap-feed-title">Community snap</span>}
+        <Link
           className="snap-time"
-          href={`https://peakd.com/@${snap.owner}/${snap.permlink}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          title="View on Hive"
+          to={feedMode ? `/p/${snap.owner}?tab=community` : `/post/${snap.owner}/${snap.permlink}`}
+          title={feedMode ? `View @${snap.owner}'s community` : 'View post'}
         >
           {hiveTime(snap.created)}
-        </a>
+        </Link>
         {feedMode && (
           <SnapOptionsMenu owner={snap.owner} permlink={snap.permlink} onHidden={() => onRemove?.(snap)} />
         )}
       </div>
 
-      <SnapBody body={snap.body} />
+      <SnapBody body={snap.body} maxVh={feedMode ? 0.15 : 0.33} />
 
       {tags.length > 0 && (
         <div className="snap-tags">

--- a/src/components/Userprofilepage/CommunitySnaps.jsx
+++ b/src/components/Userprofilepage/CommunitySnaps.jsx
@@ -44,7 +44,7 @@ function SnapCard({ snap }) {
       {tags.length > 0 && (
         <div className="snap-tags">
           {tags.map((t) => (
-            <Link key={t} to={`/t/${t}`} className="snap-tag">#{t}</Link>
+            <Link key={t} to={`/t/${t}`} className="snap-tag">{t}</Link>
           ))}
         </div>
       )}

--- a/src/components/Userprofilepage/CommunitySnaps.scss
+++ b/src/components/Userprofilepage/CommunitySnaps.scss
@@ -1,0 +1,234 @@
+.community-snaps {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 8px 0 40px;
+
+  // ── Composer ──────────────────────────────────────────────────────────────
+  .snap-composer {
+    background: var(--bg-secondary, #1a1a1a);
+    border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+    border-radius: 12px;
+    padding: 14px;
+    margin-bottom: 22px;
+
+    .snap-composer-row {
+      display: flex;
+      gap: 10px;
+      align-items: center;
+      margin-top: 10px;
+
+      .snap-tags-input {
+        flex: 1;
+        min-width: 0;
+        padding: 9px 12px;
+        border-radius: 8px;
+        border: 1px solid var(--border-color, rgba(255, 255, 255, 0.15));
+        background: var(--bg-primary, #0f0f0f);
+        color: var(--text-primary, #f1f1f1);
+        font-size: 14px;
+      }
+      .snap-options-toggle {
+        flex: none;
+        background: none;
+        border: none;
+        color: var(--accent-primary, #e53935);
+        font-size: 13px;
+        font-weight: 600;
+        cursor: pointer;
+        white-space: nowrap;
+      }
+    }
+
+    .snap-options {
+      margin-top: 12px;
+      padding-top: 12px;
+      border-top: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+
+      .snap-field {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+
+        .snap-field-label {
+          font-size: 13px;
+          font-weight: 600;
+          color: var(--text-secondary, #9aa0a6);
+        }
+        select {
+          padding: 9px 12px;
+          border-radius: 8px;
+          border: 1px solid var(--border-color, rgba(255, 255, 255, 0.15));
+          background: var(--bg-primary, #0f0f0f);
+          color: var(--text-primary, #f1f1f1);
+          font-size: 14px;
+        }
+      }
+
+      .snap-benefic-add {
+        display: flex;
+        gap: 8px;
+
+        input {
+          padding: 8px 10px;
+          border-radius: 8px;
+          border: 1px solid var(--border-color, rgba(255, 255, 255, 0.15));
+          background: var(--bg-primary, #0f0f0f);
+          color: var(--text-primary, #f1f1f1);
+          font-size: 14px;
+          &:first-child { flex: 1; min-width: 0; }
+          &[type='number'] { width: 72px; }
+        }
+        button {
+          display: inline-flex;
+          align-items: center;
+          gap: 5px;
+          padding: 8px 12px;
+          border: none;
+          border-radius: 8px;
+          background: var(--accent-primary, #e53935);
+          color: #fff;
+          font-size: 13px;
+          font-weight: 600;
+          cursor: pointer;
+          white-space: nowrap;
+        }
+      }
+      .snap-benefic-list {
+        list-style: none;
+        margin: 8px 0 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+
+        li {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          font-size: 13px;
+          color: var(--text-primary, #f1f1f1);
+          background: var(--bg-primary, #0f0f0f);
+          border-radius: 6px;
+          padding: 6px 10px;
+
+          button {
+            background: none;
+            border: none;
+            color: var(--text-secondary, #9aa0a6);
+            cursor: pointer;
+            display: inline-flex;
+          }
+        }
+      }
+
+      .snap-toggle {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        font-size: 14px;
+        color: var(--text-primary, #f1f1f1);
+        cursor: pointer;
+        input { width: 16px; height: 16px; accent-color: var(--accent-primary, #e53935); }
+      }
+    }
+
+    .snap-composer-actions {
+      display: flex;
+      justify-content: flex-end;
+      margin-top: 12px;
+
+      .snap-post-btn {
+        padding: 10px 22px;
+        border: none;
+        border-radius: 999px;
+        background: var(--accent-primary, #e53935);
+        color: #fff;
+        font-size: 14px;
+        font-weight: 700;
+        cursor: pointer;
+        transition: opacity 0.15s ease;
+        &:disabled { opacity: 0.5; cursor: not-allowed; }
+      }
+    }
+  }
+
+  // ── List + cards ──────────────────────────────────────────────────────────
+  .snap-empty {
+    text-align: center;
+    color: var(--text-secondary, #9aa0a6);
+    padding: 40px 16px;
+    font-size: 15px;
+  }
+
+  .snap-list {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .snap-card {
+    background: var(--bg-secondary, #1a1a1a);
+    border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+    border-radius: 12px;
+    padding: 14px 16px;
+
+    .snap-card-head {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 10px;
+      margin-bottom: 8px;
+
+      .snap-author {
+        font-weight: 700;
+        font-size: 14px;
+        color: var(--text-primary, #f1f1f1);
+        text-decoration: none;
+        &:hover { color: var(--accent-primary, #e53935); }
+      }
+      .snap-time {
+        font-size: 12px;
+        color: var(--text-secondary, #9aa0a6);
+        text-decoration: none;
+        white-space: nowrap;
+        &:hover { text-decoration: underline; }
+      }
+    }
+
+    .snap-body {
+      font-size: 15px;
+      line-height: 1.55;
+      color: var(--text-primary, #f1f1f1);
+      word-break: break-word;
+      overflow-wrap: anywhere;
+
+      p { margin: 0 0 10px; &:last-child { margin-bottom: 0; } }
+      a { color: var(--accent-primary, #e53935); }
+      img { max-width: 100%; height: auto; border-radius: 8px; }
+      pre { overflow-x: auto; background: var(--bg-primary, #0f0f0f); padding: 10px; border-radius: 8px; }
+      blockquote {
+        margin: 8px 0;
+        padding-left: 12px;
+        border-left: 3px solid var(--border-color, rgba(255, 255, 255, 0.2));
+        color: var(--text-secondary, #9aa0a6);
+      }
+    }
+
+    .snap-tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 12px;
+
+      .snap-tag {
+        font-size: 12px;
+        color: var(--accent-primary, #e53935);
+        text-decoration: none;
+        &:hover { text-decoration: underline; }
+      }
+    }
+  }
+}

--- a/src/components/Userprofilepage/CommunitySnaps.scss
+++ b/src/components/Userprofilepage/CommunitySnaps.scss
@@ -5,6 +5,34 @@
 
   &--feed { padding: 0; }
 
+  // Feed mode: pack several creators' snaps into ONE full-width row when there's
+  // room, mirroring the video grid's columns so the widths line up. Falls back to
+  // a single column on phones (one snap per line).
+  &--row {
+    max-width: none;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center; // a partial row (fewer snaps than columns) sits centered
+    align-items: flex-start; // each snap keeps its own height; no stretch-to-tallest
+    gap: 16px;
+
+    // Cap each snap at one video-column width and DON'T grow, so e.g. two snaps in
+    // a four-wide feed keep their natural width and center as a group instead of
+    // each stretching to half the row.
+    .snap-card {
+      margin: 0;
+      min-width: 0; // allow shrinking instead of overflowing
+      flex: 0 1 var(--card-min-w, 460px);
+      max-width: 100%;
+    }
+
+    @media screen and (max-width: 767px) {
+      gap: 10px;
+      .snap-card { flex-basis: 100%; } // one full-width snap per line on phones
+    }
+  }
+
   // ── Composer ──────────────────────────────────────────────────────────────
   .snap-composer {
     background: var(--bg-secondary, #1a1a1a);
@@ -227,7 +255,14 @@
       gap: 10px;
       margin-bottom: 8px;
 
-      // Feed-only header: "Community snap by @author".
+      // Feed header carries the author badge (+ follow) + label + time + menu, which
+      // is a lot on a narrow card — let it wrap instead of overflowing.
+      &--feed {
+        flex-wrap: wrap;
+        row-gap: 6px;
+      }
+
+      // Small muted "Community snap" caption next to the author badge in the feed.
       .snap-feed-title {
         font-size: 13px;
         font-weight: 600;
@@ -275,7 +310,7 @@
       // Clamp ONLY when the post actually overflows (JS adds `.clamped`) — a short
       // post keeps its natural height with no fade.
       &.clamped {
-        max-height: 33vh;
+        max-height: var(--snap-clamp, 33vh); // feed = 20vh, profile tab = 33vh (set inline)
         overflow: hidden;
         &::after {
           content: '';

--- a/src/components/Userprofilepage/CommunitySnaps.scss
+++ b/src/components/Userprofilepage/CommunitySnaps.scss
@@ -251,19 +251,21 @@
       word-break: break-word;
       overflow-wrap: anywhere;
 
-      // A very long post is capped at ~10% of the viewport until "Read more".
-      max-height: 10vh;
-      overflow: hidden;
-      &.expanded { max-height: none; overflow: visible; }
-      &:not(.expanded)::after {
-        content: '';
-        position: absolute;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        height: 40px;
-        background: linear-gradient(to bottom, transparent, var(--bg-secondary, #1a1a1a));
-        pointer-events: none;
+      // Clamp ONLY when the post actually overflows (JS adds `.clamped`) — a short
+      // post keeps its natural height with no fade.
+      &.clamped {
+        max-height: 10vh;
+        overflow: hidden;
+        &::after {
+          content: '';
+          position: absolute;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          height: 40px;
+          background: linear-gradient(to bottom, transparent, var(--bg-secondary, #1a1a1a));
+          pointer-events: none;
+        }
       }
 
       p { margin: 0 0 10px; &:last-child { margin-bottom: 0; } }
@@ -297,9 +299,13 @@
 
       .snap-tag {
         font-size: 12px;
-        color: var(--accent-primary, #e53935);
+        padding: 3px 10px;
+        border-radius: 999px;
+        background: var(--bg-primary, #0f0f0f);
+        border: 1px solid var(--border-color, rgba(255, 255, 255, 0.12));
+        color: var(--text-secondary, #9aa0a6);
         text-decoration: none;
-        &:hover { text-decoration: underline; }
+        &:hover { color: var(--accent-primary, #e53935); border-color: var(--accent-primary, #e53935); }
       }
     }
 
@@ -308,6 +314,8 @@
       align-items: center;
       gap: 8px;
       margin-top: 12px;
+
+      .snap-vote { position: relative; display: inline-flex; }
 
       .snap-action {
         display: inline-flex;
@@ -407,6 +415,32 @@
           p { margin: 0 0 6px; &:last-child { margin-bottom: 0; } }
           a { color: var(--accent-primary, #e53935); }
           img { max-width: 100%; height: auto; border-radius: 6px; }
+        }
+
+        .snap-comment-actions {
+          display: flex;
+          gap: 14px;
+          margin-top: 4px;
+
+          button {
+            background: none;
+            border: none;
+            padding: 0;
+            font-size: 12px;
+            font-weight: 600;
+            color: var(--text-secondary, #9aa0a6);
+            cursor: pointer;
+            &:hover { color: var(--accent-primary, #e53935); }
+          }
+        }
+
+        // Nested replies — indent + a guide line down the thread.
+        .snap-comment-list.nested {
+          margin-top: 10px;
+          margin-left: 12px;
+          padding-left: 12px;
+          border-left: 2px solid var(--border-color, rgba(255, 255, 255, 0.1));
+          gap: 10px;
         }
       }
     }

--- a/src/components/Userprofilepage/CommunitySnaps.scss
+++ b/src/components/Userprofilepage/CommunitySnaps.scss
@@ -227,6 +227,13 @@
       gap: 10px;
       margin-bottom: 8px;
 
+      // Feed-only header: "Community snap by @author".
+      .snap-feed-title {
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--text-secondary, #9aa0a6);
+        .snap-author { font-size: inherit; }
+      }
       .snap-author {
         font-weight: 700;
         font-size: 14px;

--- a/src/components/Userprofilepage/CommunitySnaps.scss
+++ b/src/components/Userprofilepage/CommunitySnaps.scss
@@ -39,6 +39,50 @@
       }
     }
 
+    // Tag chips shown UNDER the tag input (built-in `community` pinned first).
+    .snap-tag-chips {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 6px;
+      margin-top: 8px;
+
+      .snap-tag-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        font-size: 12px;
+        padding: 4px 8px;
+        border-radius: 999px;
+        background: var(--bg-primary, #0f0f0f);
+        border: 1px solid var(--border-color, rgba(255, 255, 255, 0.15));
+        color: var(--text-primary, #f1f1f1);
+
+        button {
+          display: inline-flex;
+          background: none;
+          border: none;
+          padding: 0;
+          color: var(--text-secondary, #9aa0a6);
+          cursor: pointer;
+          &:hover { color: var(--accent-primary, #e53935); }
+        }
+
+        &.built-in {
+          background: var(--accent-light, rgba(229, 57, 53, 0.12));
+          border-color: transparent;
+          color: var(--accent-primary, #e53935);
+          font-weight: 600;
+        }
+      }
+
+      .snap-tag-count {
+        font-size: 11px;
+        color: var(--text-secondary, #9aa0a6);
+        margin-left: auto;
+      }
+    }
+
     .snap-options {
       margin-top: 12px;
       padding-top: 12px;

--- a/src/components/Userprofilepage/CommunitySnaps.scss
+++ b/src/components/Userprofilepage/CommunitySnaps.scss
@@ -3,6 +3,8 @@
   margin: 0 auto;
   padding: 8px 0 40px;
 
+  &--feed { padding: 0; }
+
   // ── Composer ──────────────────────────────────────────────────────────────
   .snap-composer {
     background: var(--bg-secondary, #1a1a1a);
@@ -221,8 +223,7 @@
 
     .snap-card-head {
       display: flex;
-      align-items: baseline;
-      justify-content: space-between;
+      align-items: center;
       gap: 10px;
       margin-bottom: 8px;
 
@@ -238,7 +239,20 @@
         color: var(--text-secondary, #9aa0a6);
         text-decoration: none;
         white-space: nowrap;
+        margin-right: auto; // push the ⋮ menu to the far right
         &:hover { text-decoration: underline; }
+      }
+      .snap-menu-btn {
+        flex: none;
+        background: none;
+        border: none;
+        padding: 4px;
+        border-radius: 6px;
+        color: var(--text-secondary, #9aa0a6);
+        cursor: pointer;
+        display: inline-flex;
+        &:hover { color: var(--text-primary, #f1f1f1); background: var(--bg-primary, #0f0f0f); }
+        svg { font-size: 18px; }
       }
     }
 
@@ -444,5 +458,37 @@
         }
       }
     }
+  }
+}
+
+// Portaled to <body> (from SnapOptionsMenu) → must be top-level, not nested.
+.snap-menu-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 9998;
+}
+.snap-menu {
+  position: fixed;
+  z-index: 9999;
+  min-width: 200px;
+  padding: 4px;
+  background: var(--bg-secondary, #1a1a1a);
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.15));
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+
+  button {
+    display: block;
+    width: 100%;
+    text-align: left;
+    background: none;
+    border: none;
+    padding: 10px 12px;
+    border-radius: 6px;
+    color: var(--text-primary, #f1f1f1);
+    font-size: 14px;
+    cursor: pointer;
+    &:hover { background: var(--bg-primary, #0f0f0f); }
   }
 }

--- a/src/components/Userprofilepage/CommunitySnaps.scss
+++ b/src/components/Userprofilepage/CommunitySnaps.scss
@@ -242,12 +242,29 @@
       }
     }
 
+    .snap-body-wrap { position: relative; }
     .snap-body {
+      position: relative;
       font-size: 15px;
       line-height: 1.55;
       color: var(--text-primary, #f1f1f1);
       word-break: break-word;
       overflow-wrap: anywhere;
+
+      // A very long post is capped at ~10% of the viewport until "Read more".
+      max-height: 10vh;
+      overflow: hidden;
+      &.expanded { max-height: none; overflow: visible; }
+      &:not(.expanded)::after {
+        content: '';
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        height: 40px;
+        background: linear-gradient(to bottom, transparent, var(--bg-secondary, #1a1a1a));
+        pointer-events: none;
+      }
 
       p { margin: 0 0 10px; &:last-child { margin-bottom: 0; } }
       a { color: var(--accent-primary, #e53935); }
@@ -259,6 +276,17 @@
         border-left: 3px solid var(--border-color, rgba(255, 255, 255, 0.2));
         color: var(--text-secondary, #9aa0a6);
       }
+    }
+    .snap-readmore {
+      display: inline-block;
+      margin-top: 6px;
+      background: none;
+      border: none;
+      padding: 0;
+      color: var(--accent-primary, #e53935);
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
     }
 
     .snap-tags {
@@ -272,6 +300,114 @@
         color: var(--accent-primary, #e53935);
         text-decoration: none;
         &:hover { text-decoration: underline; }
+      }
+    }
+
+    .snap-actions {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-top: 12px;
+
+      .snap-action {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        padding: 6px 12px;
+        border-radius: 999px;
+        border: 1px solid var(--border-color, rgba(255, 255, 255, 0.12));
+        background: transparent;
+        color: var(--text-secondary, #9aa0a6);
+        font-size: 13px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: color 0.15s ease, border-color 0.15s ease;
+
+        svg { font-size: 16px; }
+        &:hover:not(:disabled) { color: var(--text-primary, #f1f1f1); border-color: var(--border-color, rgba(255, 255, 255, 0.28)); }
+        &.voted { color: var(--accent-primary, #e53935); border-color: var(--accent-primary, #e53935); }
+        &.active { color: var(--text-primary, #f1f1f1); }
+      }
+    }
+
+    .snap-comments {
+      margin-top: 14px;
+      padding-top: 12px;
+      border-top: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+
+      .snap-reply-box {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 12px;
+
+        textarea {
+          flex: 1;
+          min-width: 0;
+          resize: vertical;
+          padding: 8px 10px;
+          border-radius: 8px;
+          border: 1px solid var(--border-color, rgba(255, 255, 255, 0.15));
+          background: var(--bg-primary, #0f0f0f);
+          color: var(--text-primary, #f1f1f1);
+          font-size: 14px;
+          font-family: inherit;
+        }
+        button {
+          flex: none;
+          align-self: flex-end;
+          padding: 8px 16px;
+          border: none;
+          border-radius: 999px;
+          background: var(--accent-primary, #e53935);
+          color: #fff;
+          font-size: 13px;
+          font-weight: 600;
+          cursor: pointer;
+          &:disabled { opacity: 0.5; cursor: not-allowed; }
+        }
+      }
+
+      .snap-comments-status {
+        font-size: 13px;
+        color: var(--text-secondary, #9aa0a6);
+        padding: 4px 0;
+      }
+
+      .snap-comment-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      .snap-comment {
+        .snap-comment-head {
+          display: flex;
+          align-items: baseline;
+          gap: 8px;
+          margin-bottom: 3px;
+
+          .snap-comment-author {
+            font-weight: 700;
+            font-size: 13px;
+            color: var(--text-primary, #f1f1f1);
+            text-decoration: none;
+            &:hover { color: var(--accent-primary, #e53935); }
+          }
+          .snap-comment-time { font-size: 11px; color: var(--text-secondary, #9aa0a6); }
+        }
+        .snap-comment-body {
+          font-size: 14px;
+          line-height: 1.5;
+          color: var(--text-primary, #f1f1f1);
+          word-break: break-word;
+          overflow-wrap: anywhere;
+
+          p { margin: 0 0 6px; &:last-child { margin-bottom: 0; } }
+          a { color: var(--accent-primary, #e53935); }
+          img { max-width: 100%; height: auto; border-radius: 6px; }
+        }
       }
     }
   }

--- a/src/components/Userprofilepage/CommunitySnaps.scss
+++ b/src/components/Userprofilepage/CommunitySnaps.scss
@@ -254,7 +254,7 @@
       // Clamp ONLY when the post actually overflows (JS adds `.clamped`) — a short
       // post keeps its natural height with no fade.
       &.clamped {
-        max-height: 10vh;
+        max-height: 33vh;
         overflow: hidden;
         &::after {
           content: '';

--- a/src/components/Userprofilepage/SnapComposer.jsx
+++ b/src/components/Userprofilepage/SnapComposer.jsx
@@ -1,0 +1,149 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { MdPeopleAlt, MdClose } from 'react-icons/md';
+import MarkdownComposer from '../studio/MarkdownComposer';
+import { useAppStore } from '../../lib/store';
+import { publishSnap } from '../../lib/snaps';
+
+/**
+ * Owner-only composer for a written "snap" — same fields as the shorts description
+ * tab (body via MarkdownComposer, tags, rewards distribution, beneficiaries, NSFW),
+ * minus the video-only "Allow Remix/Clip". Publishes under @peak.snaps and calls
+ * onPosted(snap) with an optimistic snap object so the list can show it immediately.
+ */
+export default function SnapComposer({ onPosted }) {
+  const user = useAppStore((s) => s.user);
+
+  const [body, setBody] = useState('');
+  const [tagsInput, setTagsInput] = useState('');
+  const [rewards, setRewards] = useState('default');
+  const [nsfw, setNsfw] = useState(false);
+  const [beneficiaries, setBeneficiaries] = useState([]); // { account, weight } (weight: 10000 = 100%)
+  const [benAccount, setBenAccount] = useState('');
+  const [benPercent, setBenPercent] = useState('');
+  const [showOptions, setShowOptions] = useState(false);
+  const [posting, setPosting] = useState(false);
+
+  const totalBenWeight = beneficiaries.reduce((s, b) => s + Number(b.weight || 0), 0);
+
+  const addBeneficiary = () => {
+    const account = benAccount.toLowerCase().replace(/^@/, '').trim();
+    const pct = Math.round(Number(benPercent) * 100); // percent → weight
+    if (!account) { toast.error('Enter an account'); return; }
+    if (!pct || pct <= 0) { toast.error('Enter a percent above 0'); return; }
+    if (beneficiaries.some((b) => b.account === account)) { toast.error('Already added'); return; }
+    if (totalBenWeight + pct > 10000) { toast.error('Beneficiaries can’t exceed 100%'); return; }
+    setBeneficiaries([...beneficiaries, { account, weight: pct }]);
+    setBenAccount('');
+    setBenPercent('');
+  };
+  const removeBeneficiary = (account) => setBeneficiaries(beneficiaries.filter((b) => b.account !== account));
+
+  const handlePost = async () => {
+    if (!user) { toast.error('Please log in'); return; }
+    const text = body.trim();
+    if (!text) { toast.error('Write something first'); return; }
+
+    const tags = tagsInput.split(/[\s,]+/).map((t) => t.replace(/^#/, '')).filter(Boolean);
+    setPosting(true);
+    try {
+      const res = await publishSnap({ user, body: text, tags, rewards, beneficiaries, nsfw });
+      toast.success('Snap posted!');
+      const snap = res.indexed || {
+        _id: `${user}/${res.permlink}`,
+        owner: user,
+        permlink: res.permlink,
+        title: '',
+        body: text,
+        tags,
+        nsfw,
+        created: new Date().toISOString(),
+      };
+      // reset
+      setBody(''); setTagsInput(''); setRewards('default'); setNsfw(false);
+      setBeneficiaries([]); setShowOptions(false);
+      onPosted?.(snap);
+    } catch (e) {
+      toast.error(e?.message || 'Could not post the snap');
+    } finally {
+      setPosting(false);
+    }
+  };
+
+  if (!user) return null;
+
+  return (
+    <div className="snap-composer">
+      <MarkdownComposer
+        value={body}
+        onChange={setBody}
+        placeholder="Share an update with your followers…"
+      />
+
+      <div className="snap-composer-row">
+        <input
+          className="snap-tags-input"
+          placeholder="tags (space separated)"
+          value={tagsInput}
+          onChange={(e) => setTagsInput(e.target.value)}
+        />
+        <button type="button" className="snap-options-toggle" onClick={() => setShowOptions((v) => !v)}>
+          {showOptions ? 'Hide options' : 'More options'}
+        </button>
+      </div>
+
+      {showOptions && (
+        <div className="snap-options">
+          <label className="snap-field">
+            <span className="snap-field-label">Rewards Distribution</span>
+            <select value={rewards} onChange={(e) => setRewards(e.target.value)}>
+              <option value="default">Default 50% / 50%</option>
+              <option value="powerup">Power up 100%</option>
+              <option value="decline">Decline payout</option>
+            </select>
+          </label>
+
+          <div className="snap-field">
+            <span className="snap-field-label">Beneficiaries</span>
+            <div className="snap-benefic-add">
+              <input
+                placeholder="account"
+                value={benAccount}
+                onChange={(e) => setBenAccount(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addBeneficiary(); } }}
+              />
+              <input
+                type="number" min="1" max="100" placeholder="%"
+                value={benPercent}
+                onChange={(e) => setBenPercent(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addBeneficiary(); } }}
+              />
+              <button type="button" onClick={addBeneficiary}><MdPeopleAlt /> Add</button>
+            </div>
+            {beneficiaries.length > 0 && (
+              <ul className="snap-benefic-list">
+                {beneficiaries.map((b) => (
+                  <li key={b.account}>
+                    <span>@{b.account} — {Math.round(b.weight / 100)}%</span>
+                    <button type="button" onClick={() => removeBeneficiary(b.account)} aria-label="Remove"><MdClose /></button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <label className="snap-toggle">
+            <input type="checkbox" checked={nsfw} onChange={(e) => setNsfw(e.target.checked)} />
+            <span>Mark as adult / NSFW</span>
+          </label>
+        </div>
+      )}
+
+      <div className="snap-composer-actions">
+        <button type="button" className="snap-post-btn" disabled={posting || !body.trim()} onClick={handlePost}>
+          {posting ? 'Posting…' : 'Post snap'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Userprofilepage/SnapComposer.jsx
+++ b/src/components/Userprofilepage/SnapComposer.jsx
@@ -112,10 +112,10 @@ export default function SnapComposer({ onPosted }) {
       </div>
 
       <div className="snap-tag-chips">
-        <span className="snap-tag-chip built-in" title="Added to every community post">#{SNAP_TAG}</span>
+        <span className="snap-tag-chip built-in" title="Added to every community post">{SNAP_TAG}</span>
         {tags.map((t) => (
           <span key={t} className="snap-tag-chip">
-            #{t}
+            {t}
             <button type="button" onClick={() => removeTag(t)} aria-label={`Remove ${t}`}><MdClose /></button>
           </span>
         ))}

--- a/src/components/Userprofilepage/SnapComposer.jsx
+++ b/src/components/Userprofilepage/SnapComposer.jsx
@@ -3,7 +3,7 @@ import { toast } from 'sonner';
 import { MdPeopleAlt, MdClose } from 'react-icons/md';
 import MarkdownComposer from '../studio/MarkdownComposer';
 import { useAppStore } from '../../lib/store';
-import { publishSnap } from '../../lib/snaps';
+import { publishSnap, SNAP_TAG, MAX_USER_TAGS } from '../../lib/snaps';
 
 /**
  * Owner-only composer for a written "snap" — same fields as the shorts description
@@ -15,7 +15,8 @@ export default function SnapComposer({ onPosted }) {
   const user = useAppStore((s) => s.user);
 
   const [body, setBody] = useState('');
-  const [tagsInput, setTagsInput] = useState('');
+  const [tags, setTags] = useState([]);        // user tags (the built-in `community` is added on top)
+  const [tagInput, setTagInput] = useState('');
   const [rewards, setRewards] = useState('default');
   const [nsfw, setNsfw] = useState(false);
   const [beneficiaries, setBeneficiaries] = useState([]); // { account, weight } (weight: 10000 = 100%)
@@ -39,15 +40,31 @@ export default function SnapComposer({ onPosted }) {
   };
   const removeBeneficiary = (account) => setBeneficiaries(beneficiaries.filter((b) => b.account !== account));
 
+  const addTag = (raw) => {
+    const t = String(raw || '').toLowerCase().replace(/^#/, '').replace(/[^a-z0-9-]/g, '');
+    if (!t) { setTagInput(''); return; }
+    if (t === SNAP_TAG || tags.includes(t)) { setTagInput(''); return; } // built-in / duplicate
+    if (tags.length >= MAX_USER_TAGS) { toast.error(`Up to ${MAX_USER_TAGS} tags`); return; }
+    setTags([...tags, t]);
+    setTagInput('');
+  };
+  const removeTag = (t) => setTags(tags.filter((x) => x !== t));
+  const onTagKeyDown = (e) => {
+    if (e.key === 'Enter' || e.key === ' ' || e.key === ',') { e.preventDefault(); addTag(tagInput); }
+    else if (e.key === 'Backspace' && !tagInput && tags.length) { removeTag(tags[tags.length - 1]); }
+  };
+
   const handlePost = async () => {
     if (!user) { toast.error('Please log in'); return; }
     const text = body.trim();
     if (!text) { toast.error('Write something first'); return; }
 
-    const tags = tagsInput.split(/[\s,]+/).map((t) => t.replace(/^#/, '')).filter(Boolean);
+    // Include a tag still being typed, dedupe, and cap.
+    const pending = tagInput.trim().toLowerCase().replace(/^#/, '').replace(/[^a-z0-9-]/g, '');
+    const userTags = [...new Set([...tags, ...(pending && pending !== SNAP_TAG ? [pending] : [])])].slice(0, MAX_USER_TAGS);
     setPosting(true);
     try {
-      const res = await publishSnap({ user, body: text, tags, rewards, beneficiaries, nsfw });
+      const res = await publishSnap({ user, body: text, tags: userTags, rewards, beneficiaries, nsfw });
       toast.success('Snap posted!');
       const snap = res.indexed || {
         _id: `${user}/${res.permlink}`,
@@ -55,12 +72,12 @@ export default function SnapComposer({ onPosted }) {
         permlink: res.permlink,
         title: '',
         body: text,
-        tags,
+        tags: [SNAP_TAG, ...userTags, ...(nsfw ? ['nsfw'] : [])],
         nsfw,
         created: new Date().toISOString(),
       };
       // reset
-      setBody(''); setTagsInput(''); setRewards('default'); setNsfw(false);
+      setBody(''); setTags([]); setTagInput(''); setRewards('default'); setNsfw(false);
       setBeneficiaries([]); setShowOptions(false);
       onPosted?.(snap);
     } catch (e) {
@@ -83,13 +100,26 @@ export default function SnapComposer({ onPosted }) {
       <div className="snap-composer-row">
         <input
           className="snap-tags-input"
-          placeholder="tags (space separated)"
-          value={tagsInput}
-          onChange={(e) => setTagsInput(e.target.value)}
+          placeholder={tags.length >= MAX_USER_TAGS ? 'Tag limit reached' : 'Add a tag, then space or enter…'}
+          value={tagInput}
+          onChange={(e) => setTagInput(e.target.value)}
+          onKeyDown={onTagKeyDown}
+          disabled={tags.length >= MAX_USER_TAGS}
         />
         <button type="button" className="snap-options-toggle" onClick={() => setShowOptions((v) => !v)}>
           {showOptions ? 'Hide options' : 'More options'}
         </button>
+      </div>
+
+      <div className="snap-tag-chips">
+        <span className="snap-tag-chip built-in" title="Added to every community post">#{SNAP_TAG}</span>
+        {tags.map((t) => (
+          <span key={t} className="snap-tag-chip">
+            #{t}
+            <button type="button" onClick={() => removeTag(t)} aria-label={`Remove ${t}`}><MdClose /></button>
+          </span>
+        ))}
+        <span className="snap-tag-count">{tags.length}/{MAX_USER_TAGS}</span>
       </div>
 
       {showOptions && (

--- a/src/components/Userprofilepage/UserProfilePage.jsx
+++ b/src/components/Userprofilepage/UserProfilePage.jsx
@@ -36,6 +36,7 @@ import { fetchUserShortsWithDetails } from '../../hive-api/hiveApi';
 import ShortsIcon from '../icons/ShortsIcon';
 import TipModal from '../tip-reward/TipModal';
 import UserAudioList from './UserAudioList';
+import CommunitySnaps from './CommunitySnaps';
 import SocialLinks from './SocialLinks';
 import LeaderboardBadges from '../LeaderboardBadges/LeaderboardBadges';
 import ProfileHeader from '../ProfileHeader/ProfileHeader';
@@ -57,6 +58,7 @@ function UserProfilePage() {
       if (tab === 'playlists') return 'playlists';
       if (tab === 'shorts') return 'shorts';
       if (tab === 'audio') return 'audio';
+      if (tab === 'community') return 'community';
       if (tab === 'stats') return 'stats';
       return 'video';
     });
@@ -67,6 +69,7 @@ function UserProfilePage() {
       if (tab === 'playlists') setShow('playlists');
       else if (tab === 'shorts') setShow('shorts');
       else if (tab === 'audio') setShow('audio');
+      else if (tab === 'community') setShow('community');
       else if (tab === 'stats') setShow('stats');
       else if (!tab) setShow('video');
     }, [searchParams]);
@@ -494,6 +497,7 @@ const {
           <span className={show === "video" ? "active" : ""} onClick={() => selectTab("video")}>Videos</span>
           <span className={show === "shorts" ? "active" : ""} onClick={() => selectTab("shorts")}>Shorts</span>
           <span className={show === "audio" ? "active" : ""} onClick={() => selectTab("audio")}>Audio</span>
+          <span className={show === "community" ? "active" : ""} onClick={() => selectTab("community")}>Community</span>
           <span className={show === "playlists" ? "active" : ""} onClick={() => selectTab("playlists")}>
             Playlists {playlists.length > 0 && `(${playlists.length})`}
           </span>
@@ -528,6 +532,8 @@ const {
     )
   ) : show === "audio" ? (
     <UserAudioList user={user} />
+  ) : show === "community" ? (
+    <CommunitySnaps user={user} canPost={false} />
   ) : show === "stats" ? (
     canSeeStats ? <CreatorStats user={user} /> : null
   ) : show === "playlists" ? (

--- a/src/components/Userprofilepage/UserProfilePage.jsx
+++ b/src/components/Userprofilepage/UserProfilePage.jsx
@@ -502,7 +502,7 @@ const {
             Playlists {playlists.length > 0 && `(${playlists.length})`}
           </span>
           {canSeeStats && (
-            <span className={show === "stats" ? "active" : ""} onClick={() => selectTab("stats")}>Stats</span>
+            <span className={show === "stats" ? "active" : ""} onClick={() => selectTab("stats")}>Analytics</span>
           )}
         </div>
         <span className="followers" onClick={()=>{handleWalletNavigate(user)}}>wallet</span>

--- a/src/components/Userprofilepage/UserProfilePage.jsx
+++ b/src/components/Userprofilepage/UserProfilePage.jsx
@@ -37,6 +37,7 @@ import ShortsIcon from '../icons/ShortsIcon';
 import TipModal from '../tip-reward/TipModal';
 import UserAudioList from './UserAudioList';
 import CommunitySnaps from './CommunitySnaps';
+import { fetchSnaps } from '../../lib/snaps';
 import SocialLinks from './SocialLinks';
 import LeaderboardBadges from '../LeaderboardBadges/LeaderboardBadges';
 import ProfileHeader from '../ProfileHeader/ProfileHeader';
@@ -108,6 +109,15 @@ function UserProfilePage() {
     const isCreatorHidden = !!hiddenData?.creators?.some(
       (c) => String(c.creator).toLowerCase() === String(user).toLowerCase()
     );
+
+    // Community-post count for the tab header (like Playlists shows its count).
+    const { data: snapCountData } = useQuery({
+      queryKey: ['community-snaps-count', user],
+      queryFn: () => fetchSnaps(user, 1, 1),
+      enabled: !!user && user !== 'unknown',
+      staleTime: 60 * 1000,
+    });
+    const snapCount = snapCountData?.total || 0;
 
     const handleHideToggle = useCallback(async () => {
       if (!authenticatedUser || !user || isOwnProfile) return;
@@ -497,7 +507,9 @@ const {
           <span className={show === "video" ? "active" : ""} onClick={() => selectTab("video")}>Videos</span>
           <span className={show === "shorts" ? "active" : ""} onClick={() => selectTab("shorts")}>Shorts</span>
           <span className={show === "audio" ? "active" : ""} onClick={() => selectTab("audio")}>Audio</span>
-          <span className={show === "community" ? "active" : ""} onClick={() => selectTab("community")}>Community</span>
+          <span className={show === "community" ? "active" : ""} onClick={() => selectTab("community")}>
+            Community {snapCount > 0 && `(${snapCount})`}
+          </span>
           <span className={show === "playlists" ? "active" : ""} onClick={() => selectTab("playlists")}>
             Playlists {playlists.length > 0 && `(${playlists.length})`}
           </span>

--- a/src/components/playVideo/PlayVideo.jsx
+++ b/src/components/playVideo/PlayVideo.jsx
@@ -1219,11 +1219,11 @@ const PlayVideo = ({ videoDetails, author, permlink, mediaUnavailable = false, m
                     type="button"
                     className={`pv-btn stats-btn${videoStatsOpen ? ' active' : ''}`}
                     onClick={() => setVideoStatsOpen((o) => !o)}
-                    title="Video stats"
+                    title="Video analytics"
                     aria-expanded={videoStatsOpen}
                   >
                     <MdBarChart size={16} />
-                    <span>Stats</span>
+                    <span>Analytics</span>
                   </button>
                 )}
                 <button
@@ -1521,7 +1521,7 @@ const PlayVideo = ({ videoDetails, author, permlink, mediaUnavailable = false, m
             <div className="fab-actions">
               {canSeeVideoStats && (
                 <div className="fab-action">
-                  <span className="fab-action-label">Stats</span>
+                  <span className="fab-action-label">Analytics</span>
                   <button
                     className={`fab-action-btn${videoStatsOpen ? ' fab-action-btn--active' : ''}`}
                     onClick={() => {

--- a/src/components/playVideo/PlayVideo.jsx
+++ b/src/components/playVideo/PlayVideo.jsx
@@ -33,6 +33,7 @@ import CommentVoteTooltip from "../tooltip/CommentVoteTooltip";
 import axios from "axios";
 import mantequillaLogo from "../../assets/mantequilla-logo.png";
 import threespeakLogo from "../../assets/image/3S_logo.svg";
+import threespeakLogoDark from "../../assets/image/3S_logodark.png";
 import { FEED_URL, HIVE_API_URL, CHECKER_URL, FEATURE_EDITOR } from '../../utils/config';
 import { getViewerTags, getMyViewerTag } from '../../utils/viewerTag';
 import { displayTag, INTEREST_IDS, saveInterestsToHive } from '../../utils/interests';
@@ -72,6 +73,8 @@ const PlayVideo = ({ videoDetails, author, permlink, mediaUnavailable = false, m
   const { user, authenticated } = useAppStore();
   const interests = useAppStore((s) => s.interests);
   const setInterests = useAppStore((s) => s.setInterests);
+  const theme = useAppStore((s) => s.theme);
+  const isDarkTheme = theme !== 'light'; // dark is the default (matches EmergencyScreen)
 
   // Add a topic to the user's interests (from the topic popup), persisting to Hive.
   const addToInterests = useCallback(async (tag) => {
@@ -798,17 +801,19 @@ const PlayVideo = ({ videoDetails, author, permlink, mediaUnavailable = false, m
                 }}
                 playsInline
               />
-              {/* Branded preload spinner — half-transparent over the poster while the
-                  player fetches the manifest and buffers the first frame (SDK `loading`
-                  state). Clears the moment the first frame is ready; never blocks the
-                  play button (pointer-events: none). Suppressed once a video is known
-                  unavailable, so the two overlays don't stack. */}
+              {/* Branded preload cover — the SAME splash as the site's initial load
+                  (EmergencyScreen "checking": 3Speak logo + TailChase). Opaque, so it
+                  HIDES the black player until the first frame is ready (driven by the
+                  onReady gate in Watch.jsx). Cleared the moment playback is ready, and
+                  suppressed once a video is known unavailable so the overlays don't stack. */}
               {mediaLoading && !mediaUnavailable && (
                 <div className="video-preload-overlay" aria-hidden="true">
-                  <div className="video-preload-badge">
-                    <span className="video-preload-ring" />
-                    <img className="video-preload-logo" src={threespeakLogo} alt="" />
-                  </div>
+                  <img
+                    className="video-preload-logo"
+                    src={isDarkTheme ? threespeakLogoDark : threespeakLogo}
+                    alt="3Speak"
+                  />
+                  <TailChase size="42" speed="1.75" color="var(--accent-primary, #e0594b)" />
                 </div>
               )}
               {/* Media gone (old upload whose IPFS content is unpinned). The player

--- a/src/components/playVideo/PlayVideo.scss
+++ b/src/components/playVideo/PlayVideo.scss
@@ -1643,64 +1643,33 @@
   }
 }
 
-/* ── Branded preload / buffering overlay ─────────────────────────────────────
-   Half-transparent scrim over the poster while the player fetches the manifest
-   and buffers the first frame (driven by the SDK `loading` state in Watch.jsx).
-   Sits inside .video-iframe-wrapper (position: relative). pointer-events: none
-   so it never intercepts the play button or controls underneath. */
+/* ── Branded preload cover ───────────────────────────────────────────────────
+   The SAME splash as the site's initial load (EmergencyScreen "checking"): the
+   3Speak logo above a TailChase spinner, on an OPAQUE --bg-primary background — so
+   the player is fully HIDDEN behind it until the first frame is ready (the onReady
+   gate in Watch.jsx). Sits inside .video-iframe-wrapper (position: relative). z-index
+   is above the <video>, the click overlay (z 5) AND the controls (z 10) so nothing
+   peeks through while loading; it's mutually exclusive with the "unavailable" overlay. */
 .video-preload-overlay {
   position: absolute;
   inset: 0;
-  z-index: 4;
+  z-index: 11;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.45);
+  gap: 30px;
+  background: var(--bg-primary, #0f0f0f);
   pointer-events: none;
   animation: video-preload-fade 0.18s ease both;
 }
 
-.video-preload-badge {
-  position: relative;
-  width: 88px;
-  height: 88px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.video-preload-ring {
-  position: absolute;
-  inset: 0;
-  border-radius: 50%;
-  border: 3px solid rgba(255, 255, 255, 0.16);
-  border-top-color: var(--accent-primary, #e53935);
-  animation: video-preload-spin 0.85s linear infinite;
-}
-
 .video-preload-logo {
-  width: 46px;
-  height: 46px;
-  object-fit: contain;
-  animation: video-preload-pulse 1.4s ease-in-out infinite;
-}
-
-@keyframes video-preload-spin {
-  to { transform: rotate(360deg); }
-}
-
-@keyframes video-preload-pulse {
-  0%, 100% { opacity: 0.6; transform: scale(0.92); }
-  50%      { opacity: 1;   transform: scale(1); }
+  width: min(220px, 50%);
+  height: auto;
 }
 
 @keyframes video-preload-fade {
   from { opacity: 0; }
   to   { opacity: 1; }
-}
-
-/* Respect reduced-motion: keep the scrim + logo, drop the spin/pulse. */
-@media (prefers-reduced-motion: reduce) {
-  .video-preload-ring { animation: none; }
-  .video-preload-logo { animation: none; opacity: 0.9; }
 }

--- a/src/lib/hiveRenderer.js
+++ b/src/lib/hiveRenderer.js
@@ -1,0 +1,24 @@
+// Shared, lazy-loaded Hive markdown → HTML renderer (same config MarkdownComposer and
+// BlogContent use). createHiveRenderer returns a synchronous render(md) function; we
+// memoise the dynamic import so the ~renderer bundle loads once, on first use.
+let rendererPromise = null;
+
+export function getHiveRenderer() {
+  if (!rendererPromise) {
+    rendererPromise = import('@snapie/renderer').then(({ createHiveRenderer }) =>
+      createHiveRenderer({
+        ipfsGateway: 'https://hotipfs-3speak-1.b-cdn.net',
+        ipfsFallbackGateways: [
+          'https://ipfs.skatehive.app',
+          'https://cloudflare-ipfs.com',
+          'https://ipfs.io',
+        ],
+        convertHiveUrls: true,
+        internalUrlPrefix: '',
+        usertagUrlFn: (account) => `/p/${account}`,
+        hashtagUrlFn: (tag) => `/t/${tag}`,
+      }),
+    );
+  }
+  return rendererPromise;
+}

--- a/src/lib/snaps.js
+++ b/src/lib/snaps.js
@@ -85,17 +85,19 @@ function makePermlink(body) {
   return `${slug || 'snap'}-${Date.now() % 100000}`;
 }
 
-// Build comment_options from the rewards choice + user beneficiaries. Returns null
-// for the default (no beneficiaries), so we skip the op entirely in that case.
-function buildOptions(rewards, beneficiaries) {
+// Build comment_options from the rewards choice + user beneficiaries. MUST include
+// author + permlink: the client-side (Keychain) path hands this object straight to
+// aioha.comment, which serializes it — a missing author/permlink there surfaces as
+// "can't access property toString, y is undefined". (Matches the shorts uploader.)
+function buildOptions(author, permlink, rewards, beneficiaries) {
   const benes = (beneficiaries || [])
     .filter((b) => b && b.account && Number(b.weight) > 0)
     .map((b) => ({ account: String(b.account).toLowerCase().replace(/^@/, '').trim(), weight: Math.round(Number(b.weight)) }))
     .sort((a, b) => a.account.localeCompare(b.account)); // chain requires ascending account order
 
-  if (rewards === 'default' && benes.length === 0) return null;
-
   return {
+    author,
+    permlink,
     max_accepted_payout: rewards === 'decline' ? '0.000 HBD' : '1000000.000 HBD',
     percent_hbd: rewards === 'powerup' ? 0 : 10000, // 0 = 100% power-up, 10000 = default 50/50
     allow_votes: true,
@@ -136,7 +138,7 @@ export async function publishSnap({ user, body, tags = [], rewards = 'default', 
     type: 'snap',
   };
 
-  const options = buildOptions(rewards, beneficiaries);
+  const options = buildOptions(user, permlink, rewards, beneficiaries);
 
   const result = await commentWithAioha(parent.author, parent.permlink, permlink, '', text, jsonMetadata, options);
   if (result && result.success === false) throw new Error('Publishing the snap was rejected');

--- a/src/lib/snaps.js
+++ b/src/lib/snaps.js
@@ -27,6 +27,38 @@ export async function fetchSnaps(owner, page = 1, limit = 20) {
   return data; // { success, snaps, page, limit, total, hasMore }
 }
 
+/**
+ * Cross-author community-post feed for the home sections (fresh <7d, excludes the
+ * viewer's hidden + already-engaged snaps server-side).
+ * @param {{ scope?: 'all'|'following', currentuser?: string, page?: number, limit?: number }} opts
+ */
+export async function fetchCommunityFeed({ scope = 'all', currentuser = '', page = 1, limit = 10 } = {}) {
+  const params = new URLSearchParams({ scope, page: String(page), limit: String(limit) });
+  if (currentuser) params.set('currentuser', currentuser);
+  const { data } = await axios.get(`${CHECKER_URL}/snaps-feed?${params.toString()}`);
+  return data; // { success, snaps, page, limit, hasMore }
+}
+
+/** Fire-and-forget: mark that `user` voted/commented on a snap (drops it from their feed). */
+export function recordSnapInteraction(user, author, permlink) {
+  if (!user || !author || !permlink) return;
+  axios.post(`${CHECKER_URL}/snaps/interaction`, { user, author, permlink }).catch(() => {});
+}
+
+// Per-user snap hides (separate from video hides). Undo-able.
+export function hideSnap(user, author, permlink) {
+  return axios.post(`${CHECKER_URL}/snaps/hide`, { user, author, permlink });
+}
+export function unhideSnap(user, author, permlink) {
+  return axios.delete(`${CHECKER_URL}/snaps/hide`, { data: { user, author, permlink } });
+}
+export function hideSnapCreator(user, author) {
+  return axios.post(`${CHECKER_URL}/snaps/hide-creator`, { user, author });
+}
+export function unhideSnapCreator(user, author) {
+  return axios.delete(`${CHECKER_URL}/snaps/hide-creator`, { data: { user, author } });
+}
+
 // The @peak.snaps container is one long-running "daily" post; we reply under its
 // newest one, exactly like the shorts uploader does.
 async function getSnapsContainer() {

--- a/src/lib/snaps.js
+++ b/src/lib/snaps.js
@@ -15,6 +15,9 @@ import { commentWithAioha } from '../hive-api/aioha';
 // apart from any other comment the account has under @peak.snaps.
 const SNAP_APP = '3speak/snap';
 const SNAP_CONTAINER = 'peak.snaps';
+// Built-in tag on every community snap (in addition to the user's own tags).
+export const SNAP_TAG = 'community';
+export const MAX_USER_TAGS = 9; // + the built-in `community` = Hive's practical 10-tag limit
 
 /** The owner's snaps, newest first (for the Community tab). */
 export async function fetchSnaps(owner, page = 1, limit = 20) {
@@ -83,15 +86,21 @@ export async function publishSnap({ user, body, tags = [], rewards = 'default', 
   const parent = await getSnapsContainer();
   const permlink = makePermlink(text);
 
-  const cleanTags = [...new Set(
-    (tags || []).map((t) => String(t).toLowerCase().replace(/^#/, '').trim()).filter(Boolean),
-  )].slice(0, 8);
-  if (nsfw && !cleanTags.includes('nsfw')) cleanTags.push('nsfw');
+  // Every snap carries the built-in `community` tag, so users get at most 9 of their
+  // own — 1 + 9 = 10, Hive's practical tag limit. `nsfw` is a content flag on top.
+  const userTags = [...new Set(
+    (tags || [])
+      .map((t) => String(t).toLowerCase().replace(/^#/, '').trim())
+      .filter((t) => t && t !== SNAP_TAG),
+  )].slice(0, 9);
+  const cleanTags = [SNAP_TAG, ...userTags];
+  if (nsfw) cleanTags.push('nsfw');
+  const finalTags = cleanTags.slice(0, 10);
 
   const jsonMetadata = {
     app: SNAP_APP,
     format: 'markdown',
-    tags: cleanTags,
+    tags: finalTags,
     type: 'snap',
   };
 

--- a/src/lib/snaps.js
+++ b/src/lib/snaps.js
@@ -1,0 +1,115 @@
+// Community "snaps" — short WRITTEN posts a creator publishes to their followers.
+//
+// A snap is a real Hive comment under @peak.snaps' latest container (the same
+// Snaps/threads pattern 3Speak shorts use — just text, no video). After it's
+// broadcast we index the permlink in the checker so the profile's Community tab
+// loads fast from Mongo. The checker re-verifies the post on-chain, so this is a
+// best-effort "please index it" call, not a source of truth.
+
+import axios from 'axios';
+import { CHECKER_URL } from '../utils/config';
+import { getHiveUrl } from '../utils/hiveNode';
+import { commentWithAioha } from '../hive-api/aioha';
+
+// Must match SNAP_APP in the checker's routes/snaps.js — it's how a snap is told
+// apart from any other comment the account has under @peak.snaps.
+const SNAP_APP = '3speak/snap';
+const SNAP_CONTAINER = 'peak.snaps';
+
+/** The owner's snaps, newest first (for the Community tab). */
+export async function fetchSnaps(owner, page = 1, limit = 20) {
+  const { data } = await axios.get(
+    `${CHECKER_URL}/snaps/${encodeURIComponent(owner)}?page=${page}&limit=${limit}`,
+  );
+  return data; // { success, snaps, page, limit, total, hasMore }
+}
+
+// The @peak.snaps container is one long-running "daily" post; we reply under its
+// newest one, exactly like the shorts uploader does.
+async function getSnapsContainer() {
+  const res = await axios.post(getHiveUrl(), {
+    jsonrpc: '2.0',
+    method: 'bridge.get_account_posts',
+    params: { sort: 'posts', account: SNAP_CONTAINER, start_author: '', start_permlink: '', limit: 1 },
+    id: 1,
+  });
+  const latest = res.data?.result?.[0];
+  if (!latest?.author || !latest?.permlink) {
+    throw new Error('Could not find a snaps container to post under — try again shortly');
+  }
+  return { author: latest.author, permlink: latest.permlink };
+}
+
+function makePermlink(body) {
+  const slug = String(body || '')
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .slice(0, 27)
+    .replace(/-+$/, '');
+  return `${slug || 'snap'}-${Date.now() % 100000}`;
+}
+
+// Build comment_options from the rewards choice + user beneficiaries. Returns null
+// for the default (no beneficiaries), so we skip the op entirely in that case.
+function buildOptions(rewards, beneficiaries) {
+  const benes = (beneficiaries || [])
+    .filter((b) => b && b.account && Number(b.weight) > 0)
+    .map((b) => ({ account: String(b.account).toLowerCase().replace(/^@/, '').trim(), weight: Math.round(Number(b.weight)) }))
+    .sort((a, b) => a.account.localeCompare(b.account)); // chain requires ascending account order
+
+  if (rewards === 'default' && benes.length === 0) return null;
+
+  return {
+    max_accepted_payout: rewards === 'decline' ? '0.000 HBD' : '1000000.000 HBD',
+    percent_hbd: rewards === 'powerup' ? 0 : 10000, // 0 = 100% power-up, 10000 = default 50/50
+    allow_votes: true,
+    allow_curation_rewards: true,
+    extensions: benes.length ? [[0, { beneficiaries: benes }]] : [],
+  };
+}
+
+/**
+ * Publish a written snap, then index it in the checker.
+ * @param {{ user:string, body:string, tags?:string[], rewards?:'default'|'powerup'|'decline',
+ *           beneficiaries?:{account:string,weight:number}[], nsfw?:boolean }} opts
+ * @returns {{ author:string, permlink:string, indexed:object|null }}
+ */
+export async function publishSnap({ user, body, tags = [], rewards = 'default', beneficiaries = [], nsfw = false }) {
+  if (!user) throw new Error('Please log in first');
+  const text = String(body || '').trim();
+  if (!text) throw new Error('Write something first');
+
+  const parent = await getSnapsContainer();
+  const permlink = makePermlink(text);
+
+  const cleanTags = [...new Set(
+    (tags || []).map((t) => String(t).toLowerCase().replace(/^#/, '').trim()).filter(Boolean),
+  )].slice(0, 8);
+  if (nsfw && !cleanTags.includes('nsfw')) cleanTags.push('nsfw');
+
+  const jsonMetadata = {
+    app: SNAP_APP,
+    format: 'markdown',
+    tags: cleanTags,
+    type: 'snap',
+  };
+
+  const options = buildOptions(rewards, beneficiaries);
+
+  const result = await commentWithAioha(parent.author, parent.permlink, permlink, '', text, jsonMetadata, options);
+  if (result && result.success === false) throw new Error('Publishing the snap was rejected');
+
+  // Index it (the checker re-verifies on-chain). Retry across the block time — the
+  // RPC may not have the fresh comment yet.
+  let indexed = null;
+  for (let i = 0; i < 4; i++) {
+    try {
+      const { data } = await axios.post(`${CHECKER_URL}/snaps`, { author: user, permlink });
+      if (data?.success) { indexed = data.snap; break; }
+    } catch (_) { /* propagation delay — retry */ }
+    if (i < 3) await new Promise((r) => setTimeout(r, 2500));
+  }
+
+  return { author: user, permlink, indexed };
+}

--- a/src/page/HomeGrouped.jsx
+++ b/src/page/HomeGrouped.jsx
@@ -16,6 +16,8 @@ import OpenPodsLiveStrip from "../components/OpenPod/OpenPodsLiveStrip";
 import PullToRefresh from "../components/PullToRefresh/PullToRefresh";
 import ShortsRow from "../components/ShortsRow/ShortsRow";
 import { useGridColumns, useShortsPerRow } from "../hooks/useGridMetrics";
+import { fetchCommunityFeed } from "../lib/snaps";
+import { SnapCard } from "../components/Userprofilepage/CommunitySnaps";
 import { SHORTS_API_URL } from "../utils/config";
 import { TrendingIcon, NewContentIcon } from "../components/FeedIcons";
 import { Rocket, Compass, Sparkles, GripVertical } from "lucide-react";
@@ -421,6 +423,62 @@ const HomeGrouped = () => {
     shortsQ.fetchNextPage();
   }, [shortsMode, shortsNeeded, feedShorts.length, shortsQ.hasNextPage, shortsQ.isFetchingNextPage]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // ── Community posts interspersed in the feed (mirrors the shorts rails) ──────
+  // Discover + New → any fresh community post; Interests + Follow → only from people
+  // you follow. null = none for this section.
+  const communityMode = useMemo(() => {
+    const k = activeSection?.key;
+    if (k === 'discover' || k === 'new') return 'all';
+    if ((k === 'interests' || k === 'home') && authenticated && user) return 'following';
+    return null;
+  }, [activeSection?.key, authenticated, user]);
+
+  const communityQ = useInfiniteQuery({
+    queryKey: ['feed-community', activeSection?.key, communityMode, user || null],
+    queryFn: async ({ pageParam = 1 }) => {
+      const data = await fetchCommunityFeed({ scope: communityMode, currentuser: user, page: pageParam });
+      return data?.snaps || [];
+    },
+    initialPageParam: 1,
+    getNextPageParam: nextPage(),
+    enabled: !!communityMode,
+    retry: 1,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+  });
+  // Locally removed (hidden via the ⋮ menu) — the checker also records the hide, so
+  // it won't come back on the next fetch; this drops it from the current view instantly.
+  const [removedSnaps, setRemovedSnaps] = useState(() => new Set());
+  const removeSnap = useCallback((snap) => {
+    setRemovedSnaps((prev) => new Set(prev).add(`${snap.owner}/${snap.permlink}`));
+  }, []);
+  const feedCommunity = useMemo(
+    () => (communityQ.data?.pages || []).flat().filter((s) => !removedSnaps.has(`${s.owner}/${s.permlink}`)),
+    [communityQ.data, removedSnaps],
+  );
+
+  // A community post roughly every 3 rows (offset from the shorts' every-2-rows).
+  const communityEvery = gridCols > 0 ? gridCols * 3 : 0;
+  const communityNeeded = communityEvery ? Math.floor(activeVideos.length / communityEvery) : 0;
+  useEffect(() => {
+    if (!communityMode) return;
+    if (feedCommunity.length >= communityNeeded) return;
+    if (!communityQ.hasNextPage || communityQ.isFetchingNextPage) return;
+    communityQ.fetchNextPage();
+  }, [communityMode, communityNeeded, feedCommunity.length, communityQ.hasNextPage, communityQ.isFetchingNextPage]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const renderCommunityRow = useCallback((slot) => {
+    const snap = feedCommunity[slot];
+    if (!snap) return null;
+    // Wrap in .community-snaps so the SnapCard's (nested) styles apply; the feed
+    // modifier drops the tab padding.
+    return (
+      <div className="community-snaps community-snaps--feed">
+        <SnapCard snap={snap} feedMode onRemove={removeSnap} />
+      </div>
+    );
+  }, [feedCommunity, removeSnap]);
+
   const { getContentForVideo } = useContentBatch(visibleVideos);
   const { isWatched, version: watchedVersion } = useWatchHistory(visibleVideos);
   const { getViewCount } = useViewCounts(visibleVideos);
@@ -581,6 +639,9 @@ const HomeGrouped = () => {
              mobile, 4-5 on desktop). 0 until measured → no interleave, no jump. */
           interleaveEvery={shortsMode && s.key === activeSection?.key && gridCols > 0 ? gridCols * 2 : 0}
           renderInterleave={shortsMode && s.key === activeSection?.key ? renderShortsRail : null}
+          /* Community posts on the same feeds, ~every 3 rows (see communityMode). */
+          communityEvery={communityMode && s.key === activeSection?.key && gridCols > 0 ? communityEvery : 0}
+          renderCommunity={communityMode && s.key === activeSection?.key ? renderCommunityRow : null}
         />
         {q && (
           <InfiniteSentinel

--- a/src/page/HomeGrouped.jsx
+++ b/src/page/HomeGrouped.jsx
@@ -458,26 +458,32 @@ const HomeGrouped = () => {
   );
 
   // A community post roughly every 3 rows (offset from the shorts' every-2-rows).
+  // Each interleave slot packs up to a full grid-row of snaps (one per column) so
+  // several creators' posts share one line when there's room.
   const communityEvery = gridCols > 0 ? gridCols * 3 : 0;
+  const communityPerRow = gridCols > 0 ? gridCols : 1;
   const communityNeeded = communityEvery ? Math.floor(activeVideos.length / communityEvery) : 0;
   useEffect(() => {
     if (!communityMode) return;
-    if (feedCommunity.length >= communityNeeded) return;
+    if (feedCommunity.length >= communityNeeded * communityPerRow) return;
     if (!communityQ.hasNextPage || communityQ.isFetchingNextPage) return;
     communityQ.fetchNextPage();
-  }, [communityMode, communityNeeded, feedCommunity.length, communityQ.hasNextPage, communityQ.isFetchingNextPage]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [communityMode, communityNeeded, communityPerRow, feedCommunity.length, communityQ.hasNextPage, communityQ.isFetchingNextPage]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const renderCommunityRow = useCallback((slot) => {
-    const snap = feedCommunity[slot];
-    if (!snap) return null;
-    // Wrap in .community-snaps so the SnapCard's (nested) styles apply; the feed
-    // modifier drops the tab padding.
+    const start = slot * communityPerRow;
+    const group = feedCommunity.slice(start, start + communityPerRow);
+    if (!group.length) return null;
+    // Wrap in .community-snaps so the SnapCards' (nested) styles apply; --row makes
+    // it a full-width grid that mirrors the video columns.
     return (
-      <div className="community-snaps community-snaps--feed">
-        <SnapCard snap={snap} feedMode onRemove={removeSnap} />
+      <div className="community-snaps community-snaps--feed community-snaps--row">
+        {group.map((snap) => (
+          <SnapCard key={`${snap.owner}/${snap.permlink}`} snap={snap} feedMode onRemove={removeSnap} />
+        ))}
       </div>
     );
-  }, [feedCommunity, removeSnap]);
+  }, [feedCommunity, removeSnap, communityPerRow]);
 
   const { getContentForVideo } = useContentBatch(visibleVideos);
   const { isWatched, version: watchedVersion } = useWatchHistory(visibleVideos);

--- a/src/page/ProfilePage.jsx
+++ b/src/page/ProfilePage.jsx
@@ -13,6 +13,7 @@ import Follower from "../components/Userprofilepage/Follower";
 import BarLoader from "../components/Loader/BarLoader";
 import CreatorStats from "../components/CreatorStats/CreatorStats";
 import CommunitySnaps from "../components/Userprofilepage/CommunitySnaps";
+import { fetchSnaps } from "../lib/snaps";
 import { useContentBatch } from "../hooks/useContentBatch";
 import { useWatchHistory } from "../hooks/useWatchHistory";
 import useViewCounts from "../hooks/useViewCounts";
@@ -297,6 +298,15 @@ function ProfilePage() {
     staleTime: 30 * 1000,
   });
 
+  // Community-post count for the tab header (like Playlists shows its count).
+  const { data: snapCountData } = useQuery({
+    queryKey: ["community-snaps-count", user],
+    queryFn: () => fetchSnaps(user, 1, 1),
+    enabled: !!user,
+    staleTime: 60 * 1000,
+  });
+  const snapCount = snapCountData?.total || 0;
+
   const scheduledCards = useMemo(() => {
     return (scheduledData || [])
       .map(normalizeScheduledForCard)
@@ -470,7 +480,9 @@ function ProfilePage() {
           <span className={show === "video" ? "active" : ""} onClick={() => selectTab("video")}>Videos</span>
           <span className={show === "shorts" ? "active" : ""} onClick={() => selectTab("shorts")}>Shorts</span>
           <span className={show === "audio" ? "active" : ""} onClick={() => selectTab("audio")}>Audio</span>
-          <span className={show === "community" ? "active" : ""} onClick={() => selectTab("community")}>Community</span>
+          <span className={show === "community" ? "active" : ""} onClick={() => selectTab("community")}>
+            Community {snapCount > 0 && `(${snapCount})`}
+          </span>
           <span className={show === "playlists" ? "active" : ""} onClick={() => selectTab("playlists")}>
             Playlists
           </span>

--- a/src/page/ProfilePage.jsx
+++ b/src/page/ProfilePage.jsx
@@ -474,7 +474,7 @@ function ProfilePage() {
           <span className={show === "playlists" ? "active" : ""} onClick={() => selectTab("playlists")}>
             Playlists
           </span>
-          <span className={show === "stats" ? "active" : ""} onClick={() => selectTab("stats")}>Stats</span>
+          <span className={show === "stats" ? "active" : ""} onClick={() => selectTab("stats")}>Analytics</span>
         </div>
 
         <div className="wrap-in">

--- a/src/page/ProfilePage.jsx
+++ b/src/page/ProfilePage.jsx
@@ -12,6 +12,7 @@ import Card3 from "../components/Cards/Card3";
 import Follower from "../components/Userprofilepage/Follower";
 import BarLoader from "../components/Loader/BarLoader";
 import CreatorStats from "../components/CreatorStats/CreatorStats";
+import CommunitySnaps from "../components/Userprofilepage/CommunitySnaps";
 import { useContentBatch } from "../hooks/useContentBatch";
 import { useWatchHistory } from "../hooks/useWatchHistory";
 import useViewCounts from "../hooks/useViewCounts";
@@ -60,6 +61,7 @@ function ProfilePage() {
     if (tab === 'playlists') return 'playlists';
     if (tab === 'shorts') return 'shorts';
     if (tab === 'audio') return 'audio';
+    if (tab === 'community') return 'community';
     if (tab === 'stats') return 'stats';
     return 'video';
   });
@@ -69,6 +71,7 @@ function ProfilePage() {
     if (tab === 'playlists') setShow('playlists');
     else if (tab === 'shorts') setShow('shorts');
     else if (tab === 'audio') setShow('audio');
+    else if (tab === 'community') setShow('community');
     else if (tab === 'stats') setShow('stats');
     else if (!tab) setShow('video');
   }, [searchParams]);
@@ -467,6 +470,7 @@ function ProfilePage() {
           <span className={show === "video" ? "active" : ""} onClick={() => selectTab("video")}>Videos</span>
           <span className={show === "shorts" ? "active" : ""} onClick={() => selectTab("shorts")}>Shorts</span>
           <span className={show === "audio" ? "active" : ""} onClick={() => selectTab("audio")}>Audio</span>
+          <span className={show === "community" ? "active" : ""} onClick={() => selectTab("community")}>Community</span>
           <span className={show === "playlists" ? "active" : ""} onClick={() => selectTab("playlists")}>
             Playlists
           </span>
@@ -542,6 +546,8 @@ function ProfilePage() {
           )
         ) : show === "audio" ? (
           <UserAudioList user={user} />
+        ) : show === "community" ? (
+          <CommunitySnaps user={user} canPost={!!user} />
         ) : show === "stats" ? (
           <CreatorStats user={user} />
         ) : show === "playlists" ? (

--- a/src/page/Watch.jsx
+++ b/src/page/Watch.jsx
@@ -180,6 +180,15 @@ function Watch({ v2 = false }) {
   const mediaUnavailable = playbackFailed
     || (!!author && !!permlink && deadVideos.has(videoKey(author, permlink)));
 
+  // Show the branded loader OVER the player until it's actually ready to paint a
+  // frame (SDK `onReady`). We can't drive this off playerState.loading: the SDK's
+  // react hook never re-renders on its "loading" event, and the poster stays black
+  // until the Hive metadata arrives — so without this the user just sees a black
+  // box while the source loads. Reset per video.
+  const [videoReady, setVideoReady] = useState(false);
+  useEffect(() => { setVideoReady(false); }, [author, permlink]);
+  const mediaLoading = !videoReady && !mediaUnavailable && !scheduled;
+
   // Track which videos we've recorded to avoid duplicate API calls
   const recordedWatchRef = useRef(new Set());
 
@@ -303,6 +312,8 @@ function Watch({ v2 = false }) {
         setPlaybackFailed(true); // swap the player for a "not available" hint
       }
     },
+    // First frame decoded — drop the branded loader and reveal the player.
+    onReady: () => setVideoReady(true),
     // Tuned for 3Speak's reality: older uploads sit on COLD IPFS and a segment can
     // take 30–45s to serve the first time (then the CDN has it hot). See the HAR
     // analysis of 2026-07-15.
@@ -1343,7 +1354,7 @@ function Watch({ v2 = false }) {
         author={author}
         permlink={permlink}
         mediaUnavailable={mediaUnavailable}
-        mediaLoading={!!playerState?.loading && !mediaUnavailable}
+        mediaLoading={mediaLoading}
         videoRef={videoRef}
         wrapperRef={wrapperRef}
         playlistData={showPlaylist ? playlistData : null}

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.55.0';
+export const APP_VERSION = '1.56.0';

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.56.0';
+export const APP_VERSION = '1.57.0';


### PR DESCRIPTION
This pull request introduces a major new "Community" tab to creator profiles, allowing creators to post short written updates ("snaps") to their followers. It also adds support for displaying these community posts in user feeds, improves the video playback loading experience, and enhances the usability and accessibility of analytics and stats features. Below are the most important changes:

---

**New Community Tab and Snaps Feature:**

* Added a "Community" tab to creator profiles where creators can post and manage written updates ("snaps") with tags, images, and links. Followers can view, like, and comment on these posts, which also appear in home feeds. (`src/changelog.js`, `src/components/Userprofilepage/UserProfilePage.jsx`, `src/components/Userprofilepage/SnapComposer.jsx`, `src/lib/snaps.js`) [[1]](diffhunk://#diff-2b5b164299e9a44e90c14ae81c0182d162656fec55e07d328651882df8c9c689R9-R20) [[2]](diffhunk://#diff-848a3d91488e85372b5372bf0ca901321b6455350263c11e1c8c035cd1ea11aeR39-R40) [[3]](diffhunk://#diff-848a3d91488e85372b5372bf0ca901321b6455350263c11e1c8c035cd1ea11aeR62) [[4]](diffhunk://#diff-848a3d91488e85372b5372bf0ca901321b6455350263c11e1c8c035cd1ea11aeR73) [[5]](diffhunk://#diff-848a3d91488e85372b5372bf0ca901321b6455350263c11e1c8c035cd1ea11aeR113-R121) [[6]](diffhunk://#diff-848a3d91488e85372b5372bf0ca901321b6455350263c11e1c8c035cd1ea11aeR510-R517) [[7]](diffhunk://#diff-848a3d91488e85372b5372bf0ca901321b6455350263c11e1c8c035cd1ea11aeR547-R548) [[8]](diffhunk://#diff-6c00506e29ad4ca391aae5ac1d9cd5c91a24df6c9ff2a7d2ea6316049a1a0e8eR1-R179)

* Refactored the `withInterleave` function in `Card3.jsx` to support multiple interleaved content streams (e.g., both shorts and community posts), allowing both to be displayed between video cards in feeds. (`src/components/Cards/Card3.jsx`) [[1]](diffhunk://#diff-6ae7ad9f53a84c22304bfcdf83c50291913cbf8416e58c0dcc6e1627e6105d85L34-R54) [[2]](diffhunk://#diff-6ae7ad9f53a84c22304bfcdf83c50291913cbf8416e58c0dcc6e1627e6105d85L291-R300)

---

**Playback and UI Improvements:**

* Updated the video playback preload overlay to use the branded 3Speak splash and loading animation, with theme-aware (dark/light) logo selection for a more polished and consistent experience. (`src/components/playVideo/PlayVideo.jsx`) [[1]](diffhunk://#diff-654a8c51f9968effcc09dcfead456c46d7634ce851e944d250051fc69a21db56R36) [[2]](diffhunk://#diff-654a8c51f9968effcc09dcfead456c46d7634ce851e944d250051fc69a21db56R76-R77) [[3]](diffhunk://#diff-654a8c51f9968effcc09dcfead456c46d7634ce851e944d250051fc69a21db56L801-R816)

---

**Analytics and Stats Enhancements:**

* Improved accessibility and usability of the creator stats list: video/short titles are now links that open in a new tab, and the rest of the row toggles analytics. Also improved keyboard navigation and visual cues for clickable elements. (`src/components/CreatorStats/CreatorStats.jsx`, `src/components/CreatorStats/CreatorStats.scss`) [[1]](diffhunk://#diff-5596e1ccfa925a63a489a7ba62bf175f168ae500a814b3f53f4c15be391b2066L377-R409) [[2]](diffhunk://#diff-fd4124d7a3fbd8a86a987087e58f2153eb81691d6a6472811d0cb054ffa0fe2dR116-R119)
* Updated terminology from "Stats" to "Analytics" in both the video player and profile tabs for clarity. (`src/components/playVideo/PlayVideo.jsx`, `src/components/Userprofilepage/UserProfilePage.jsx`) [[1]](diffhunk://#diff-654a8c51f9968effcc09dcfead456c46d7634ce851e944d250051fc69a21db56L1217-R1226) [[2]](diffhunk://#diff-848a3d91488e85372b5372bf0ca901321b6455350263c11e1c8c035cd1ea11aeR510-R517)

---

**Changelog Updates:**

* Documented all major user-facing changes, including the new Community tab, improved playback loading, and other enhancements. (`src/changelog.js`)