### PR TITLE
Feat/july fun

### DIFF
--- a/server/index.cjs
+++ b/server/index.cjs
@@ -141,6 +141,72 @@ function clearSessionCookie(res) {
   res.clearCookie(PKCE_COOKIE_NAME, { path: '/' })
 }
 
+// === ButrAuth refresh token (RFC 6749 §6) ===
+// The access token above lives ONE HOUR. Without this the session simply ended
+// there and every proxied op 401'd, because /api/broadcast could no longer tell
+// who the user was. The refresh token is long-lived, httpOnly, and ROTATED on
+// every use — so it is replaced on each refresh and a replay of the old value
+// revokes the whole chain server-side.
+const REFRESH_COOKIE_NAME = 'threespeak_refresh'
+const REFRESH_TTL_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
+
+function setRefreshCookie(res, refreshToken) {
+  res.cookie(REFRESH_COOKIE_NAME, refreshToken, {
+    httpOnly: true, secure: true, sameSite: 'lax', maxAge: REFRESH_TTL_MS, path: '/'
+  })
+}
+function clearRefreshCookie(res) {
+  res.clearCookie(REFRESH_COOKIE_NAME, { path: '/' })
+}
+
+// Call ButrAuth's token endpoint directly. The published SDK (0.2.0) has no
+// refresh grant and its exchangeCode drops `refresh_token`, so both flows go
+// through here; swap to client.refreshAccessToken() once a newer SDK ships.
+async function butrTokenRequest(body) {
+  const r = await fetch(`${MANTEAUTH_URL}/api/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ...body, client_id: MANTEAUTH_CLIENT_ID, client_secret: MANTEAUTH_CLIENT_SECRET })
+  })
+  const data = await r.json().catch(() => ({}))
+  return { ok: r.ok, status: r.status, data }
+}
+
+/**
+ * Resolve the ButrAuth user for a request, transparently refreshing an expired
+ * access token. Returns the Hive username, or null when there is no usable
+ * session. On a successful refresh the rotated tokens are written back as
+ * cookies, so the caller's response carries the renewed session.
+ */
+async function resolveButrUser(req, res) {
+  const cookieToken = req.cookies?.[SESSION_COOKIE_NAME]
+  if (cookieToken) {
+    const tokenData = await verifyManteAuthToken(cookieToken)
+    if (tokenData?.hiveUsername) return tokenData.hiveUsername
+  }
+  const refreshToken = req.cookies?.[REFRESH_COOKIE_NAME]
+  if (!refreshToken) {
+    if (cookieToken) clearSessionCookie(res) // expired with nothing to renew from
+    return null
+  }
+  try {
+    const { ok, data } = await butrTokenRequest({ grant_type: 'refresh_token', refresh_token: refreshToken })
+    if (!ok || !data.access_token) {
+      // Refused (expired, revoked, or a detected replay) — drop both cookies so
+      // the user is cleanly logged out instead of retrying a dead token forever.
+      clearRefreshCookie(res)
+      clearSessionCookie(res)
+      return null
+    }
+    setSessionCookie(res, data.access_token, data.username)
+    if (data.refresh_token) setRefreshCookie(res, data.refresh_token)
+    return data.username
+  } catch (err) {
+    console.warn('[butrauth] refresh failed:', err.message)
+    return null // transient (ButrAuth down): keep the cookies, retry next request
+  }
+}
+
 function setPkceCookie(res, verifier) {
   // httpOnly cookie carrying the PKCE verifier across the auth redirect.
   // 2 hours — the verifier is set at the START of the flow, so it must outlive
@@ -359,19 +425,46 @@ app.post('/api/manteauth/exchange', exchangeLimiter, async (req, res) => {
     if (!butr) return res.status(503).json({ error: 'ButrAuth not ready' })
 
     let tokens
+    let refreshToken = null
     try {
-      tokens = await butr.exchangeCode({
+      // Direct call so the response's refresh_token survives (the SDK drops it).
+      // Any transport failure falls back to the SDK, which is the proven path.
+      const { ok, data } = await butrTokenRequest({
         code,
-        redirectUri: redirect_uri,
-        codeVerifier: code_verifier
+        redirect_uri,
+        code_verifier,
+        grant_type: 'authorization_code'
       })
-    } catch (err) {
-      clearPkceCookie(res)
-      return res.status(401).json({ error: err.message || 'Token exchange failed' })
+      if (!ok || !data.access_token) {
+        clearPkceCookie(res)
+        return res.status(401).json({ error: data.error || 'Token exchange failed' })
+      }
+      tokens = { accessToken: data.access_token, username: data.username }
+      refreshToken = data.refresh_token || null
+    } catch {
+      try {
+        tokens = await butr.exchangeCode({
+          code,
+          redirectUri: redirect_uri,
+          codeVerifier: code_verifier
+        })
+      } catch (err) {
+        clearPkceCookie(res)
+        return res.status(401).json({ error: err.message || 'Token exchange failed' })
+      }
     }
     clearPkceCookie(res)
 
     setSessionCookie(res, tokens.accessToken, tokens.username)
+    // The access token lasts an hour; the refresh token renews it for 30 days
+    // (see resolveButrUser). Without it the session died at the hour mark and
+    // every proxied op 401'd.
+    if (refreshToken) setRefreshCookie(res, refreshToken)
+    // Belt and braces: also mint our own signed session, the same stateless
+    // 30-day token wallet logins use (auth path 2 in /api/broadcast). It keeps
+    // the user working even if a refresh is ever refused.
+    const buser = String(tokens.username || '').toLowerCase()
+    if (buser && SESSION_SIGNING_SECRET) setWalletSessionCookie(res, mintWalletSession(buser))
     res.json({ username: tokens.username })
   } catch (err) {
     console.error('Exchange error:', err.message)
@@ -396,6 +489,10 @@ app.get('/api/manteauth/me', baseLimiter, async (req, res) => {
 app.post('/api/manteauth/logout', baseLimiter, (req, res) => {
   console.log('[logout] clearing cookies for:', Object.keys(req.cookies || {}))
   clearSessionCookie(res)
+  // A ButrAuth login also carries the refresh token and our own signed session —
+  // clear both, or logging out would leave the user able to act.
+  clearRefreshCookie(res)
+  clearWalletSessionCookie(res)
   res.json({ success: true })
 })
 
@@ -570,13 +667,10 @@ app.post('/api/broadcast', broadcastLimiter, async (req, res) => {
   try {
     let hiveUsername = null
 
-    // 1) ButrAuth httpOnly session cookie
-    const cookieToken = req.cookies?.[SESSION_COOKIE_NAME]
-    if (cookieToken) {
-      const tokenData = await verifyManteAuthToken(cookieToken)
-      if (tokenData?.hiveUsername) hiveUsername = tokenData.hiveUsername
-      else clearSessionCookie(res)
-    }
+    // 1) ButrAuth httpOnly session cookie — auto-refreshed when the (1 hour)
+    //    access token has expired, so the session lasts as long as the refresh
+    //    token rather than dying mid-use.
+    hiveUsername = await resolveButrUser(req, res)
 
     // 2) SIWH wallet session cookie (Keychain/HiveAuth/PeakVault/Ledger): the
     //    user proved posting-key control at login, so the username is bound to a

--- a/server/index.cjs
+++ b/server/index.cjs
@@ -744,12 +744,10 @@ app.post('/api/broadcast', broadcastLimiter, async (req, res) => {
 
 // Resolve the acting Hive user from cookie → HiveSigner token → app-key+username.
 async function resolveDelegatedSignUser(req, res) {
-  const cookieToken = req.cookies?.[SESSION_COOKIE_NAME]
-  if (cookieToken) {
-    const tokenData = await verifyManteAuthToken(cookieToken)
-    if (tokenData?.hiveUsername) return tokenData.hiveUsername.toLowerCase()
-    clearSessionCookie(res)
-  }
+  // Same auto-refresh as /api/broadcast — otherwise the OpenPods / chat handover
+  // silently broke an hour after login while broadcasting still worked.
+  const butrUser = await resolveButrUser(req, res)
+  if (butrUser) return butrUser.toLowerCase()
   const authHeader = req.headers.authorization || ''
   const bearer = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : ''
   if (bearer) {

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.78.4',
+    date: '2026-07-29',
+    summary:
+      'Video cards on community pages now show the topic and comment count, matching the cards in the feeds and on profiles.',
+  },
+  {
     version: '1.78.3',
     date: '2026-07-28',
     summary:

--- a/src/components/Cards/Card3.jsx
+++ b/src/components/Cards/Card3.jsx
@@ -323,7 +323,10 @@ function Card3({ videos = [], loading = false, error = null, interleaveEvery = 0
                 <CommentCount
                   count={(() => {
                     const author = video.author?.username || video.author || video.owner;
-                    return getContentForVideo?.(author, video.permlink)?.children ?? null;
+                    // Fall back to the feed's cached count (video-stats), same as
+                    // payout/votes above — feed items have has_stats:true so the
+                    // client-side content batch skips them and children is absent.
+                    return getContentForVideo?.(author, video.permlink)?.children ?? video.stats?.num_comments ?? null;
                   })()}
                 />
               </div>

--- a/src/components/UploadLinks.jsx
+++ b/src/components/UploadLinks.jsx
@@ -5,7 +5,7 @@ import { Clapperboard } from "lucide-react";
 import { MdGraphicEq, MdDesktopWindows, MdSmartphone, MdGroups } from "react-icons/md";
 import { BiCommentDetail } from "react-icons/bi";
 import ShortsIcon from "./icons/ShortsIcon";
-import { FEATURE_EDITOR, ENABLE_OPENPODS } from "../utils/config";
+import { FEATURE_EDITOR, openpodsEnabledFor } from "../utils/config";
 import { getCreatorSettings, isUploadBlocked } from "../utils/creatorSettings";
 import { useSupportBlock } from "../lib/supportBlockStore";
 import { useAppStore } from "../lib/store";
@@ -79,8 +79,9 @@ export default function UploadLinks({ linkClass, iconClass = "icon", onClick }) 
       </a>
 
       {/* OpenPods live streaming — the whole "Live" category is gated behind
-          VITE_ENABLE_OPENPODS (off by default). */}
-      {ENABLE_OPENPODS && (
+          VITE_ENABLE_OPENPODS (off by default), plus an always-on allowlist of
+          test accounts (see openpodsEnabledFor). */}
+      {openpodsEnabledFor(user) && (
         <>
           <div className="share-menu-heading">Live</div>
           <Link

--- a/src/components/embed-studio/EmbedCameraRecord.jsx
+++ b/src/components/embed-studio/EmbedCameraRecord.jsx
@@ -7,7 +7,8 @@ import {
 import { useEmbedUpload } from '../../context/EmbedUploadContext';
 import { useVoiceTeleprompter } from '../../hooks/useVoiceTeleprompter';
 import { generateVideoThumbnails } from '../../utils/videoThumbnails';
-import { ENABLE_CAMERA_RECORD, SHORTS_MAX_DURATION_SEC, STT_WS_URL } from '../../utils/config';
+import { cameraRecordEnabledFor, SHORTS_MAX_DURATION_SEC, STT_WS_URL } from '../../utils/config';
+import { useAppStore } from '../../lib/store';
 import { detectScriptLang, modelIdToTag } from '../../utils/detectLang';
 import { createSttStream } from '../../utils/sttClient';
 import './EmbedCameraRecord.scss';
@@ -147,6 +148,7 @@ function useMovable(storageKey, makeDefault) {
 function EmbedCameraRecord() {
   const navigate = useNavigate();
   const location = useLocation();
+  const user = useAppStore((s) => s.user);
   const {
     fromStories, setFromStories, setVideoFile, setPrevVideoFile,
     setVideoDuration, setGeneratedThumbnail, setVideoMode,
@@ -793,7 +795,7 @@ function EmbedCameraRecord() {
     navigate('/embed-studio');
   };
 
-  if (!ENABLE_CAMERA_RECORD) return <Navigate to="/embed-studio" replace />;
+  if (!cameraRecordEnabledFor(user)) return <Navigate to="/embed-studio" replace />;
 
   const capLabel = fromStories && isFinite(shortsCap) ? ` / ${fmtTime(shortsCap)}` : '';
   const showBox = (phase === 'setup' || phase === 'recording') && tp.totalWords > 0;

--- a/src/components/embed-studio/EmbedVideoUploadStep1.jsx
+++ b/src/components/embed-studio/EmbedVideoUploadStep1.jsx
@@ -14,7 +14,7 @@ import { useAppStore } from '../../lib/store';
 import { canUseUploadFaults, getUploadFaults, setUploadFaults, initUploadFaults } from '../../utils/uploadFaults';
 import { checkPostingRc } from '../../utils/rcCheck';
 import RcInsufficientModal from './RcInsufficientModal';
-import { SHORTS_MAX_DURATION_SEC, shortsMaxDurationLabel, ENABLE_CAMERA_RECORD } from '../../utils/config';
+import { SHORTS_MAX_DURATION_SEC, shortsMaxDurationLabel, cameraRecordEnabledFor } from '../../utils/config';
 import { isChromium } from '../../utils/browser';
 
 function EmbedVideoUploadStep1() {
@@ -432,7 +432,7 @@ function EmbedVideoUploadStep1() {
               ) : loading ? (
                 <TailChase size="30" speed="1.75" color="red" />
               ) : !videoFile ? (
-                (ENABLE_CAMERA_RECORD && isMobile && isChromium()) ? (
+                (cameraRecordEnabledFor(faultUser) && isMobile && isChromium()) ? (
                   // Mobile + Chromium only (Web Speech API): record straight from
                   // the front camera with a voice-driven teleprompter, or pick a file.
                   <div className="button-group">

--- a/src/components/playVideo/EditVideoModal.jsx
+++ b/src/components/playVideo/EditVideoModal.jsx
@@ -438,6 +438,15 @@ export default function EditVideoModal({ isOpen, onClose, author, permlink, onSa
           throw new Error("This post has no embed video entry to replace — its metadata doesn't reference one.");
         }
         await registerMediaReplacement(newAsset.permlink, originalAssetPermlink);
+        // A fresh, playable source means any "deleted"/unavailable shadow-ban no
+        // longer applies — clear it so the badge drops. Best-effort + idempotent.
+        if (CHECKER_API_KEY) {
+          axios.post(
+            `${CHECKER_URL}/video/reinstate`,
+            { owner: author, permlink },
+            { headers: { Authorization: `Bearer ${CHECKER_API_KEY}` } },
+          ).catch((e) => console.warn('Reinstate (clear unavailable) failed:', e?.message));
+        }
         // No toast here — the single success toast at the end carries the
         // encoding caveat, so a replacement doesn't fire two in a row.
       }

--- a/src/hooks/useSeekPreview.js
+++ b/src/hooks/useSeekPreview.js
@@ -34,9 +34,9 @@ export default function useSeekPreview({ videoId, trackRef, duration, getPlaybac
   const loadedRef = useRef(false); // lazy: only load the stream on first interaction
   const pendingRef = useRef(null); // latest requested preview time
   const [preview, setPreview] = useState({ visible: false, leftPx: 0, time: 0 });
-  // True when this video has no small rung to preview cheaply — we then show the
-  // timestamp only, instead of spawning a second loader for the SAME 480p segments
-  // the main player is already streaming. See lowResPreviewPlayer requirePreviewRung.
+  // Kept for the callers' "timestamp only" styling. Nothing sets it any more — the
+  // rung-based suppression that did is gone (see the createLowResPreviewPlayer note
+  // below) — but the flag stays so a future cheap-preview policy can reuse it.
   const [frameless, setFrameless] = useState(false);
 
   // Apply the pending seek only when the element is idle; the 'seeked' handler
@@ -59,13 +59,13 @@ export default function useSeekPreview({ videoId, trackRef, duration, getPlaybac
     const el = videoRef.current;
     if (!videoId || !el) return undefined;
 
+    // NOTE: deliberately NOT passing requirePreviewRung. 3Speak videos ship a SINGLE
+    // 480p rung, so "is the lowest rung smaller than what playback uses?" is never
+    // true and that guard suppressed the frame on effectively every video. Instead we
+    // bound the cost by only loading while the user is actually scrubbing (below).
     const player = createLowResPreviewPlayer(el, {
       loop: false,
-      // Don't compete with playback: if the video's smallest rung isn't smaller than
-      // the rung the main player is on, skip the frame and show the time only.
-      requirePreviewRung: true,
       getPlaybackHeight,
-      onNoPreviewRung: () => setFrameless(true),
     });
     playerRef.current = player;
 
@@ -109,6 +109,10 @@ export default function useSeekPreview({ videoId, trackRef, duration, getPlaybac
   }, [trackRef, duration, applySeek, ensureLoaded]);
 
   const hide = useCallback(() => {
+    // Only hide the box. Do NOT stop the underlying stream: tearing segment loading
+    // down on mouseleave left the element half-buffered (a black frame) and it did
+    // not recover on the next hover. The stream is lazy, pinned to the lowest rung
+    // and capped at a 10s buffer, so leaving it alone is the cheap, working state.
     setPreview((p) => (p.visible ? { ...p, visible: false } : p));
   }, []);
 

--- a/src/lib/lowResPreviewPlayer.js
+++ b/src/lib/lowResPreviewPlayer.js
@@ -49,6 +49,36 @@ export function createLowResPreviewPlayer(videoEl, { loop = false, requirePrevie
   });
   player.attach(videoEl);
 
+  // A rung is a real "preview rung" only if it's genuinely small — a 240p/360p
+  // ladder step. A 480p+ lowest rung costs about as much as playback itself.
+  const isCheapRung = (lvl) =>
+    !lvl ? false : lvl.height ? lvl.height <= 360 : (lvl.bitrate || Infinity) <= 500000;
+
+  const findLowest = (levels) => {
+    if (!levels || !levels.length) return -1;
+    let lo = 0;
+    for (let i = 1; i < levels.length; i++) {
+      if ((levels[i].bitrate || Infinity) < (levels[lo].bitrate || Infinity)) lo = i;
+    }
+    return lo;
+  };
+
+  // Would this preview just re-download what playback already streams? Skip if the
+  // smallest rung isn't smaller than the main player's CURRENT rung. When that
+  // height is unknown (native HLS, not yet settled), fall back to a static cutoff:
+  // only a genuinely-small rung (≤360p) earns a separate stream.
+  const wouldDuplicate = (levels, lo) => {
+    const playH = (typeof getPlaybackHeight === 'function' ? getPlaybackHeight() : 0) || 0;
+    const lowH = levels[lo].height || 0;
+    return playH > 0 ? lowH >= playH : !isCheapRung(levels[lo]);
+  };
+
+  const pinTo = (hls, lo) => {
+    if ((hls.levels || []).length < 2) return; // single rendition — nothing to choose
+    hls.autoLevelCapping = lo; // ABR may never climb above the smallest
+    hls.currentLevel = lo;     // and start there immediately
+  };
+
   // Lock to the lowest-bitrate rendition as soon as the manifest's levels are
   // known — order-independent, so it's correct for both encoders. player.hls is
   // created synchronously inside load(), so it exists by the time load() resolves.
@@ -57,34 +87,16 @@ export function createLowResPreviewPlayer(videoEl, { loop = false, requirePrevie
     const res = await origLoad(refOrSource);
     const hls = player.hls;
     if (hls) {
-      // A rung is a real "preview rung" only if it's genuinely small — a 240p/360p
-      // ladder step. A 480p+ lowest rung costs about as much as playback itself.
-      const isCheapRung = (lvl) =>
-        !lvl ? false : lvl.height ? lvl.height <= 360 : (lvl.bitrate || Infinity) <= 500000;
       const pinLowest = () => {
         const levels = hls.levels || [];
-        if (!levels.length) return;
-        let lo = 0;
-        for (let i = 1; i < levels.length; i++) {
-          if ((levels[i].bitrate || Infinity) < (levels[lo].bitrate || Infinity)) lo = i;
+        const lo = findLowest(levels);
+        if (lo < 0) return;
+        if (requirePreviewRung && wouldDuplicate(levels, lo)) {
+          try { hls.stopLoad(); } catch { /* noop */ }
+          if (onNoPreviewRung) onNoPreviewRung();
+          return;
         }
-        // Would this preview just re-download what playback already streams? Skip if
-        // the smallest rung isn't smaller than the main player's CURRENT rung. When
-        // that height is unknown (native HLS, not yet settled), fall back to a static
-        // cutoff: only a genuinely-small rung (≤360p) earns a separate stream.
-        if (requirePreviewRung) {
-          const playH = (typeof getPlaybackHeight === 'function' ? getPlaybackHeight() : 0) || 0;
-          const lowH = levels[lo].height || 0;
-          const wouldDuplicate = playH > 0 ? lowH >= playH : !isCheapRung(levels[lo]);
-          if (wouldDuplicate) {
-            try { hls.stopLoad(); } catch { /* noop */ }
-            if (onNoPreviewRung) onNoPreviewRung();
-            return;
-          }
-        }
-        if (levels.length < 2) return; // single rendition — nothing to choose
-        hls.autoLevelCapping = lo; // ABR may never climb above the smallest
-        hls.currentLevel = lo;     // and start there immediately
+        pinTo(hls, lo);
       };
       if (hls.levels && hls.levels.length) pinLowest();
       else hls.once(Hls.Events.MANIFEST_PARSED, pinLowest);

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -199,6 +199,11 @@ const OPENPODS_STANDALONE = import.meta.env.VITE_OPENPODS_STANDALONE !== 'false'
 // Gates the OpenPods live-streaming options in the create/share menu (the whole
 // "Live" category). OFF by default — set VITE_ENABLE_OPENPODS=true to show it.
 const ENABLE_OPENPODS = import.meta.env.VITE_ENABLE_OPENPODS === 'true';
+// These accounts can always see/test OpenPods regardless of VITE_ENABLE_OPENPODS,
+// so the team can keep testing while it stays hidden for everyone else.
+const OPENPODS_ALWAYS_USERS = ['badadib', 'meno', 'tibfox', 'coolmole'];
+const openpodsEnabledFor = (user) =>
+  ENABLE_OPENPODS || (!!user && OPENPODS_ALWAYS_USERS.includes(String(user).toLowerCase()));
 
 // Hosts whose live streams / rooms are kept OUT of the discovery feeds
 // (discover, follow, new). Same spirit as the checker's LEADERBOARD_EXCLUDED_USERS
@@ -276,6 +281,7 @@ export {
   ENABLE_SUBS,
   OPENPODS_STANDALONE,
   ENABLE_OPENPODS,
+  openpodsEnabledFor,
   FEED_EXCLUDED_HOSTS,
   ENABLE_CAMERA_RECORD,
   STT_WS_URL,

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -199,11 +199,12 @@ const OPENPODS_STANDALONE = import.meta.env.VITE_OPENPODS_STANDALONE !== 'false'
 // Gates the OpenPods live-streaming options in the create/share menu (the whole
 // "Live" category). OFF by default — set VITE_ENABLE_OPENPODS=true to show it.
 const ENABLE_OPENPODS = import.meta.env.VITE_ENABLE_OPENPODS === 'true';
-// These accounts can always see/test OpenPods regardless of VITE_ENABLE_OPENPODS,
-// so the team can keep testing while it stays hidden for everyone else.
-const OPENPODS_ALWAYS_USERS = ['badadib', 'meno', 'tibfox', 'coolmole'];
-const openpodsEnabledFor = (user) =>
-  ENABLE_OPENPODS || (!!user && OPENPODS_ALWAYS_USERS.includes(String(user).toLowerCase()));
+// These accounts can always see/test preview-gated features (OpenPods, the
+// camera-record teleprompter) regardless of the env flags, so the team can keep
+// testing on prod while the features stay hidden for everyone else.
+const ALWAYS_ON_TEST_USERS = ['badadib', 'meno', 'tibfox', 'coolmole'];
+const isTestUser = (user) => !!user && ALWAYS_ON_TEST_USERS.includes(String(user).toLowerCase());
+const openpodsEnabledFor = (user) => ENABLE_OPENPODS || isTestUser(user);
 
 // Hosts whose live streams / rooms are kept OUT of the discovery feeds
 // (discover, follow, new). Same spirit as the checker's LEADERBOARD_EXCLUDED_USERS
@@ -220,6 +221,9 @@ const FEED_EXCLUDED_HOSTS = new Set(
 // (prototype). When on, the video upload step shows a "Record" button on phones
 // that opens a front-camera recording page. Off unless explicitly "true".
 const ENABLE_CAMERA_RECORD = import.meta.env.VITE_ENABLE_CAMERA_RECORD === 'true';
+// Always-on for the test accounts (see ALWAYS_ON_TEST_USERS) so they can keep
+// testing the teleprompter regardless of VITE_ENABLE_CAMERA_RECORD.
+const cameraRecordEnabledFor = (user) => ENABLE_CAMERA_RECORD || isTestUser(user);
 
 // Self-hosted streaming speech-to-text WebSocket for the teleprompter. Empty =
 // use the browser Web Speech API only (which can't share the mic with the audio
@@ -284,6 +288,7 @@ export {
   openpodsEnabledFor,
   FEED_EXCLUDED_HOSTS,
   ENABLE_CAMERA_RECORD,
+  cameraRecordEnabledFor,
   STT_WS_URL,
   ENABLE_PPL,
   THREESPEAK_AUDIO_API_URL,

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.78.3';
+export const APP_VERSION = '1.78.4';


### PR DESCRIPTION
This pull request introduces several important improvements and fixes across authentication/session handling, video playback, feature gating, and UI consistency. The main highlights are the implementation of refresh tokens for ButrAuth sessions, smarter video seek preview handling, more flexible feature flags, and UI polish for video cards and moderation tools.

**Authentication and Session Management:**

* Added refresh token support for ButrAuth sessions, enabling sessions to auto-renew and last up to 30 days instead of expiring after one hour. This includes issuing, rotating, and clearing refresh tokens, and updating `/api/manteauth/exchange`, `/api/manteauth/logout`, and `/api/broadcast` handlers to use the new logic. (`server/index.cjs`) [[1]](diffhunk://#diff-546d8ea40577568b90ed41739d01efc62fa56bb2d1f21f994393e22460973023R144-R209) [[2]](diffhunk://#diff-546d8ea40577568b90ed41739d01efc62fa56bb2d1f21f994393e22460973023R428-R444) [[3]](diffhunk://#diff-546d8ea40577568b90ed41739d01efc62fa56bb2d1f21f994393e22460973023R455-R467) [[4]](diffhunk://#diff-546d8ea40577568b90ed41739d01efc62fa56bb2d1f21f994393e22460973023R492-R495) [[5]](diffhunk://#diff-546d8ea40577568b90ed41739d01efc62fa56bb2d1f21f994393e22460973023L573-R673) [[6]](diffhunk://#diff-546d8ea40577568b90ed41739d01efc62fa56bb2d1f21f994393e22460973023L653-R750)

**Video Playback and Seek Preview:**

* Simplified the seek preview logic so that video frame previews are now always shown while scrubbing, removing the previous suppression when only a 480p rung was available. The preview stream is now loaded only during active scrubbing, and segment loading is not torn down on mouseleave to avoid black frames. (`src/hooks/useSeekPreview.js`, `src/lib/lowResPreviewPlayer.js`) [[1]](diffhunk://#diff-2c3a443adcebe35144e135a3470610c4e7de86ee20f24c99995d281ec20ccb4aL37-R39) [[2]](diffhunk://#diff-2c3a443adcebe35144e135a3470610c4e7de86ee20f24c99995d281ec20ccb4aR62-L68) [[3]](diffhunk://#diff-2c3a443adcebe35144e135a3470610c4e7de86ee20f24c99995d281ec20ccb4aR112-R115) [[4]](diffhunk://#diff-05e7a1313d8a6dc7e291b22aedd95c6d5c1a7f089aa8e73d9aa7cd33f91c87f4L52-R99)

**Feature Gating Improvements:**

* Replaced global feature flags like `ENABLE_OPENPODS` and `ENABLE_CAMERA_RECORD` with user-aware functions (`openpodsEnabledFor`, `cameraRecordEnabledFor`) to allow for per-user or allowlist-based feature access. Updated all relevant components to use the new gating logic. (`src/components/UploadLinks.jsx`, `src/components/embed-studio/EmbedCameraRecord.jsx`, `src/components/embed-studio/EmbedVideoUploadStep1.jsx`, `src/utils/config`) [[1]](diffhunk://#diff-be05db7e74e65ffa776e9eda78c4958e5cb68751245dd735bde1f989424e11b1L8-R8) [[2]](diffhunk://#diff-be05db7e74e65ffa776e9eda78c4958e5cb68751245dd735bde1f989424e11b1L82-R84) [[3]](diffhunk://#diff-36dbdbbd6a43de5007ae0ceebc66cb2901bf66e00746b3cf02a5c77c9f70ca14L10-R11) [[4]](diffhunk://#diff-36dbdbbd6a43de5007ae0ceebc66cb2901bf66e00746b3cf02a5c77c9f70ca14R151) [[5]](diffhunk://#diff-36dbdbbd6a43de5007ae0ceebc66cb2901bf66e00746b3cf02a5c77c9f70ca14L796-R798) [[6]](diffhunk://#diff-53735a493d200f68f173a1929fdfac6394ad58b8be8b454a931ca6b4a33b11e0L17-R17) [[7]](diffhunk://#diff-53735a493d200f68f173a1929fdfac6394ad58b8be8b454a931ca6b4a33b11e0L435-R435)

**UI/UX and Community Features:**

* Video cards on community pages now display topic and comment count, matching the UI in feeds and profiles. The comment count falls back to the cached count if live data is unavailable. (`src/changelog.js`, `src/components/Cards/Card3.jsx`) [[1]](diffhunk://#diff-2b5b164299e9a44e90c14ae81c0182d162656fec55e07d328651882df8c9c689R9-R14) [[2]](diffhunk://#diff-6ae7ad9f53a84c22304bfcdf83c50291913cbf8416e58c0dcc6e1627e6105d85L326-R329)

**Moderation and Video Availability:**

* When a video is replaced with a new source, any "deleted"/unavailable shadow-ban is cleared by notifying the checker API, so the badge is removed. (`src/components/playVideo/EditVideoModal.jsx`)