### PR TITLE
chore(deps): declare @dnd-kit/sortable (Spotlight drag-arrange)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@capacitor/cli": "^8.1.0",
     "@capacitor/core": "^8.1.0",
     "@capacitor/ios": "^8.1.0",
+    "@dnd-kit/sortable": "^10.0.0",
     "@ecency/render-helper": "^2.2.38",
     "@emoji-mart/data": "^1.2.1",
     "@emoji-mart/react": "^1.1.1",


### PR DESCRIPTION
The Spotlight ArrangeGrid uses @dnd-kit; it was only in node_modules, not package.json, so a clean install/build had no drag-and-drop dep. Matches the version preview builds with. The hangouts SDK file: pin stays intentionally uncommitted.