### PR TITLE
Community snaps: edit own posts, instant counters, feed comments popu…

### DIFF
--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.58.0',
+    date: '2026-07-16',
+    summary:
+      'Community posts got a round of polish: edit your own posts with the pencil on the post card, and like/comment counts now update instantly after you vote or reply. In the home feeds, comments on a community post open in a popup, and your own posts live on your profile’s Community tab instead of appearing in your own feed.',
+  },
+  {
     version: '1.57.0',
     date: '2026-07-16',
     summary:

--- a/src/components/Userprofilepage/CommunitySnaps.jsx
+++ b/src/components/Userprofilepage/CommunitySnaps.jsx
@@ -6,11 +6,12 @@ import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { toast } from 'sonner';
 import { BiCommentDetail } from 'react-icons/bi';
-import { MdMoreVert } from 'react-icons/md';
+import { MdMoreVert, MdEdit, MdClose } from 'react-icons/md';
 import {
-  fetchSnaps, SNAP_TAG, recordSnapInteraction,
+  fetchSnaps, SNAP_TAG, MAX_USER_TAGS, recordSnapInteraction, updateSnap,
   hideSnap, unhideSnap, hideSnapCreator, unhideSnapCreator,
 } from '../../lib/snaps';
+import MarkdownComposer from '../studio/MarkdownComposer';
 import { getHiveRenderer } from '../../lib/hiveRenderer';
 import { getHiveClient } from '../../utils/hiveNode';
 import { getVotePower, getDynamicProps } from '../../utils/hiveUtils';
@@ -79,7 +80,9 @@ function SnapBody({ body, maxVh = 0.33 }) {
 }
 
 // Reply composer — reused for the snap itself and for any comment (nested replies).
-function ReplyBox({ parentAuthor, parentPermlink, onPosted, autoFocus = false }) {
+// onSigned fires the moment the broadcast succeeds (for instant counters);
+// onPosted fires ~3s later, when the RPC can actually return the new reply.
+function ReplyBox({ parentAuthor, parentPermlink, onPosted, onSigned, autoFocus = false }) {
   const user = useAppStore((s) => s.user);
   const [reply, setReply] = useState('');
   const [posting, setPosting] = useState(false);
@@ -93,6 +96,7 @@ function ReplyBox({ parentAuthor, parentPermlink, onPosted, autoFocus = false })
       const rp = `re-${parentPermlink}-${Date.now() % 1000000}`.toLowerCase().replace(/[^a-z0-9-]/g, '').slice(0, 250);
       await commentWithAioha(parentAuthor, parentPermlink, rp, '', text, { app: '3speak/snap', format: 'markdown' }, null);
       toast.success('Comment posted!');
+      onSigned?.(); // instant — counters bump right after signing
       setReply('');
       setTimeout(() => onPosted?.(), 3000);
     } catch (e) {
@@ -182,7 +186,7 @@ function SnapComments({ owner, permlink, onCommented }) {
 
   return (
     <div className="snap-comments">
-      <ReplyBox parentAuthor={owner} parentPermlink={permlink} onPosted={() => { refetch(); onCommented?.(); }} />
+      <ReplyBox parentAuthor={owner} parentPermlink={permlink} onSigned={onCommented} onPosted={refetch} />
       {isLoading ? (
         <div className="snap-comments-status">Loading comments…</div>
       ) : comments.length === 0 ? (
@@ -259,10 +263,124 @@ function SnapOptionsMenu({ owner, permlink, onHidden }) {
   );
 }
 
+// Inline editor for the owner's own snap — body + tags + NSFW, reusing the composer
+// styles. Rewards and beneficiaries stay as originally posted (Hive only allows
+// changing comment_options before the first vote), so they're not shown here.
+function SnapEditForm({ owner, permlink, initialBody, initialTags, initialNsfw, onCancel, onSaved }) {
+  const user = useAppStore((s) => s.user);
+  const [body, setBody] = useState(initialBody || '');
+  const [tags, setTags] = useState(initialTags || []);
+  const [tagInput, setTagInput] = useState('');
+  const [nsfw, setNsfw] = useState(!!initialNsfw);
+  const [saving, setSaving] = useState(false);
+
+  const addTag = (raw) => {
+    const t = String(raw || '').toLowerCase().replace(/^#/, '').trim();
+    if (!t || t === SNAP_TAG || tags.includes(t)) return;
+    if (tags.length >= MAX_USER_TAGS) { toast.error(`Up to ${MAX_USER_TAGS} tags`); return; }
+    setTags((prev) => [...prev, t]);
+  };
+  const onTagKeyDown = (e) => {
+    if (e.key === 'Enter' || e.key === ' ' || e.key === ',') { e.preventDefault(); addTag(tagInput); setTagInput(''); }
+    else if (e.key === 'Backspace' && !tagInput && tags.length) setTags(tags.slice(0, -1));
+  };
+  const removeTag = (t) => setTags(tags.filter((x) => x !== t));
+
+  const save = async () => {
+    const text = body.trim();
+    if (!text) { toast.error('Write something first'); return; }
+    if (!user || user !== owner) { toast.error('Only the author can edit this post'); return; }
+    setSaving(true);
+    try {
+      // Don't lose a half-typed tag left in the input.
+      const pending = tagInput.trim() ? [...tags, tagInput.trim().toLowerCase().replace(/^#/, '')] : tags;
+      await updateSnap({ user, permlink, body: text, tags: pending, nsfw });
+      toast.success('Post updated!');
+      onSaved({ body: text, tags: [SNAP_TAG, ...pending, ...(nsfw ? ['nsfw'] : [])] });
+    } catch (e) {
+      toast.error(e?.message || 'Could not update the post');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="snap-composer snap-edit-form">
+      <MarkdownComposer value={body} onChange={setBody} placeholder="Edit your community post…" />
+      <div className="snap-composer-row">
+        <input
+          className="snap-tags-input"
+          placeholder={tags.length >= MAX_USER_TAGS ? 'Tag limit reached' : 'Add a tag, then space or enter…'}
+          value={tagInput}
+          onChange={(e) => setTagInput(e.target.value)}
+          onKeyDown={onTagKeyDown}
+          disabled={tags.length >= MAX_USER_TAGS}
+        />
+        <label className="snap-toggle">
+          <input type="checkbox" checked={nsfw} onChange={(e) => setNsfw(e.target.checked)} />
+          <span>NSFW</span>
+        </label>
+      </div>
+      <div className="snap-tag-chips">
+        <span className="snap-tag-chip built-in" title="Added to every community post">{SNAP_TAG}</span>
+        {tags.map((t) => (
+          <span key={t} className="snap-tag-chip">
+            {t}
+            <button type="button" onClick={() => removeTag(t)} aria-label={`Remove ${t}`}><MdClose /></button>
+          </span>
+        ))}
+        <span className="snap-tag-count">{tags.length}/{MAX_USER_TAGS}</span>
+      </div>
+      <div className="snap-composer-actions">
+        <button type="button" className="snap-cancel-btn" onClick={onCancel} disabled={saving}>Cancel</button>
+        <button type="button" className="snap-post-btn" disabled={saving || !body.trim()} onClick={save}>
+          {saving ? 'Saving…' : 'Save changes'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// Comments in a popup — used in the home feed, where expanding the thread inline
+// would stretch the grid row. Centered dialog on desktop, bottom sheet on mobile
+// (the app-wide popup convention). The community-snaps/snap-card classes are only
+// there so the nested .snap-comments styles apply inside the portal.
+function SnapCommentsModal({ owner, permlink, onClose, onCommented }) {
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden'; // don't scroll the feed behind the sheet
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [onClose]);
+
+  return createPortal(
+    <div className="snap-comments-modal-backdrop" onClick={onClose}>
+      <div className="community-snaps snap-comments-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="snap-comments-modal-head">
+          <span>Comments on @{owner}’s post</span>
+          <button type="button" onClick={onClose} aria-label="Close"><MdClose /></button>
+        </div>
+        <div className="snap-card snap-comments-modal-scroll">
+          <SnapComments owner={owner} permlink={permlink} onCommented={onCommented} />
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
 export function SnapCard({ snap, feedMode = false, onRemove }) {
   const user = useAppStore((s) => s.user);
   const client = getHiveClient();
+  const queryClient = useQueryClient();
   const [showComments, setShowComments] = useState(false);
+  const [commentsPopup, setCommentsPopup] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [localEdit, setLocalEdit] = useState(null); // optimistic body/tags after an edit
 
   // Vote-dialog state (the reused CommentVoteTooltip owns the actual vote).
   const [showVote, setShowVote] = useState(false);
@@ -297,10 +415,38 @@ export function SnapCard({ snap, feedMode = false, onRemove }) {
     staleTime: 60_000,
   });
 
+  // Bump the counters the moment the signed transaction succeeds — a chain read
+  // right after broadcast usually still returns the OLD counts, which made the
+  // numbers look frozen. The cached meta is patched instantly; a delayed refetch
+  // reconciles with the chain once it has caught up.
+  const metaKey = ['snap-meta', snap.owner, snap.permlink];
+  const onVoted = () => {
+    queryClient.setQueryData(metaKey, (old) => ({
+      votes: (old?.votes ?? 0) + (old?.voted ? 0 : 1),
+      comments: old?.comments ?? 0,
+      voted: true,
+    }));
+    recordSnapInteraction(user, snap.owner, snap.permlink);
+    setTimeout(() => refetch(), 8000);
+  };
+  const onCommented = () => {
+    queryClient.setQueryData(metaKey, (old) => ({
+      votes: old?.votes ?? 0,
+      comments: (old?.comments ?? 0) + 1,
+      voted: old?.voted ?? false,
+    }));
+    recordSnapInteraction(user, snap.owner, snap.permlink);
+    setTimeout(() => refetch(), 8000);
+  };
+
+  const isOwn = !!user && user === snap.owner;
+  const effBody = localEdit?.body ?? snap.body;
+  const effTags = localEdit?.tags ?? snap.tags ?? [];
+
   const votes = meta?.votes ?? 0;
   const voted = meta?.voted ?? false;
   const comments = meta?.comments ?? 0;
-  const tags = (snap.tags || []).filter((t) => t && t !== 'nsfw' && t !== SNAP_TAG);
+  const tags = effTags.filter((t) => t && t !== 'nsfw' && t !== SNAP_TAG);
 
   return (
     <article className="snap-card">
@@ -319,14 +465,31 @@ export function SnapCard({ snap, feedMode = false, onRemove }) {
         >
           {hiveTime(snap.created)}
         </Link>
+        {isOwn && !editing && (
+          <button type="button" className="snap-menu-btn snap-edit-btn" onClick={() => setEditing(true)} title="Edit post" aria-label="Edit post">
+            <MdEdit />
+          </button>
+        )}
         {feedMode && (
           <SnapOptionsMenu owner={snap.owner} permlink={snap.permlink} onHidden={() => onRemove?.(snap)} />
         )}
       </div>
 
-      <SnapBody body={snap.body} maxVh={feedMode ? 0.15 : 0.33} />
+      {editing ? (
+        <SnapEditForm
+          owner={snap.owner}
+          permlink={snap.permlink}
+          initialBody={effBody}
+          initialTags={effTags.filter((t) => t && t !== SNAP_TAG && t !== 'nsfw')}
+          initialNsfw={effTags.includes('nsfw') || !!snap.nsfw}
+          onCancel={() => setEditing(false)}
+          onSaved={(edit) => { setLocalEdit(edit); setEditing(false); }}
+        />
+      ) : (
+        <SnapBody body={effBody} maxVh={feedMode ? 0.15 : 0.33} />
+      )}
 
-      {tags.length > 0 && (
+      {!editing && tags.length > 0 && (
         <div className="snap-tags">
           {tags.map((t) => <Link key={t} to={`/t/${t}`} className="snap-tag">{t}</Link>)}
         </div>
@@ -349,7 +512,7 @@ export function SnapCard({ snap, feedMode = false, onRemove }) {
               setAccountData={setAccountData}
               cachedDynamicProps={voteData?.dynProps || null}
               setActiveTooltipPermlink={() => {}}
-              onVoteSuccess={() => { refetch(); recordSnapInteraction(user, snap.owner, snap.permlink); }}
+              onVoteSuccess={onVoted}
               enableViewerTag={false}
               postCreatedAt={snap.created}
             />
@@ -357,19 +520,25 @@ export function SnapCard({ snap, feedMode = false, onRemove }) {
         </div>
         <button
           type="button"
-          className={`snap-action${showComments ? ' active' : ''}`}
-          onClick={() => setShowComments((v) => !v)}
+          className={`snap-action${showComments || commentsPopup ? ' active' : ''}`}
+          onClick={() => (feedMode ? setCommentsPopup(true) : setShowComments((v) => !v))}
         >
           <BiCommentDetail />
           <span>{comments}</span>
         </button>
       </div>
 
-      {showComments && (
-        <SnapComments
+      {/* Profile tab expands the thread inline; the feed opens a popup so the
+          grid row doesn't stretch. */}
+      {showComments && !feedMode && (
+        <SnapComments owner={snap.owner} permlink={snap.permlink} onCommented={onCommented} />
+      )}
+      {commentsPopup && (
+        <SnapCommentsModal
           owner={snap.owner}
           permlink={snap.permlink}
-          onCommented={() => { refetch(); recordSnapInteraction(user, snap.owner, snap.permlink); }}
+          onClose={() => setCommentsPopup(false)}
+          onCommented={onCommented}
         />
       )}
     </article>

--- a/src/components/Userprofilepage/CommunitySnaps.scss
+++ b/src/components/Userprofilepage/CommunitySnaps.scss
@@ -17,14 +17,15 @@
     align-items: flex-start; // each snap keeps its own height; no stretch-to-tallest
     gap: 16px;
 
-    // Cap each snap at one video-column width and DON'T grow, so e.g. two snaps in
-    // a four-wide feed keep their natural width and center as a group instead of
-    // each stretching to half the row.
+    // Base width = one video column, but let a card GROW a bit (capped) so the
+    // header row (badge + follow + label + time + ⋮ menu) fits on ONE line instead
+    // of wrapping the menu underneath. Once cards hit the cap the group still
+    // centers, so a partial row doesn't stretch edge-to-edge.
     .snap-card {
       margin: 0;
       min-width: 0; // allow shrinking instead of overflowing
-      flex: 0 1 var(--card-min-w, 460px);
-      max-width: 100%;
+      flex: 1 1 var(--card-min-w, 460px);
+      max-width: min(560px, 100%);
     }
 
     @media screen and (max-width: 767px) {
@@ -66,6 +67,19 @@
         font-weight: 600;
         cursor: pointer;
         white-space: nowrap;
+      }
+
+      // Compact NSFW checkbox next to the tag input (used by the edit form).
+      .snap-toggle {
+        flex: none;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 13px;
+        color: var(--text-secondary, #9aa0a6);
+        cursor: pointer;
+        white-space: nowrap;
+        input { width: 15px; height: 15px; accent-color: var(--accent-primary, #e53935); }
       }
     }
 
@@ -212,6 +226,7 @@
     .snap-composer-actions {
       display: flex;
       justify-content: flex-end;
+      gap: 10px;
       margin-top: 12px;
 
       .snap-post-btn {
@@ -226,7 +241,26 @@
         transition: opacity 0.15s ease;
         &:disabled { opacity: 0.5; cursor: not-allowed; }
       }
+
+      .snap-cancel-btn {
+        padding: 10px 18px;
+        border: 1px solid var(--border-color, rgba(255, 255, 255, 0.15));
+        border-radius: 999px;
+        background: transparent;
+        color: var(--text-secondary, #9aa0a6);
+        font-size: 14px;
+        font-weight: 600;
+        cursor: pointer;
+        &:hover { color: var(--text-primary, #f1f1f1); background: var(--bg-primary, #0f0f0f); }
+        &:disabled { opacity: 0.5; cursor: not-allowed; }
+      }
     }
+  }
+
+  // The composer reused as the in-card edit form: the card supplies the frame, so
+  // drop the composer's outer margin.
+  .snap-edit-form {
+    margin: 4px 0 8px;
   }
 
   // ── List + cards ──────────────────────────────────────────────────────────
@@ -255,11 +289,23 @@
       gap: 10px;
       margin-bottom: 8px;
 
-      // Feed header carries the author badge (+ follow) + label + time + menu, which
-      // is a lot on a narrow card — let it wrap instead of overflowing.
+      // Feed header carries the author badge (+ follow) + label + time + menu.
+      // The middle pieces shrink/ellipsize first so the ⋮ menu stays on the same
+      // row; wrapping only remains as a last resort on very narrow screens.
       &--feed {
         flex-wrap: wrap;
         row-gap: 6px;
+
+        .author-badge { min-width: 0; } // its name already truncates with …
+        .snap-feed-title {
+          flex: 0 1 auto;
+          min-width: 0;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+        .snap-time { flex: none; }
+        .snap-menu-btn { flex: none; }
       }
 
       // Small muted "Community snap" caption next to the author badge in the feed.
@@ -533,4 +579,89 @@
     cursor: pointer;
     &:hover { background: var(--bg-primary, #0f0f0f); }
   }
+}
+
+// ── Feed comments popup (portaled to <body>) ─────────────────────────────────
+// Centered dialog on desktop, bottom sheet on mobile (app-wide popup convention).
+// The dialog carries .community-snaps/.snap-card only so the nested comment styles
+// apply — the overrides below strip those wrappers' page-layout chrome.
+.snap-comments-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+
+  @media screen and (max-width: 767px) {
+    align-items: flex-end; // bottom sheet
+    padding: 0;
+  }
+}
+
+.snap-comments-modal {
+  // neutralise .community-snaps page-layout defaults
+  max-width: none;
+  margin: 0;
+  padding: 0;
+
+  width: min(560px, 100%);
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-secondary, #1a1a1a);
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  border-radius: 14px;
+  overflow: hidden;
+
+  @media screen and (max-width: 767px) {
+    width: 100%;
+    max-height: 75vh;
+    border-radius: 14px 14px 0 0; // bottom sheet: rounded top only
+    border-left: none;
+    border-right: none;
+    border-bottom: none;
+    animation: snap-sheet-up 0.25s ease;
+  }
+
+  .snap-comments-modal-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+    font-weight: 600;
+    font-size: 14px;
+    color: var(--text-primary, #f1f1f1);
+    flex: none;
+
+    button {
+      background: none;
+      border: none;
+      color: var(--text-secondary, #9aa0a6);
+      cursor: pointer;
+      display: inline-flex;
+      padding: 4px;
+      border-radius: 6px;
+      svg { font-size: 20px; }
+      &:hover { color: var(--text-primary, #f1f1f1); background: var(--bg-primary, #0f0f0f); }
+    }
+  }
+
+  // the .snap-card wrapper only exists for the nested comment styles — the modal
+  // supplies its own frame
+  .snap-comments-modal-scroll {
+    overflow-y: auto;
+    border: none;
+    border-radius: 0;
+    background: transparent;
+  }
+}
+
+@keyframes snap-sheet-up {
+  from { transform: translateY(40%); opacity: 0.6; }
+  to { transform: none; opacity: 1; }
 }

--- a/src/lib/snaps.js
+++ b/src/lib/snaps.js
@@ -156,3 +156,61 @@ export async function publishSnap({ user, body, tags = [], rewards = 'default', 
 
   return { author: user, permlink, indexed };
 }
+
+/**
+ * Edit an existing snap: re-broadcast the comment with the SAME permlink under its
+ * ORIGINAL parent (Hive replaces the content), then re-index in the checker (which
+ * upserts from the chain). comment_options are intentionally NOT resent — Hive only
+ * allows changing them before the first vote, so the original rewards/beneficiaries
+ * stay as they are.
+ * @param {{ user:string, permlink:string, body:string, tags?:string[], nsfw?:boolean }} opts
+ */
+export async function updateSnap({ user, permlink, body, tags = [], nsfw = false }) {
+  if (!user) throw new Error('Please log in first');
+  const text = String(body || '').trim();
+  if (!text) throw new Error('Write something first');
+
+  // The edit must reply under the snap's ORIGINAL container, not today's latest one.
+  const res = await axios.post(getHiveUrl(), {
+    jsonrpc: '2.0',
+    method: 'condenser_api.get_content',
+    params: [user, permlink],
+    id: 1,
+  });
+  const post = res.data?.result;
+  if (!post?.author || post.author !== user) throw new Error('Could not load the snap to edit');
+
+  // Same tag rules as publishSnap: built-in `community` + up to 9 user tags (+nsfw).
+  const userTags = [...new Set(
+    (tags || [])
+      .map((t) => String(t).toLowerCase().replace(/^#/, '').trim())
+      .filter((t) => t && t !== SNAP_TAG),
+  )].slice(0, 9);
+  const cleanTags = [SNAP_TAG, ...userTags];
+  if (nsfw) cleanTags.push('nsfw');
+
+  const jsonMetadata = {
+    app: SNAP_APP,
+    format: 'markdown',
+    tags: cleanTags.slice(0, 10),
+    type: 'snap',
+  };
+
+  const result = await commentWithAioha(post.parent_author, post.parent_permlink, permlink, '', text, jsonMetadata, null);
+  if (result && result.success === false) throw new Error('Updating the snap was rejected');
+
+  // Re-index; retry until the checker's chain read reflects the edit.
+  let indexed = null;
+  for (let i = 0; i < 4; i++) {
+    try {
+      const { data } = await axios.post(`${CHECKER_URL}/snaps`, { author: user, permlink });
+      if (data?.success) {
+        indexed = data.snap;
+        if (String(data.snap?.body || '').trim() === text) break; // chain caught up
+      }
+    } catch (_) { /* propagation delay — retry */ }
+    if (i < 3) await new Promise((r) => setTimeout(r, 2500));
+  }
+
+  return { author: user, permlink, indexed };
+}

--- a/src/page/HomeGrouped.jsx
+++ b/src/page/HomeGrouped.jsx
@@ -453,8 +453,12 @@ const HomeGrouped = () => {
     setRemovedSnaps((prev) => new Set(prev).add(`${snap.owner}/${snap.permlink}`));
   }, []);
   const feedCommunity = useMemo(
-    () => (communityQ.data?.pages || []).flat().filter((s) => !removedSnaps.has(`${s.owner}/${s.permlink}`)),
-    [communityQ.data, removedSnaps],
+    () => (communityQ.data?.pages || []).flat().filter(
+      // Own snaps never show in your own feed (the checker also filters them
+      // server-side — this covers pages cached before login/logout).
+      (s) => s.owner !== user && !removedSnaps.has(`${s.owner}/${s.permlink}`),
+    ),
+    [communityQ.data, removedSnaps, user],
   );
 
   // A community post roughly every 3 rows (offset from the shorts' every-2-rows).

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.57.0';
+export const APP_VERSION = '1.58.0';


### PR DESCRIPTION
…p (1.58.0)

- Edit own snaps (pencil -> inline form; same permlink under original parent, comment_options untouched)
- Vote/comment counters bump instantly on signing (optimistic snap-meta cache patch + delayed chain reconcile)
- Feed comment icon opens a popup (centered dialog / mobile bottom sheet) instead of inline expansion
- Own snaps filtered out of own home feed (client side; checker filters server-side too)
- Feed cards grow up to 560px + header middle ellipsizes so the options menu stays on one row
- Changelog + version bump to 1.58.0