### PR TITLE
Feat/july fun

### DIFF
--- a/server/spotlight.js
+++ b/server/spotlight.js
@@ -200,6 +200,7 @@ function sanitizeSection(raw) {
         author, permlink,
         title: str(raw.title, 140),
         thumbnail: safeUrl(raw.thumbnail) || null,
+        isShort: !!raw.isShort, // shorts render in a 9:16 (vertical) player
       };
     }
     case 'embed': {
@@ -401,11 +402,24 @@ function renderSection(s, theme) {
     return cell(s.url ? `<a href="${esc(s.url)}" target="_blank" rel="noopener noreferrer nofollow">${img}</a>` : img);
   }
   if (s.type === 'video') {
-    // Direct iframe — the 3Speak player renders its OWN thumbnail/poster + play
-    // button, so no overlay is needed. `loading=lazy` defers offscreen players.
-    // Canonical embed = /watch?v=…&mode=iframe&layout=desktop (16:9) per EMBEDDING.md.
-    const embed = `https://play.3speak.tv/watch?v=${esc(s.author)}/${esc(s.permlink)}&mode=iframe&layout=desktop`;
-    return cell(`<div class="vid" style="${rad}${box}"><iframe src="${esc(embed)}" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>`);
+    // Our own SDK player, served same-origin at /embed/<author>/<permlink> (see
+    // src/page/EmbedPlayer.jsx) — NOT a play.3speak.tv iframe. `?short=1` => vertical.
+    const embed = `/embed/${esc(s.author)}/${esc(s.permlink)}${s.isShort ? '?short=1' : ''}`;
+    const vcls = s.isShort ? 'vid vid-short' : 'vid';
+    const frame = `<div class="${vcls}"><iframe src="${esc(embed)}" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>`;
+    const watch = `https://3speak.tv/watch?v=${esc(s.author)}/${esc(s.permlink)}`;
+    const title = s.title
+      ? `<a class="vtitle" href="${watch}" target="_blank" rel="noopener noreferrer nofollow">${esc(s.title)}</a>`
+      : '';
+    // ONE tile like a rich-link card. Defaults to the theme's section background (what
+    // the other blocks show) so it matches them; a per-block bg overrides. Border /
+    // shadow / font / radius / padding wrap the title + player together.
+    const cardBg = withOpacity(s.bg, s.bgOpacity) || theme.sectionBg || 'rgba(255,255,255,.08)';
+    const cardText = s.text || theme.sectionText || '#f5f5f7';
+    const cardRad = s.radius != null ? s.radius : (theme.radius != null ? theme.radius : 16);
+    const pad = s.padding != null ? `padding:${s.padding}px;` : 'padding:10px;';
+    const cardStyle = `${sfs}background:${esc(cardBg)};color:${esc(cardText)};border-radius:${cardRad}px;${pad}${box}`;
+    return cell(`<div class="vcard${s.isShort ? ' vcard-short' : ''}" style="${cardStyle}">${title}${frame}</div>`);
   }
   if (s.type === 'embed') {
     const aspect = embAspect(s.imgSize);
@@ -490,8 +504,15 @@ transition:transform .12s,filter .12s,box-shadow .12s}
 .ic{flex:0 0 auto;width:34px;height:34px;border-radius:50%;display:inline-flex;align-items:center;justify-content:center}
 .lt{flex:1 1 auto;min-width:0;text-align:center;margin-right:34px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .img{width:100%;display:block;object-fit:cover;border-radius:${theme.radius != null ? theme.radius : 16}px}
-.vid{position:relative;width:100%;aspect-ratio:16/9;overflow:hidden;background:#000;border-radius:${theme.radius != null ? theme.radius : 16}px;cursor:pointer}
-.vid img{width:100%;height:100%;object-fit:cover}.vid iframe{width:100%;height:100%;border:0}
+.vcard{display:flex;flex-direction:column;gap:8px;box-sizing:border-box}
+.vcard-short{max-width:340px;margin-left:auto;margin-right:auto}
+.vtitle{display:block;text-decoration:none;color:inherit;font-size:calc(14.5px*var(--fs)*var(--sfs,1));font-weight:600;line-height:1.3;transition:filter .12s}
+.vtitle:hover{filter:brightness(1.12)}
+.vid{position:relative;width:100%;aspect-ratio:16/9;overflow:hidden;background:#000;border-radius:${theme.radius != null ? theme.radius : 16}px}
+.vid::after{content:"";position:absolute;top:50%;left:50%;width:38px;height:38px;margin:-19px 0 0 -19px;border:3px solid rgba(255,255,255,.25);border-top-color:#fff;border-radius:50%;animation:vspin .8s linear infinite;z-index:0}
+.vid-short{aspect-ratio:9/16;max-width:100%;margin-left:auto;margin-right:auto}
+.vid img{width:100%;height:100%;object-fit:cover}.vid iframe{width:100%;height:100%;border:0;position:relative;z-index:1;background:transparent}
+@keyframes vspin{to{transform:rotate(360deg)}}
 .play{position:absolute;inset:0;margin:auto;width:60px;height:60px;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.55);border-radius:50%;transition:.12s}
 .vid:hover .play{transform:scale(1.08);background:#e53935}
 .vt{position:absolute;left:0;right:0;bottom:0;padding:20px 12px 10px;text-align:left;color:#fff;font-size:13px;font-weight:600;background:linear-gradient(transparent,rgba(0,0,0,.75))}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,6 +39,7 @@ import TagFeed from "./page/TagFeed";
 import Leaderboard from "./page/Leaderboard";
 import ProfilePage from "./page/ProfilePage";
 import Spotlight from "./page/Spotlight";
+import EmbedPlayer from "./page/EmbedPlayer";
 import Wallet from "./page/Wallet";
 import UserProfilePage from "./components/Userprofilepage/UserProfilePage";
 import DraftStudio from "./components/studio/DraftStudio";
@@ -475,6 +476,17 @@ function App() {
     setLoginModalOpen(false);
     loginInProgress.current = false;
     toast.success("Login successful!");
+  }
+
+  // Bare, chrome-free player route (iframed by the Spotlight /links page). Rendered
+  // WITHOUT the nav / context providers so the iframe is just the player. Wrapped in
+  // Routes/Route so EmbedPlayer's useParams() resolves author/permlink.
+  if (location.pathname.startsWith('/embed/')) {
+    return (
+      <Routes>
+        <Route path="/embed/:author/:permlink" element={<EmbedPlayer />} />
+      </Routes>
+    );
   }
 
   return (

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.77.0',
+    date: '2026-07-25',
+    summary:
+      'Spotlight link pages can now feature your videos and shorts, playing right on the page in the 3Speak player, with shorts shown vertically.',
+  },
+  {
     version: '1.76.0',
     date: '2026-07-24',
     summary:

--- a/src/components/Spotlight/SpotlightEditor.jsx
+++ b/src/components/Spotlight/SpotlightEditor.jsx
@@ -26,8 +26,10 @@ const STYLE_KEYS = [
   'animType', 'animSpeed', 'animLoop', 'animDur',
 ];
 import { uploadThumbnail } from '../../utils/uploadThumbnail';
-import { parseEmbedUrl, timeAgo } from '../../hive-api/hiveApi';
+import axios from 'axios';
+import { parseEmbedUrl, timeAgo, fetchUserShortsList, bodyToPlaintext } from '../../hive-api/hiveApi';
 import { getHiveClient } from '../../utils/hiveNode';
+import { CHECKER_URL } from '../../utils/config';
 import { isLoggedIn } from '../../hive-api/aioha';
 import './SpotlightEditor.scss';
 
@@ -94,57 +96,113 @@ function MotionControls({ prefix, obj, onChange }) {
 
 // The account's most recent 3Speak videos (own root posts flagged as 3speak/video),
 // for the video block's "choose from my videos" dropdown. bridge caps limit at 20.
+// Recent videos for a channel. Same call the profile Videos tab uses
+// (checker /api/my-videos, status:'all' + include_unlisted, axios) so the picker
+// behaves identically to a source the user already sees working.
 async function fetchRecentVideos(account) {
-  const posts = await getHiveClient().call('bridge', 'get_account_posts', { sort: 'posts', account, limit: 20 });
+  const res = await axios.get(`${CHECKER_URL}/api/my-videos`, {
+    params: {
+      username: account,
+      limit: 20,
+      offset: 0,
+      status: 'all',
+      sort: 'newest',
+      include_unlisted: 1,
+    },
+    headers: { 'Content-Type': 'application/json' },
+  });
+  const vids = res.data?.data?.videos || [];
   const out = [];
-  for (const p of (posts || [])) {
-    if (!p || p.author !== account) continue;
-    let jm = p.json_metadata;
-    if (typeof jm === 'string') { try { jm = JSON.parse(jm); } catch { jm = {}; } }
-    jm = jm || {};
-    if (!(/3speak/i.test(String(jm.app || '')) || jm.video)) continue;
-    const thumb = (Array.isArray(jm.image) && jm.image[0]) || '';
+  for (const v of vids) {
+    if (!v || !v.permlink || v.status === 'uploaded') continue; // skip incomplete uploads
+    const thumb = (v.images && (v.images.thumbnail || v.images.poster)) || '';
     out.push({
-      author: p.author, permlink: p.permlink, title: p.title || 'Untitled',
-      thumbnail: /^https?:\/\//i.test(thumb) ? thumb : '', created: p.created,
+      author: v.owner || v.author || account,
+      permlink: v.permlink,
+      title: v.title || 'Untitled',
+      thumbnail: /^https?:\/\//i.test(thumb) ? thumb : '',
+      created: v.created_at || v.createdAt || v.created,
     });
   }
   return out;
 }
 
+// Recent shorts for a channel, via the same helper the profile Shorts tab uses.
+async function fetchRecentShorts(account) {
+  const data = await fetchUserShortsList(account, 1, 20, true);
+  const shorts = (data && Array.isArray(data.shorts)) ? data.shorts : [];
+  const out = [];
+  for (const s of shorts) {
+    if (!s || !s.permlink) continue;
+    const thumb = s.thumbnail_url || '';
+    // Shorts rarely have a title, so use the first words of the post body — the same
+    // caption the profile Shorts tab shows (bodyToPlaintext(hive_body)).
+    const caption = (bodyToPlaintext(s.hive_body) || s.hive_title || s.embed_title || '').slice(0, 100).trim();
+    out.push({
+      author: s.owner || account,
+      permlink: s.permlink,
+      title: caption || 'Short',
+      thumbnail: /^https?:\/\//i.test(thumb) ? thumb : '',
+      created: s.createdAt || s.created,
+    });
+  }
+  return out;
+}
+
+// Per-kind config for the media picker dropdown (videos and shorts share the UI).
+const MEDIA_PICKERS = {
+  video: { fetch: fetchRecentVideos, label: 'Choose from my videos', loading: 'Loading your videos…', empty: 'No recent 3Speak videos found.' },
+  short: { fetch: fetchRecentShorts, label: 'Choose from my shorts', loading: 'Loading your shorts…', empty: 'No recent 3Speak shorts found.' },
+};
+
 // Thumbnail + title + "how long ago" dropdown that fills a video block on pick.
-function VideoPicker({ username, onPick }) {
+// kind picks the source: 'video' → published videos, 'short' → shorts.
+function MediaPicker({ username, kind = 'video', onPick }) {
+  const cfg = MEDIA_PICKERS[kind] || MEDIA_PICKERS.video;
   const [open, setOpen] = useState(false);
-  const [vids, setVids] = useState(null);
+  const [items, setItems] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState(null);
+  // Cache the username we've already loaded so reopening doesn't refetch. NOT using
+  // `items`/`loading` as effect deps: setLoading(true) would re-run this effect, whose
+  // cleanup flips `alive` false on the in-flight request, so the response is discarded
+  // and it hangs on "Loading…" forever. Effect runs only on open/username/kind change.
+  const loadedFor = useRef(null);
   useEffect(() => {
-    if (!open || vids || loading || !username) return undefined;
+    if (!open || !username || loadedFor.current === username) return undefined;
     let alive = true;
-    setLoading(true);
-    fetchRecentVideos(username)
-      .then((v) => { if (alive) setVids(v); })
-      .catch(() => { if (alive) setVids([]); })
+    setLoading(true); setErr(null);
+    cfg.fetch(username)
+      .then((v) => { if (alive) { setItems(v); loadedFor.current = username; } })
+      .catch((e) => { if (alive) { setErr(e?.message || String(e)); setItems([]); } })
       .finally(() => { if (alive) setLoading(false); });
     return () => { alive = false; };
-  }, [open, username, vids, loading]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, username, kind]);
   return (
     <div className="sp-e-vpick">
       <button type="button" className={`sp-e-vpick-btn${open ? ' open' : ''}`} onClick={() => setOpen((o) => !o)}>
-        <span><FiVideo size={14} /> Choose from my videos</span>
+        <span><FiVideo size={14} /> {cfg.label}</span>
         <FiChevronDown className="sp-e-chev" size={15} />
       </button>
       {open && (
-        <div className="sp-e-vpick-menu">
+        <div className={`sp-e-vpick-menu sp-e-vpick-menu--${kind}`}>
           {loading ? (
-            <div className="sp-e-vpick-note">Loading your videos…</div>
-          ) : !vids || !vids.length ? (
-            <div className="sp-e-vpick-note">No recent 3Speak videos found.</div>
-          ) : vids.map((v) => (
+            <div className="sp-e-vpick-note">{cfg.loading}</div>
+          ) : !username ? (
+            <div className="sp-e-vpick-note">No channel detected (are you logged in?)</div>
+          ) : err ? (
+            <div className="sp-e-vpick-note">Couldn’t load: {err}</div>
+          ) : !items || !items.length ? (
+            <div className="sp-e-vpick-note">{cfg.empty} <span style={{ opacity: 0.6 }}>[@{username}]</span></div>
+          ) : items.map((v) => (
             <button type="button" key={`${v.author}/${v.permlink}`} className="sp-e-vpick-item"
-              onClick={() => { onPick(v); setOpen(false); }}>
-              {v.thumbnail
-                ? <img className="sp-e-vpick-thumb" src={v.thumbnail} alt="" loading="lazy" />
-                : <span className="sp-e-vpick-thumb sp-e-vpick-noimg"><FiVideo size={16} /></span>}
+              onClick={() => { onPick(v); setOpen(false); }} title={v.title}>
+              <span className="sp-e-vpick-tile">
+                {v.thumbnail
+                  ? <img src={v.thumbnail} alt="" loading="lazy" />
+                  : <FiVideo className="sp-e-vpick-tile-ico" size={18} />}
+              </span>
               <span className="sp-e-vpick-meta">
                 <span className="sp-e-vpick-title">{v.title}</span>
                 <span className="sp-e-vpick-time">{timeAgo(v.created)}</span>
@@ -193,8 +251,8 @@ function SectionCard({ section, onChange, onRemove, onApplyStyleToType, uploadin
 
   const onVideoPaste = async (raw) => {
     const { author, permlink } = parseEmbedUrl(raw) || {};
-    if (!author || !permlink) { set({ author: '', permlink: raw }); return; }
-    set({ author: author.toLowerCase(), permlink, thumbnail: null });
+    if (!author || !permlink) { set({ author: '', permlink: raw, isShort: false }); return; }
+    set({ author: author.toLowerCase(), permlink, thumbnail: null, isShort: false });
     try {
       const post = await getHiveClient().call('bridge', 'get_post', { author, permlink });
       let jm = post?.json_metadata;
@@ -328,18 +386,34 @@ function SectionCard({ section, onChange, onRemove, onApplyStyleToType, uploadin
 
         {section.type === 'video' && (
           <>
-            <VideoPicker username={username}
-              onPick={(v) => set({ author: v.author, permlink: v.permlink, title: v.title, thumbnail: v.thumbnail || null })} />
+            <div className="sp-e-vmode" role="radiogroup" aria-label="Content type">
+              <label className={`sp-e-vmode-opt${!section.isShort ? ' active' : ''}`}>
+                <input type="radio" name={`vmode-${section.id}`} checked={!section.isShort}
+                  onChange={() => set({ isShort: false })} />
+                <FiVideo size={13} /> Video
+              </label>
+              <label className={`sp-e-vmode-opt${section.isShort ? ' active' : ''}`}>
+                <input type="radio" name={`vmode-${section.id}`} checked={!!section.isShort}
+                  onChange={() => set({ isShort: true })} />
+                <FiVideo size={13} /> Short
+              </label>
+            </div>
+            <MediaPicker key={section.isShort ? 'short' : 'video'} username={username} kind={section.isShort ? 'short' : 'video'}
+              onPick={(v) => set({ author: v.author, permlink: v.permlink, title: v.title, thumbnail: v.thumbnail || null, isShort: !!section.isShort })} />
             <div className="sp-e-vpick-or"><span>or paste a link</span></div>
             <input className="sp-e-input" placeholder="Paste a 3Speak video link or author/permlink"
               defaultValue={section.author && section.permlink ? `${section.author}/${section.permlink}` : ''}
               onBlur={(e) => onVideoPaste(e.target.value)} />
             {section.author && section.permlink ? (
-              <div className="sp-e-videochip">
-                {section.thumbnail ? <img src={section.thumbnail} alt="" /> : null}
-                <span>{section.title || `${section.author}/${section.permlink}`}</span>
-              </div>
-            ) : <div className="sp-e-hint">Selected video will embed and play on your page.</div>}
+              <>
+                <div className="sp-e-videochip">
+                  {section.thumbnail ? <img src={section.thumbnail} alt="" /> : null}
+                  <span>{section.title || `${section.author}/${section.permlink}`}</span>
+                </div>
+                <input className="sp-e-input" placeholder="Title shown above the video (links to 3Speak)"
+                  value={section.title || ''} onChange={(e) => set({ title: e.target.value })} />
+              </>
+            ) : <div className="sp-e-hint">Selected content will embed and play on your page.</div>}
           </>
         )}
 
@@ -390,7 +464,7 @@ function SectionCard({ section, onChange, onRemove, onApplyStyleToType, uploadin
         )}
 
         {(() => {
-          const hasBg = section.type === 'link' || section.type === 'header' || section.type === 'embed';
+          const hasBg = section.type === 'link' || section.type === 'header' || section.type === 'embed' || section.type === 'video';
           const borderOn = (section.borderWidth ?? 0) > 0;
           const shadowOn = (section.shadowOpacity ?? 0) > 0;
           return (
@@ -528,7 +602,23 @@ export default function SpotlightEditor({ username }) {
   const setTheme = (patch) => markDirty({ ...layout, theme: { ...theme, ...patch } });
   const setBg = (patch) => markDirty({ ...layout, theme: { ...theme, bg: { ...theme.bg, ...patch } } });
 
-  const addSection = (type) => markDirty({ ...layout, sections: [...sections, { ...newSection(type), id: uid() }] });
+  // A newly added block inherits the visual style (background / border / shadow / font
+  // / anim) already in use — each setting taken from the most recent block that has it
+  // (preferring the same type, falling back to any block), so e.g. the background color
+  // is picked up even if it lives on a block of a different type.
+  const inheritedStyle = (type) => {
+    const out = {};
+    const recent = [...sections].reverse();
+    for (const k of STYLE_KEYS) {
+      const src = recent.find((s) => s.type === type && s[k] !== undefined)
+               || recent.find((s) => s[k] !== undefined);
+      if (src) out[k] = src[k];
+    }
+    return out;
+  };
+  const newBlock = (type) => ({ ...newSection(type), ...inheritedStyle(type), id: uid() });
+
+  const addSection = (type) => markDirty({ ...layout, sections: [...sections, newBlock(type)] });
   const changeSection = (next) => markDirty({ ...layout, sections: sections.map((s) => (s.id === next.id ? next : s)) });
   // Re-normalise widths after a delete so a row-mate of a removed half/third
   // reflows to fill the row (otherwise it'd keep its old width + leave a gap).
@@ -778,7 +868,7 @@ export default function SpotlightEditor({ username }) {
       <div className="sp-e-glabel">Add a block</div>
       <div className="sp-e-add">
         {SECTION_TYPES.map(({ type, label, Icon }) => (
-          <button type="button" key={type} onClick={() => { const s = { ...newSection(type), id: uid() }; markDirty({ ...layout, sections: [...sections, s] }); setSelectedId(s.id); }}><Icon size={15} /> {label}</button>
+          <button type="button" key={type} onClick={() => { const s = newBlock(type); markDirty({ ...layout, sections: [...sections, s] }); setSelectedId(s.id); }}><Icon size={15} /> {label}</button>
         ))}
       </div>
 

--- a/src/components/Spotlight/SpotlightEditor.scss
+++ b/src/components/Spotlight/SpotlightEditor.scss
@@ -271,6 +271,16 @@
   .sp-e-embchip-t { font-size: 13px; font-weight: 700; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .sp-e-embchip-d { font-size: 12px; color: var(--text-secondary); line-height: 1.35; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
 
+  // ── video/short mode toggle (segmented radio) ──
+  .sp-e-vmode { display: flex; gap: 4px; padding: 4px; background: var(--sp-hover); border-radius: 10px; }
+  .sp-e-vmode-opt {
+    flex: 1; display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+    padding: 7px 10px; border-radius: 7px; font-size: 12.5px; font-weight: 600; cursor: pointer;
+    color: var(--text-secondary); transition: background 0.12s, color 0.12s;
+    input { position: absolute; opacity: 0; pointer-events: none; }
+    svg { opacity: 0.8; }
+    &.active { background: var(--bg-primary, #0f0f0f); color: var(--text-primary); box-shadow: 0 1px 3px rgba(0,0,0,0.25); }
+  }
   // ── video picker dropdown (choose from my videos) ──
   .sp-e-vpick { position: relative; }
   .sp-e-vpick-btn {
@@ -284,22 +294,32 @@
     &:hover { border-color: var(--sp-accent); }
   }
   .sp-e-vpick-menu {
-    margin-top: 6px; max-height: 292px; overflow-y: auto; scrollbar-width: thin;
+    margin-top: 6px; max-height: 380px; overflow-y: auto; scrollbar-width: thin;
     border: 1px solid var(--sp-border); border-radius: 10px; background: var(--bg-primary, #0f0f0f);
-    display: flex; flex-direction: column; padding: 4px;
+    display: grid; gap: 8px; padding: 8px;
+    grid-template-columns: repeat(2, 1fr); // videos: 2-up 16:9
   }
-  .sp-e-vpick-note { padding: 16px; text-align: center; font-size: 12.5px; color: var(--text-secondary); }
+  .sp-e-vpick-menu--short { grid-template-columns: repeat(3, 1fr); } // shorts: 3-up 9:16
+  .sp-e-vpick-note { grid-column: 1 / -1; padding: 18px; text-align: center; font-size: 12.5px; color: var(--text-secondary); }
   .sp-e-vpick-item {
-    display: flex; align-items: center; gap: 10px; width: 100%; text-align: left;
-    padding: 6px; border: none; border-radius: 8px; background: transparent; cursor: pointer;
+    display: flex; flex-direction: column; gap: 6px; width: 100%; text-align: left;
+    padding: 6px; border: none; border-radius: 10px; background: transparent; cursor: pointer;
     transition: background 0.1s;
     &:hover { background: var(--sp-hover); }
   }
-  .sp-e-vpick-thumb { flex: 0 0 auto; width: 64px; height: 38px; object-fit: cover; border-radius: 6px; background: var(--sp-hover); }
-  .sp-e-vpick-noimg { display: inline-flex; align-items: center; justify-content: center; color: var(--text-secondary); }
-  .sp-e-vpick-meta { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
-  .sp-e-vpick-title { font-size: 13px; font-weight: 600; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .sp-e-vpick-time { font-size: 11px; color: var(--text-secondary); }
+  .sp-e-vpick-tile {
+    width: 100%; aspect-ratio: 16 / 9; border-radius: 8px; overflow: hidden;
+    background: var(--sp-hover); display: flex; align-items: center; justify-content: center;
+    img { width: 100%; height: 100%; object-fit: cover; display: block; }
+    .sp-e-vpick-tile-ico { color: var(--text-secondary); }
+  }
+  .sp-e-vpick-menu--short .sp-e-vpick-tile { aspect-ratio: 9 / 16; }
+  .sp-e-vpick-meta { min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+  .sp-e-vpick-title {
+    font-size: 12px; font-weight: 600; color: var(--text-primary); line-height: 1.25;
+    display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+  }
+  .sp-e-vpick-time { font-size: 10.5px; color: var(--text-secondary); }
   .sp-e-vpick-or {
     display: flex; align-items: center; gap: 10px; margin: 2px 0;
     span { font-size: 10.5px; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; }
@@ -414,10 +434,14 @@
     span:last-child { flex: 1 1 auto; min-width: 0; text-align: center; margin-right: 26px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   }
   .sp-e-pv-img { width: 100%; max-height: 200px; object-fit: cover; display: block; }
+  .sp-e-pv-vcard { display: flex; flex-direction: column; gap: 6px; box-sizing: border-box; }
+  .sp-e-pv-vcard.short { max-width: 210px; margin-left: auto; margin-right: auto; }
+  .sp-e-pv-vtitle { font-weight: 600; line-height: 1.3; overflow-wrap: anywhere; }
   .sp-e-pv-video {
     position: relative; width: 100%; aspect-ratio: 16/9; overflow: hidden; background: #000;
     img { width: 100%; height: 100%; object-fit: cover; }
     span { position: absolute; inset: 0; margin: auto; width: 40px; height: 40px; display: flex; align-items: center; justify-content: center; color: #fff; background: rgba(0,0,0,0.5); border-radius: 50%; font-size: 14px; }
+    &.short { aspect-ratio: 9/16; max-width: 100%; }
   }
 
   // ── drag-to-arrange grid (ArrangeGrid) — compact tiles ──

--- a/src/components/Spotlight/SpotlightPreview.jsx
+++ b/src/components/Spotlight/SpotlightPreview.jsx
@@ -28,9 +28,20 @@ function Block({ s, theme }) {
     return s.src ? <img className="sp-e-pv-img" src={s.src} alt="" style={{ borderRadius: radius }} /> : null;
   }
   if (s.type === 'video' && s.permlink) {
+    const cardStyle = {
+      background: s.bg || theme.sectionBg || 'rgba(255,255,255,0.08)',
+      color: s.text || theme.sectionText || undefined,
+      borderRadius: radius,
+      fontSize: `calc(13px * ${s.fontScale ? s.fontScale / 100 : 1})`,
+      padding: 8,
+      border: s.borderWidth ? `${s.borderWidth}px solid ${s.borderColor || '#000'}` : undefined,
+    };
     return (
-      <div className="sp-e-pv-video" style={{ borderRadius: radius }}>
-        <img src={s.thumbnail || `https://img.3speak.tv/${s.permlink}/thumbnail.png`} alt="" /><span>▶</span>
+      <div className={`sp-e-pv-vcard${s.isShort ? ' short' : ''}`} style={cardStyle}>
+        {s.title ? <div className="sp-e-pv-vtitle">{s.title}</div> : null}
+        <div className={`sp-e-pv-video${s.isShort ? ' short' : ''}`} style={{ borderRadius: radius }}>
+          <img src={s.thumbnail || `https://img.3speak.tv/${s.permlink}/thumbnail.png`} alt="" /><span>▶</span>
+        </div>
       </div>
     );
   }

--- a/src/page/EmbedPlayer.jsx
+++ b/src/page/EmbedPlayer.jsx
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+import { usePlayer } from '@mantequilla-soft/3speak-player/react';
+import { getPlayerUrl } from '../utils/playerUrl';
+import './EmbedPlayer.scss';
+
+// Bare, chrome-free 3Speak player used INSIDE the Spotlight /links page (iframed).
+// Mirrors the watch/shorts technique: usePlayer + a <video> element, resolving the
+// HLS source from author/permlink via the SDK's apiBase (getPlayerUrl) — no
+// play.3speak.tv iframe. `?short=1` renders it for a vertical 9:16 frame. Shorts do
+// NOT autoplay. The page is kept transparent so the parent iframe's own loading
+// spinner (.vid::after) shows through until the poster/first frame paints.
+export default function EmbedPlayer() {
+  const { author, permlink } = useParams();
+  const [sp] = useSearchParams();
+  const isShort = sp.get('short') === '1';
+  const [attached, setAttached] = useState(false);
+
+  const a = String(author || '').toLowerCase();
+  const p = String(permlink || '').toLowerCase();
+  const valid = /^[a-z][a-z0-9.\-]{2,15}$/.test(a) && /^[a-z0-9-]{1,255}$/.test(p);
+
+  const {
+    ref: sdkVideoRef,
+    player,
+    load: loadVideo,
+  } = usePlayer({
+    apiBase: getPlayerUrl(),
+    muted: false,
+    loop: isShort, // a short loops once it's playing — but never autoplays
+    poster: true,  // SDK paints the thumbnail/poster + play affordance
+  });
+
+  // Keep the document transparent so the parent's loading spinner shows through
+  // until the player paints. Restored on unmount (SPA safety).
+  useEffect(() => {
+    const els = [document.documentElement, document.body, document.getElementById('root')].filter(Boolean);
+    const prev = els.map((el) => el.style.background);
+    els.forEach((el) => { el.style.background = 'transparent'; });
+    return () => { els.forEach((el, i) => { el.style.background = prev[i]; }); };
+  }, []);
+
+  const videoRef = useCallback((el) => {
+    sdkVideoRef(el);
+    setAttached(!!el);
+  }, [sdkVideoRef]);
+
+  useEffect(() => {
+    if (!valid || !player || !attached) return;
+    loadVideo(`${a}/${p}`).catch(() => {});
+  }, [valid, a, p, player, attached, loadVideo]);
+
+  if (!valid) return <div className="emb-player emb-player--err">Video unavailable</div>;
+
+  return (
+    <div className={`emb-player${isShort ? ' short' : ''}`}>
+      <video ref={videoRef} playsInline controls loop={isShort} />
+    </div>
+  );
+}

--- a/src/page/EmbedPlayer.scss
+++ b/src/page/EmbedPlayer.scss
@@ -1,0 +1,30 @@
+// Full-bleed player for the iframed Spotlight /links embed. Fills whatever aspect
+// the parent iframe is (16:9 for video, 9:16 for a short). Transparent until the
+// video paints so the parent's .vid::after loading spinner shows through.
+.emb-player {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+
+  video {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    background: transparent;
+    display: block;
+  }
+
+  // A short's source is already 9:16, so fill the vertical frame edge-to-edge.
+  &.short video { object-fit: cover; }
+
+  &--err {
+    color: #9aa0a6;
+    font: 500 14px/1.4 system-ui, -apple-system, sans-serif;
+  }
+}

--- a/src/page/Spotlight.jsx
+++ b/src/page/Spotlight.jsx
@@ -66,21 +66,43 @@ function fxStyle(s) {
 
 // Direct 3Speak embed — the player renders its own thumbnail/poster + play button.
 // `loading="lazy"` defers offscreen players. Canonical: /watch?v=…&mode=iframe (16:9).
-function VideoBlock({ section, radius, fx }) {
+function VideoBlock({ section, radius, fx, theme }) {
   // Only render for a well-formed Hive author/permlink (guards the iframe URL).
   const author = String(section.author || '').toLowerCase();
   const permlink = String(section.permlink || '').toLowerCase();
   if (!/^[a-z][a-z0-9.\-]{2,15}$/.test(author) || !/^[a-z0-9-]{1,255}$/.test(permlink)) return null;
-  const src = `https://play.3speak.tv/watch?v=${author}/${permlink}&mode=iframe&layout=desktop`;
+  const isShort = !!section.isShort;
+  // Our own same-origin SDK player (src/page/EmbedPlayer.jsx), not a play.3speak.tv iframe.
+  const src = `/embed/${author}/${permlink}${isShort ? '?short=1' : ''}`;
+  // ONE tile like a rich-link card. Defaults to the theme's section background (what
+  // the other blocks show) so it matches them; a per-block bg overrides.
+  const cardBg = (section.bg ? withOpacity(safeColor(section.bg), num(section.bgOpacity, 100)) : null)
+    || safeColor(theme?.sectionBg) || 'rgba(255,255,255,0.08)';
+  const cardStyle = {
+    background: cardBg,
+    color: safeColor(section.text) || safeColor(theme?.sectionText) || undefined,
+    borderRadius: radius,
+    fontSize: `calc(14.5px * ${section.fontScale ? section.fontScale / 100 : 1})`,
+    padding: section.padding != null ? num(section.padding) : 10,
+    ...fx,
+  };
+  const watch = `https://3speak.tv/watch?v=${author}/${permlink}`;
   return (
-    <div className="sp-video" style={{ borderRadius: radius, ...fx }}>
-      <iframe
-        src={src}
-        title={section.title || `${author}/${permlink}`}
-        loading="lazy"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowFullScreen
-      />
+    <div className={`sp-video-card${isShort ? ' short' : ''}`} style={cardStyle}>
+      {section.title ? (
+        <a className="sp-video-title" href={watch} target="_blank" rel="noopener noreferrer nofollow">
+          {section.title}
+        </a>
+      ) : null}
+      <div className={`sp-video${isShort ? ' sp-video-short' : ''}`} style={{ borderRadius: radius }}>
+        <iframe
+          src={src}
+          title={section.title || `${author}/${permlink}`}
+          loading="lazy"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+        />
+      </div>
     </div>
   );
 }
@@ -160,7 +182,7 @@ function Section({ section, theme, username }) {
       : img;
   }
 
-  if (section.type === 'video') return <VideoBlock section={section} radius={radius} fx={fx} />;
+  if (section.type === 'video') return <VideoBlock section={section} radius={radius} fx={fx} theme={theme} />;
 
   if (section.type === 'embed') return <EmbedBlock section={section} theme={theme} username={username} />;
 

--- a/src/page/Spotlight.scss
+++ b/src/page/Spotlight.scss
@@ -142,6 +142,14 @@
   .sp-embed-d { margin-top: 6px; font-size: 13px; line-height: 1.45; opacity: 0.82; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
 
   // ── video (lazy embed) ──
+  .sp-video-card { display: flex; flex-direction: column; gap: 8px; box-sizing: border-box; }
+  .sp-video-card.short { max-width: 340px; margin-left: auto; margin-right: auto; }
+  .sp-video-title {
+    display: block; text-decoration: none; color: inherit;
+    font-weight: 600; line-height: 1.3; transition: filter 0.12s;
+    &:hover { filter: brightness(1.12); }
+  }
+
   .sp-video {
     width: 100%;
     aspect-ratio: 16 / 9;
@@ -149,7 +157,15 @@
     background: #000;
     position: relative;
 
-    iframe { width: 100%; height: 100%; border: 0; display: block; }
+    &.sp-video-short { aspect-ratio: 9 / 16; max-width: 100%; }
+
+    &::after {
+      content: ""; position: absolute; top: 50%; left: 50%; width: 38px; height: 38px;
+      margin: -19px 0 0 -19px; border: 3px solid rgba(255, 255, 255, 0.25); border-top-color: #fff;
+      border-radius: 50%; animation: sp-vspin 0.8s linear infinite; z-index: 0;
+    }
+
+    iframe { width: 100%; height: 100%; border: 0; display: block; position: relative; z-index: 1; background: transparent; }
 
     .sp-video-poster {
       width: 100%;
@@ -218,3 +234,5 @@
 }
 
 @keyframes sp-spin { to { transform: rotate(360deg); } }
+
+@keyframes sp-vspin { to { transform: rotate(360deg); } }

--- a/src/sw.js
+++ b/src/sw.js
@@ -13,11 +13,14 @@ clientsClaim();
 precacheAndRoute(self.__WB_MANIFEST);
 cleanupOutdatedCaches();
 
-// SPA navigation fallback (exclude hivesigner callback)
+// SPA navigation fallback. Denylist = routes that must hit the network instead of
+// the cached SPA shell: the hivesigner callback, and the server-rendered Spotlight
+// link pages (/links/<user> and legacy /@<user>/links) which are standalone HTML
+// from the API, NOT part of the React app.
 const navHandler = createHandlerBoundToURL('/index.html');
 registerRoute(
   new NavigationRoute(navHandler, {
-    denylist: [/^\/hivesigner\.html/],
+    denylist: [/^\/hivesigner\.html/, /^\/links\//, /^\/@[^/]+\/links\/?$/],
   })
 );
 

--- a/src/utils/spotlight.js
+++ b/src/utils/spotlight.js
@@ -259,7 +259,7 @@ export function newSection(type) {
     case 'header': return { id, type: 'header', text: 'Section title', size: 'md', align: 'center' };
     case 'link': return { id, type: 'link', title: '', url: '', icon: 'link', iconColor: null, iconBg: null };
     case 'image': return { id, type: 'image', src: '', alt: '', url: null };
-    case 'video': return { id, type: 'video', author: '', permlink: '', title: '', thumbnail: null };
+    case 'video': return { id, type: 'video', author: '', permlink: '', title: '', thumbnail: null, isShort: false };
     case 'embed': return { id, type: 'embed', source: 'link', url: '', title: '', description: '', image: null, siteName: '', imgSize: 55, count: 3, perRow: 1 };
     default: return { id, type: 'link', title: '', url: '', icon: 'link' };
   }
@@ -267,7 +267,7 @@ export function newSection(type) {
 
 export const SECTION_TYPES = [
   { type: 'link', label: 'Link', Icon: FaLink },
-  { type: 'video', label: '3Speak video', Icon: FaVideo },
+  { type: 'video', label: '3Speak content', Icon: FaVideo },
   { type: 'embed', label: 'Rich link', Icon: FaShareNodes },
   { type: 'image', label: 'Image', Icon: FaCamera },
   { type: 'header', label: 'Title / text', Icon: FaStar },

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.76.0';
+export const APP_VERSION = '1.77.0';


### PR DESCRIPTION
This pull request adds first-class support for 3Speak Shorts alongside regular videos in the Spotlight editor and player, and improves the overall user experience for adding and displaying video content. The changes introduce a "Short" mode for video blocks, a unified media picker for both videos and shorts, and update the rendering and styling to support vertical (9:16) short videos. Additionally, newly added blocks now inherit visual styles from recent blocks for consistency.

**Spotlight video/shorts support and UI improvements:**

* Added support for 3Speak Shorts as a distinct mode in video blocks, including a toggle to choose between "Video" and "Short" and a new media picker for recent shorts (`SpotlightEditor.jsx`, `spotlight.js`). [[1]](diffhunk://#diff-df0cfdf24711182fa76641cfa0c11f3b9da58cd6b889c04f88f5a750e6eb9f80R99-R205) [[2]](diffhunk://#diff-df0cfdf24711182fa76641cfa0c11f3b9da58cd6b889c04f88f5a750e6eb9f80L331-R416) [[3]](diffhunk://#diff-df0cfdf24711182fa76641cfa0c11f3b9da58cd6b889c04f88f5a750e6eb9f80L196-R255) [[4]](diffhunk://#diff-5bb8bf2c64f27098b1d080b0c71eeb8eed2f18a40514cc43406acebcb1d2107dR203)
* Updated the Spotlight editor's media picker to fetch and display both recent videos and shorts, with improved error handling and UI feedback (`SpotlightEditor.jsx`). [[1]](diffhunk://#diff-df0cfdf24711182fa76641cfa0c11f3b9da58cd6b889c04f88f5a750e6eb9f80R99-R205) [[2]](diffhunk://#diff-df0cfdf24711182fa76641cfa0c11f3b9da58cd6b889c04f88f5a750e6eb9f80L331-R416)
* Video blocks now render using a same-origin `/embed/:author/:permlink` player route, with `?short=1` for vertical shorts, and display a styled card with title and player (`spotlight.js`, `App.jsx`). [[1]](diffhunk://#diff-5bb8bf2c64f27098b1d080b0c71eeb8eed2f18a40514cc43406acebcb1d2107dL404-R422) [[2]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R42) [[3]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R481-R491)

**Styling and layout enhancements:**

* Added new CSS for short video cards, vertical aspect ratios, and the video/short mode toggle in the editor, ensuring consistent and visually distinct presentation for shorts (`spotlight.js`, `SpotlightEditor.scss`). [[1]](diffhunk://#diff-5bb8bf2c64f27098b1d080b0c71eeb8eed2f18a40514cc43406acebcb1d2107dL493-R515) [[2]](diffhunk://#diff-ef37fa99b614e6d7cbe565d8ec25a666bf99cee5b791ce39e4d8d3a4cffadd01R274-R283)
* New blocks added in the Spotlight editor now inherit visual style properties (background, border, etc.) from the most recent blocks, improving design consistency (`SpotlightEditor.jsx`). [[1]](diffhunk://#diff-df0cfdf24711182fa76641cfa0c11f3b9da58cd6b889c04f88f5a750e6eb9f80L531-R621) [[2]](diffhunk://#diff-df0cfdf24711182fa76641cfa0c11f3b9da58cd6b889c04f88f5a750e6eb9f80L781-R871)

These changes significantly enhance the video/shorts workflow in Spotlight, making it easier to add, distinguish, and display both content types with improved UI and style inheritance.