### PR TITLE
fix: dark-theme text invisible in cookie consent, data request form a…

### DIFF
--- a/src/components/CookieConsent/CookieConsent.scss
+++ b/src/components/CookieConsent/CookieConsent.scss
@@ -13,7 +13,7 @@
   max-width: calc(100vw - 32px);
   border-radius: 14px;
   background: var(--card-bg, #fff);
-  color: var(--text-color, #222);
+  color: var(--text-primary, #222);
   border: 1px solid var(--border-color, rgba(127, 127, 127, 0.25));
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.22);
   animation: cookie-consent-in 0.32s ease forwards;
@@ -67,14 +67,14 @@
     color: var(--text-muted, #555);
   }
 
-  strong { color: var(--text-color, #222); }
+  strong { color: var(--text-primary, #222); }
 }
 
 .cookie-consent-link {
   padding: 0;
   border: none;
   background: none;
-  color: var(--accent-color, #e23a3a);
+  color: var(--accent-primary, #e23a3a);
   font-size: 0.76rem;
   font-weight: 600;
   cursor: pointer;
@@ -85,7 +85,7 @@
   margin: 10px 0;
   padding: 10px 12px;
   border-radius: 10px;
-  background: var(--hover-bg, rgba(127, 127, 127, 0.08));
+  background: var(--bg-hover, rgba(127, 127, 127, 0.08));
 
   ul {
     margin: 4px 0 0;
@@ -104,7 +104,7 @@
 .cookie-consent-cat-title {
   font-size: 0.76rem;
   font-weight: 700;
-  color: var(--text-color, #222);
+  color: var(--text-primary, #222);
 }
 
 .cookie-consent-note {
@@ -142,15 +142,15 @@
 
   /* Accept — accent fill. */
   &.primary {
-    background: var(--accent-color, #e23a3a);
+    background: var(--accent-primary, #e23a3a);
     color: #fff;
   }
 
   /* Decline the optional category — a solid neutral fill of equal prominence, NOT a
      transparent outline. Same visual weight as Accept; only the colour differs. */
   &.secondary {
-    background: var(--hover-bg, rgba(127, 127, 127, 0.16));
-    color: var(--text-color, #222);
+    background: var(--bg-hover, rgba(127, 127, 127, 0.16));
+    color: var(--text-primary, #222);
     border-color: var(--border-color, rgba(127, 127, 127, 0.35));
   }
 }

--- a/src/components/SettingsModal/DataRequestForm.scss
+++ b/src/components/SettingsModal/DataRequestForm.scss
@@ -9,16 +9,16 @@
 .drf-account {
   font-size: 0.82rem;
   color: var(--text-muted, #666);
-  strong { color: var(--text-color, #222); }
+  strong { color: var(--text-primary, #222); }
 }
 
 .drf-signin {
   padding: 14px;
   border-radius: 10px;
-  background: var(--hover-bg, rgba(127, 127, 127, 0.08));
+  background: var(--bg-hover, rgba(127, 127, 127, 0.08));
   font-size: 0.85rem;
   line-height: 1.5;
-  color: var(--text-color, #222);
+  color: var(--text-primary, #222);
 }
 
 /* Segmented "Get my data" / "Delete my account data" switch. */
@@ -27,7 +27,7 @@
   gap: 6px;
   padding: 4px;
   border-radius: 10px;
-  background: var(--hover-bg, rgba(127, 127, 127, 0.1));
+  background: var(--bg-hover, rgba(127, 127, 127, 0.1));
 }
 
 .drf-choice-btn {
@@ -36,7 +36,7 @@
   border: none;
   border-radius: 7px;
   background: transparent;
-  color: var(--text-color, #222);
+  color: var(--text-primary, #222);
   font-size: 0.85rem;
   font-weight: 600;
   cursor: pointer;
@@ -45,7 +45,7 @@
   &:hover { background: var(--card-bg, rgba(255, 255, 255, 0.5)); }
 
   &.active {
-    background: var(--accent-color, #e23a3a);
+    background: var(--accent-primary, #e23a3a);
     color: #fff;
   }
 }
@@ -54,13 +54,13 @@
   margin: 2px 0 0;
   font-size: 0.85rem;
   line-height: 1.45;
-  color: var(--text-color, #222);
+  color: var(--text-primary, #222);
 }
 
 .drf-scope {
   padding: 10px 12px;
   border-radius: 10px;
-  background: var(--hover-bg, rgba(127, 127, 127, 0.08));
+  background: var(--bg-hover, rgba(127, 127, 127, 0.08));
 
   ul {
     margin: 6px 0 0;
@@ -76,13 +76,13 @@
     color: var(--text-muted, #666);
   }
 
-  strong { color: var(--text-color, #222); }
+  strong { color: var(--text-primary, #222); }
 }
 
 .drf-scope-title {
   font-size: 0.78rem;
   font-weight: 700;
-  color: var(--text-color, #222);
+  color: var(--text-primary, #222);
 }
 
 /* The blockchain caveat. Deliberately loud: it is the one thing a user must read
@@ -97,7 +97,7 @@
     margin: 6px 0 0;
     font-size: 0.78rem;
     line-height: 1.45;
-    color: var(--text-color, #222);
+    color: var(--text-primary, #222);
   }
 }
 
@@ -111,7 +111,7 @@
   margin-top: 4px;
   font-size: 0.78rem;
   font-weight: 600;
-  color: var(--text-color, #222);
+  color: var(--text-primary, #222);
 }
 
 .drf-input,
@@ -121,13 +121,13 @@
   border: 1px solid var(--border-color, rgba(127, 127, 127, 0.3));
   border-radius: 8px;
   background: var(--card-bg, #fff);
-  color: var(--text-color, #222);
+  color: var(--text-primary, #222);
   font-size: 0.85rem;
   font-family: inherit;
 
   &:focus {
     outline: none;
-    border-color: var(--accent-color, #e23a3a);
+    border-color: var(--accent-primary, #e23a3a);
   }
 
   &::placeholder { color: var(--text-muted, #999); }
@@ -141,7 +141,7 @@
   align-items: flex-start;
   font-size: 0.78rem;
   line-height: 1.4;
-  color: var(--text-color, #222);
+  color: var(--text-primary, #222);
   cursor: pointer;
 
   input { margin-top: 2px; flex-shrink: 0; }
@@ -152,7 +152,7 @@
   padding: 10px 14px;
   border: none;
   border-radius: 8px;
-  background: var(--accent-color, #e23a3a);
+  background: var(--accent-primary, #e23a3a);
   color: #fff;
   font-size: 0.85rem;
   font-weight: 600;
@@ -168,25 +168,25 @@
   color: var(--text-muted, #666);
   text-align: center;
 
-  a { color: var(--accent-color, #e23a3a); }
+  a { color: var(--accent-primary, #e23a3a); }
 }
 
 .drf-done {
   padding: 14px;
   border-radius: 10px;
-  background: var(--hover-bg, rgba(127, 127, 127, 0.08));
+  background: var(--bg-hover, rgba(127, 127, 127, 0.08));
 
   h5 {
     margin: 0 0 6px;
     font-size: 0.95rem;
-    color: var(--text-color, #222);
+    color: var(--text-primary, #222);
   }
 
   p {
     margin: 0 0 6px;
     font-size: 0.82rem;
     line-height: 1.45;
-    color: var(--text-color, #222);
+    color: var(--text-primary, #222);
   }
 }
 

--- a/src/page/Legal.scss
+++ b/src/page/Legal.scss
@@ -2,7 +2,7 @@
   max-width: 820px;
   margin: 0 auto;
   padding: 24px 20px 64px;
-  color: var(--text-color, #1a1a1a);
+  color: var(--text-primary, #1a1a1a);
   line-height: 1.6;
 
   h1 {
@@ -17,7 +17,7 @@
 
   p, li { font-size: 0.92rem; }
 
-  a { color: var(--accent-color, #e23a3a); }
+  a { color: var(--accent-primary, #e23a3a); }
 
   section { margin-bottom: 8px; }
 
@@ -46,8 +46,8 @@
   padding: 14px 18px;
   margin: 16px 0 24px;
   border-radius: 12px;
-  border-left: 4px solid var(--accent-color, #e23a3a);
-  background: var(--hover-bg, rgba(127, 127, 127, 0.08));
+  border-left: 4px solid var(--accent-primary, #e23a3a);
+  background: var(--bg-hover, rgba(127, 127, 127, 0.08));
 
   h2 { margin-top: 0; }
 }
@@ -81,7 +81,7 @@
 .legal-note {
   padding: 10px 12px;
   border-radius: 8px;
-  background: var(--hover-bg, rgba(127, 127, 127, 0.08));
+  background: var(--bg-hover, rgba(127, 127, 127, 0.08));
 }
 
 /* Placeholders are visually obvious so a half-finished page can't masquerade as done. */


### PR DESCRIPTION
…nd legal pages

The GDPR-batch styles referenced CSS vars that don't exist in the theme (--text-color, --hover-bg, --accent-color), so dark mode fell back to light-theme colors: near-black text on the dark card background. Renamed to the real theme vars (--text-primary, --bg-hover, --accent-primary).