### PR TITLE
Feat/july fun

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@mantequilla-soft/3speak-player": "^0.3.2",
         "@rajesh896/video-thumbnails-generator": "^2.3.9",
         "@reduxjs/toolkit": "^2.6.1",
-        "@snapie/chat-client": "^0.2.0",
+        "@snapie/chat-client": "^0.3.0",
         "@snapie/hangouts-core": "^0.14.2",
         "@snapie/hangouts-react": "^0.20.0",
         "@snapie/renderer": "^0.1.1",
@@ -4765,9 +4765,10 @@
       }
     },
     "node_modules/@snapie/chat-client": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@snapie/chat-client/-/chat-client-0.2.0.tgz",
-      "integrity": "sha512-ltKBw1rCpbuvqzkNjxtu3NxWqAR5Jn8a0qmH6Fl6nahZASF6DsrSRZGdqHu/dNCa8Y4p604Q5ffsWCkeOCEP2A==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@snapie/chat-client/-/chat-client-0.3.0.tgz",
+      "integrity": "sha512-1+V9B4jqV89NDs9OZtnm7G0xk3LOhUSikTCFl+TxovrO/Nz0UoYRZmdWvQyiNcCLyYqf/TXANq2n2SSBINXc/w==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@mantequilla-soft/3speak-player": "^0.3.2",
     "@rajesh896/video-thumbnails-generator": "^2.3.9",
     "@reduxjs/toolkit": "^2.6.1",
-    "@snapie/chat-client": "^0.2.0",
+    "@snapie/chat-client": "^0.3.0",
     "@snapie/hangouts-core": "^0.14.2",
     "@snapie/hangouts-react": "^0.20.0",
     "@snapie/renderer": "^0.1.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -130,6 +130,8 @@ import { useAioha } from "@aioha/react-ui";
 import LoginModal from "./components/LoginModal/LoginModal";
 import ActiveAuthModal from "./components/ActiveAuthModal/ActiveAuthModal";
 import InterestsPrompt from "./components/InterestsPrompt/InterestsPrompt";
+import WelcomePrompt from "./components/WelcomePrompt/WelcomePrompt";
+import AvatarSync from "./components/HiveAvatar/AvatarSync";
 import EditorModal from "./components/modal/EditorModal";
 import { FEATURE_EDITOR } from "./utils/config";
 import BottomNav from "./components/BottomNav/BottomNav";
@@ -665,6 +667,10 @@ function App() {
           }}
         />
         <ActiveAuthModal />
+        <AvatarSync />
+        {/* Welcome first, interests after — WelcomePrompt claims the modal slot
+            so the two never stack (see utils/welcomeGate). */}
+        <WelcomePrompt />
         <InterestsPrompt />
         {FEATURE_EDITOR && (
           <EditorModal

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,48 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.78.11',
+    date: '2026-08-03',
+    summary:
+      'Discover leans a little more on the newest uploads, hovering a short shows its description, and the suggested creators row now scrolls with arrows.',
+  },
+  {
+    version: '1.78.10',
+    date: '2026-08-03',
+    summary:
+      'Chat keeps your unread count in step with your messages, and you can clear them all at once with Mark all as read on the chat page (/chat).',
+  },
+  {
+    version: '1.78.9',
+    date: '2026-08-03',
+    summary:
+      'Mobile navigation update: the + button for sharing moved up to the top bar, and Chat now sits in the middle of the bottom bar with your unread count on it.',
+  },
+  {
+    version: '1.78.8',
+    date: '2026-08-03',
+    summary:
+      'New on the home page: a row of the creators you follow who posted something you have not watched yet, showing how many new shorts and videos each of them has.',
+  },
+  {
+    version: '1.78.7',
+    date: '2026-08-03',
+    summary:
+      'Profiles now lead with your display name, with your @username and location underneath and a bigger profile picture.',
+  },
+  {
+    version: '1.78.6',
+    date: '2026-08-03',
+    summary:
+      'New to 3Speak? A short welcome introduces what you can do here: videos, shorts, live streams and communities, and helps you set up your profile in one step.',
+  },
+  {
+    version: '1.78.5',
+    date: '2026-08-03',
+    summary:
+      'You can now edit your profile on 3Speak: press Edit (or your picture) on your profile page to set your profile picture, display name, bio and location. It saves to your Hive account, so every Hive app shows it.',
+  },
+  {
     version: '1.78.4',
     date: '2026-07-29',
     summary:

--- a/src/components/AuthorBadge/AuthorBadge.jsx
+++ b/src/components/AuthorBadge/AuthorBadge.jsx
@@ -7,7 +7,9 @@ import { useAppStore } from '../../lib/store';
 import PremiumBadge from '../PremiumBadge/PremiumBadge';
 import './AuthorBadge.scss';
 
-function AuthorBadge({ author, onClick, followersCount, fetchFollowers, showFollow, isFollowing: isFollowingProp, onFollow, noLink, compact, reputation, color, tabHint }) {
+// `subtitle` replaces the followers line — used by rails that describe the
+// creator by something other than their follower count ("3 shorts / 2 videos").
+function AuthorBadge({ author, onClick, followersCount, fetchFollowers, showFollow, isFollowing: isFollowingProp, onFollow, noLink, compact, reputation, color, tabHint, subtitle }) {
   const navigate = useNavigate();
   const { user } = useAppStore();
   const [localFollowers, setLocalFollowers] = useState(null);
@@ -91,7 +93,9 @@ function AuthorBadge({ author, onClick, followersCount, fetchFollowers, showFoll
           <span className="author-name">@{author}{reputation != null ? ` (${Math.round(reputation)})` : ''}</span>
           <PremiumBadge username={author} size={11} />
         </span>
-        {displayFollowers != null && (
+        {subtitle ? (
+          <span className="followers-count">{subtitle}</span>
+        ) : displayFollowers != null && (
           <span className="followers-count">{displayFollowers} Followers</span>
         )}
       </div>

--- a/src/components/BottomNav/BottomNav.jsx
+++ b/src/components/BottomNav/BottomNav.jsx
@@ -1,5 +1,5 @@
 import { Link, useLocation, useNavigate } from "react-router-dom";
-import { MdOutlineSearch, MdOutlineDownload, MdGraphicEq, MdSettings, MdAdd, MdTrendingUp } from "react-icons/md";
+import { MdOutlineSearch, MdOutlineDownload, MdGraphicEq, MdSettings, MdTrendingUp } from "react-icons/md";
 import { IoAddCircleOutline, IoPower, IoCloudUploadSharp, IoShareOutline } from "react-icons/io5";
 import { IoMdPerson } from "react-icons/io";
 import { HiInformationCircle } from "react-icons/hi";
@@ -8,10 +8,11 @@ import { RiWallet3Fill } from "react-icons/ri";
 import { FaDiscord } from "react-icons/fa";
 import { FaSquareXTwitter, FaMedal, FaChartBar } from "react-icons/fa6";
 import { SiTelegram } from "react-icons/si";
-import { Clapperboard } from "lucide-react";
+import { Clapperboard, MessageCircle } from "lucide-react";
 import { useAppStore } from "../../lib/store";
+import { useChat } from "../../context/ChatContext";
+import { useServerUnread } from "../../hooks/useServerUnread";
 import ShortsIcon from "../icons/ShortsIcon";
-import UploadLinks from "../UploadLinks";
 import SettingsModal from "../SettingsModal/SettingsModal";
 import { FEATURE_EDITOR } from "../../utils/config";
 import { APP_VERSION } from "../../version";
@@ -24,6 +25,16 @@ import logo from "../../assets/image/3S_logo.svg";
 import logoDark from "../../assets/image/3S_logodark.png";
 import "./BottomNav.scss";
 
+// Split out so the polling subscription only exists while the badge is actually
+// rendered (mobile + connected chat). Server-truth count, never a local tally.
+function BottomNavChatBadge() {
+  const { unreadCount } = useServerUnread();
+  if (!unreadCount) return null;
+  return (
+    <span className="bottom-nav-chat-badge">{unreadCount > 9 ? "9+" : unreadCount}</span>
+  );
+}
+
 const BottomNav = ({ openLoginModal }) => {
   const location = useLocation();
   const navigate = useNavigate();
@@ -31,10 +42,21 @@ const BottomNav = ({ openLoginModal }) => {
   const isManteAuth = localStorage.getItem("manteauth_login") === "true";
   const path = location.pathname;
   const [menuOpen, setMenuOpen] = useState(false);
-  const [uploadOpen, setUploadOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const menuRef = useRef(null);
-  const uploadRef = useRef(null);
+  const { ready: chatReady } = useChat();
+
+  // This bar is CSS-hidden rather than unmounted on desktop, so gate the unread
+  // subscription on the same breakpoint the CSS uses.
+  const [isMobileBar, setIsMobileBar] = useState(
+    () => typeof window !== "undefined" && window.matchMedia("(max-width: 1024px)").matches,
+  );
+  useEffect(() => {
+    const mq = window.matchMedia("(max-width: 1024px)");
+    const on = () => setIsMobileBar(mq.matches);
+    mq.addEventListener("change", on);
+    return () => mq.removeEventListener("change", on);
+  }, []);
 
   const isActive = (route) => path === route;
   const isShortsActive = path.startsWith("/shorts");
@@ -71,36 +93,27 @@ const BottomNav = ({ openLoginModal }) => {
       if (menuRef.current && !menuRef.current.contains(e.target)) {
         setMenuOpen(false);
       }
-      if (uploadRef.current && !uploadRef.current.contains(e.target)) {
-        setUploadOpen(false);
-      }
     };
-    if (menuOpen || uploadOpen) document.addEventListener("mousedown", handleClickOutside);
+    if (menuOpen) document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [menuOpen, uploadOpen]);
+  }, [menuOpen]);
 
   // (Hide-on-scroll behavior was removed — the bar is now always visible.)
 
   // Close menus on route change
   useEffect(() => {
     setMenuOpen(false);
-    setUploadOpen(false);
   }, [path]);
 
-  const handleUploadClick = (e) => {
-    e.preventDefault();
+  // Chat needs an account, so logged out this asks for one instead of routing to
+  // a page that can't do anything.
+  const handleChatClick = (e) => {
     if (!authenticated) {
+      e.preventDefault();
       openLoginModal();
-    } else {
-      setUploadOpen((prev) => !prev);
-      setMenuOpen(false);
+      return;
     }
-  };
-
-  const handleEditorClick = (e) => {
-    e.preventDefault();
-    setUploadOpen(false);
-    window.dispatchEvent(new CustomEvent('open-shorts-editor'));
+    setMenuOpen(false);
   };
 
   const showInstallOption = !isStandalone && (installPrompt || isIOS);
@@ -112,7 +125,6 @@ const BottomNav = ({ openLoginModal }) => {
       openLoginModal();
     } else {
       setMenuOpen((prev) => !prev);
-      setUploadOpen(false);
     }
   };
 
@@ -131,27 +143,22 @@ const BottomNav = ({ openLoginModal }) => {
         <span>Audio</span>
       </Link>
 
-      {/* Share = the centre item. Same UploadLinks popup that used to live in the
-          profile menu, now opened straight from the bar. */}
-      <div className="bottom-nav-upload-wrap" ref={uploadRef}>
-        <a href="#" className={`bottom-nav-item ${uploadOpen ? "active" : ""}`} onClick={handleUploadClick}>
-          <span className="bottom-nav-icon-wrap">
-            <span className="bottom-nav-share-plus">
-              <MdAdd />
-            </span>
-          </span>
-          <span>Share</span>
-        </a>
-        {uploadOpen && authenticated && (
-          <div className="bottom-nav-menu bottom-nav-upload-menu">
-            <UploadLinks
-              linkClass="bottom-nav-menu-item"
-              iconClass="bottom-nav-menu-icon"
-              onClick={() => setUploadOpen(false)}
-            />
-          </div>
-        )}
-      </div>
+      {/* Chat = the centre item (Share moved to the top bar's "+"). Logged out it
+          opens the login modal, exactly as the old centre item did. */}
+      <Link
+        to="/chat"
+        className={`bottom-nav-item ${isActive("/chat") ? "active" : ""}`}
+        onClick={handleChatClick}
+      >
+        <span className="bottom-nav-icon-wrap">
+          <MessageCircle className="bottom-nav-icon" />
+          {/* Mounted on mobile only: the badge polls the server for unread, and
+              this bar stays mounted (just CSS-hidden) on desktop, where the
+              top-bar chat button already owns that subscription. */}
+          {authenticated && chatReady && isMobileBar && <BottomNavChatBadge />}
+        </span>
+        <span>Chat</span>
+      </Link>
 
       <Link to="/shorts" className={`bottom-nav-item ${isShortsActive ? "active" : ""}`}>
         <span className="bottom-nav-icon-wrap">

--- a/src/components/BottomNav/BottomNav.scss
+++ b/src/components/BottomNav/BottomNav.scss
@@ -132,6 +132,25 @@
   animation: bottom-nav-live-pulse 1.6s ease-in-out infinite;
 }
 
+// Unread count on the centre Chat item. Same pill as the top bar's chat badge,
+// ringed in the bar's own background so it stays legible over the icon.
+.bottom-nav-chat-badge {
+  position: absolute;
+  top: -3px;
+  right: -8px;
+  min-width: 15px;
+  height: 15px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: var(--accent-primary, #e53935);
+  color: #fff;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 15px;
+  text-align: center;
+  box-shadow: 0 0 0 2px var(--nav-bg, #1a1a1a);
+}
+
 @keyframes bottom-nav-live-pulse {
   0%, 100% { box-shadow: 0 0 0 2px var(--nav-bg, #1a1a1a), 0 0 0 0 rgba(255, 59, 48, 0.55); }
   50%      { box-shadow: 0 0 0 2px var(--nav-bg, #1a1a1a), 0 0 0 5px rgba(255, 59, 48, 0); }

--- a/src/components/Cards/Card3.jsx
+++ b/src/components/Cards/Card3.jsx
@@ -1,4 +1,5 @@
 import PayoutAmount from "../PayoutAmount/PayoutAmount";
+import { bodyToPlaintext } from '../../hive-api/hiveApi';
 import { useDeadVideos } from '../../lib/deadVideos';
 import UpvoteCount from "../UpvoteCount/UpvoteCount";
 import CommentCount from "../CommentCount/CommentCount";
@@ -51,6 +52,22 @@ function withInterleave(cards, channels) {
     });
   });
   return out;
+}
+
+// Hover hint for a shorts card. Shorts are Hive COMMENTS, so they have no real
+// title — the caption lives in the body (same source the shorts viewer and the
+// watch-page rail use). Feeds hand us either an already-flattened caption (the
+// profile tabs map it into `title`) or the raw `hive_body`, so accept both.
+const SHORT_HINT_MAX = 70;
+function shortsHint(video) {
+  const raw = (
+    video.caption
+    || bodyToPlaintext(video.hive_body || '')
+    || video.title
+    || ''
+  ).trim();
+  if (!raw) return undefined;
+  return raw.length > SHORT_HINT_MAX ? `${raw.slice(0, SHORT_HINT_MAX).trimEnd()}…` : raw;
 }
 
 function Card3({ videos = [], loading = false, error = null, interleaveEvery = 0, renderInterleave = null, communityEvery = 0, renderCommunity = null, creatorsEvery = 0, renderCreators = null, getContentForVideo = null, isWatched = null, getViewCount = null, linkPrefix = '/watch', linkQuery = '', shortTimeAgo = true, shortsGrid = false, priority = false, hideWatched = false, watchedVersion = 0 }) {
@@ -160,6 +177,7 @@ function Card3({ videos = [], loading = false, error = null, interleaveEvery = 0
             {...(video._liveStream
               ? {}
               : getCardProps(postKey, cardAuthor, video.permlink, video._processedThumbnail, video.status, video.title))}
+            {...(shortsGrid ? { title: shortsHint(video) } : {})}
           >
             {/* Thumbnail — fast fallback so a dead image host can't leave the
                 card blank for ~a minute (see CardThumbnail). */}

--- a/src/components/Chat/ChatButton.jsx
+++ b/src/components/Chat/ChatButton.jsx
@@ -1,6 +1,6 @@
 import { NavLink } from 'react-router-dom'
 import { MessageCircle } from 'lucide-react'
-import { useUnreadCount } from '@snapie/chat-client/react'
+import { useServerUnread } from '../../hooks/useServerUnread'
 import { useChat } from '../../context/ChatContext'
 import './ChatButton.scss'
 
@@ -8,7 +8,8 @@ import './ChatButton.scss'
 // the SDK hook keys its subscription on the client, not on auth state, so we
 // remount it (via conditional render) when `ready` flips.
 function UnreadDot() {
-  const { unreadCount } = useUnreadCount()
+  // Server-truth, never a locally accumulated number (see useServerUnread).
+  const { unreadCount } = useServerUnread()
   if (!unreadCount) return null
   return (
     <span className="chat-nav-badge" aria-hidden="true">

--- a/src/components/Chat/ChatButton.scss
+++ b/src/components/Chat/ChatButton.scss
@@ -7,6 +7,12 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+
+  // Chat moved to the centre item of the mobile bottom bar (BottomNav), so the
+  // top-bar button hides wherever that bar is shown (phone + tab, ≤1024px).
+  @media screen and (max-width: 1024px) {
+    display: none;
+  }
   background: transparent;
   border: none;
   cursor: pointer;

--- a/src/components/Chat/ChatPage.jsx
+++ b/src/components/Chat/ChatPage.jsx
@@ -4,8 +4,10 @@ import {
   useConversations,
   useChatMessages,
   useTyping,
+  useUnreadCount,
 } from '@snapie/chat-client/react'
 import { extractImageUrls } from '@snapie/chat-client'
+import { getChatClient } from '../../lib/snapieChat'
 import { toast } from 'sonner'
 import { useSearchParams } from 'react-router-dom'
 import ChatComposerTools from './ChatComposerTools'
@@ -14,6 +16,7 @@ import ChatLinkCard from './ChatLinkCard'
 import ChatImageLightbox from './ChatImageLightbox'
 import { parseChatLink, timeAgo } from './chatLinks'
 import { useChat } from '../../context/ChatContext'
+import { useServerUnread } from '../../hooks/useServerUnread'
 import { useAppStore } from '../../lib/store'
 import { EMBED_API_KEY } from '../../utils/config'
 import { getAccounts } from '../../hive-api/hiveApi'
@@ -439,6 +442,15 @@ function BrowseChannels() {
 function ConversationList() {
   const { conversations, loading } = useConversations()
   const { openConversation, activeConversation, shareDraft } = useChat()
+  // Per-conversation unread from the same snapshot that drives the nav badge.
+  // The row dot used the server's conv.unread while the badge used a separate
+  // count, so the two could disagree.
+  // Counts come from the server on every check, never from a locally kept
+  // tally that can drift (see useServerUnread). markRead still comes from the
+  // SDK hook; we resync straight after using it.
+  const { markRead } = useUnreadCount()
+  const { unreadCount, byConversation, refresh: refreshUnread } = useServerUnread()
+  const [clearing, setClearing] = useState(false)
   const groups = useGroups()
 
   // Merge polled groups in, deduped by id (a real /conversations entry — which
@@ -452,6 +464,116 @@ function ConversationList() {
     return Array.from(byId.values())
   }, [conversations, groups])
 
+  // Show the button on ANY unread signal, not just the aggregate. The aggregate
+  // can read 0 while rows still show unread (they fall back to the server's
+  // per-conversation flag — see the list below), and gating on it alone made the
+  // button disappear in exactly the stuck-count case it exists to fix.
+  const hasUnread = useMemo(() => {
+    if (unreadCount > 0) return true
+    return merged.some((c) => (byConversation ? (byConversation[c._id] ?? 0) > 0 : !!c.unread))
+  }, [unreadCount, merged, byConversation])
+
+  // Mark every conversation the SERVER says is unread, not just the ones shown
+  // in the list. That distinction is the point: marking on open only reaches
+  // chats the user can see and click, so a count stuck on a conversation that
+  // never appears in their list can never be cleared that way — which is why
+  // it survived the earlier fix.
+  //
+  // byConversation is the server's own breakdown, so it includes those. There
+  // is no bulk endpoint, so this is one POST /read per id, in small batches.
+  async function markAllRead() {
+    if (clearing) return
+    setClearing(true)
+    try {
+      // Go through the raw client, NOT the hook. The hook's markRead returns
+      // undefined either way, and client.markRead swallows its own errors and
+      // returns null — so via the hook there is no way to tell a successful
+      // clear from a failed one, and Promise.allSettled would report every
+      // call as fulfilled regardless.
+      const client = getChatClient()
+
+      // Prefer the server's own breakdown: it can name conversations that are
+      // NOT in the visible list, which is exactly where a stuck count hides.
+      // But the server may return a total with no breakdown at all — in that
+      // case fall back to every conversation we can see, otherwise there is
+      // nothing to iterate and the button silently does nothing.
+      let ids = Object.entries(byConversation || {})
+        .filter(([, n]) => Number(n) > 0)
+        .map(([id]) => id)
+      const usedFallback = ids.length === 0
+      if (usedFallback) ids = merged.map((c) => c._id).filter(Boolean)
+
+      if (!ids.length) {
+        toast.error('No conversations to clear. The count may be stuck server-side.')
+        return
+      }
+
+      // client.markRead swallows its own errors and returns null, so a null
+      // tells us nothing about WHY. Probe auth state around the calls to
+      // separate "we are logged out" from "the server refused" — otherwise the
+      // user just sees a generic failure and we are guessing.
+      const authedBefore = client.isAuthenticated()
+      let last = null
+      let serverError = ''
+      for (let i = 0; i < ids.length; i += 4) {
+        const res = await Promise.all(
+          ids.slice(i, i + 4).map((id) => client.markRead(id).catch(() => null))
+        )
+        for (const r of res) if (r) last = r
+      }
+      const authedAfter = client.isAuthenticated()
+
+      // markRead swallows the server's error, so on total failure repeat ONE
+      // call by hand purely to read the status and body back. Without this the
+      // only signal is `null`, which is why this took several rounds to pin
+      // down. TS `private` is compile-time only, so the token is reachable.
+      if (!last && authedAfter) {
+        try {
+          const svc = client.service || {}
+          const r = await fetch(`${svc.base}/read`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Snapie-Chat-Read-Mode': 'explicit',
+              ...(svc.token ? { Authorization: `Bearer ${svc.token}` } : {})
+            },
+            body: JSON.stringify({ conversationId: ids[0] })
+          })
+          const body = await r.text()
+          serverError = ` (HTTP ${r.status}: ${body.slice(0, 120)})`
+        } catch (e) {
+          serverError = ` (${e?.message || 'request failed'})`
+        }
+      }
+
+      if (last && (last.total || 0) === 0) {
+        toast.success('All caught up')
+      } else if (last) {
+        toast.error(
+          `Still showing ${last.total} unread after clearing ${ids.length} chat${ids.length === 1 ? '' : 's'}.` +
+          (usedFallback ? ' The server reports a count but no matching conversation.' : '')
+        )
+      } else if (!authedBefore) {
+        toast.error('Chat is not signed in. Reconnect chat and try again.')
+      } else if (!authedAfter) {
+        // request() nulls the token on any 401 and rethrows, so one rejected
+        // call silently disarms every call after it.
+        toast.error('Chat session expired while clearing. Reconnect chat and try again.')
+      } else {
+        toast.error(
+          `Server rejected all ${ids.length} request${ids.length === 1 ? '' : 's'}` +
+          `${usedFallback ? ' (ids from the visible list)' : ' (ids from the server\'s own unread map)'}` +
+          `${serverError}`
+        )
+      }
+    } catch {
+      toast.error('Could not mark everything as read')
+    } finally {
+      setClearing(false)
+      refreshUnread()
+    }
+  }
+
   return (
     <div className="chat-list">
       {shareDraft && (
@@ -460,6 +582,18 @@ function ConversationList() {
       <NewDmForm />
       <NewRoomForm />
       <BrowseChannels />
+      {hasUnread && (
+        <button
+          type="button"
+          className="chat-mark-all-read"
+          onClick={markAllRead}
+          disabled={clearing}
+        >
+          {clearing
+            ? 'Marking as read…'
+            : `Mark all as read${unreadCount > 0 ? ` (${unreadCount})` : ''}`}
+        </button>
+      )}
       {loading && merged.length === 0 && (
         <div className="chat-empty">Loading conversations…</div>
       )}
@@ -473,10 +607,15 @@ function ConversationList() {
           const title = convTitle(conv)
           const isDm = conv.type === 'dm'
           const active = activeConversation?._id === conv._id
+          // Fall back to the server flag until the first snapshot lands, so dots
+          // do not blink off on load.
+          const unread = byConversation
+            ? (byConversation[conv._id] ?? 0) > 0
+            : !!conv.unread
           return (
             <li
               key={conv._id}
-              className={`chat-conv-row${conv.unread ? ' unread' : ''}${active ? ' active' : ''}`}
+              className={`chat-conv-row${unread ? ' unread' : ''}${active ? ' active' : ''}`}
               onClick={() => openConversation(conv)}
             >
               <img
@@ -500,7 +639,7 @@ function ConversationList() {
                   </div>
                 )}
               </div>
-              {conv.unread && <span className="chat-conv-dot" />}
+              {unread && <span className="chat-conv-dot" />}
             </li>
           )
         })}
@@ -548,6 +687,17 @@ function Thread({ conv }) {
     conv.type
   )
   const { typingUsers, setTyping } = useTyping(conv._id)
+  const { markRead } = useUnreadCount()
+
+  // Tell the server this conversation has been seen. Nothing did this before,
+  // so the count only ever went UP — including for chats where YOU sent the
+  // last message, which is how you could sit on a badge of 1 with no unread
+  // chat anywhere. Re-runs as messages arrive so a chat you are already
+  // looking at does not start counting again.
+  useEffect(() => {
+    if (!conv?._id) return
+    markRead(conv._id).catch(() => { /* non-fatal: badge clears on next open */ })
+  }, [conv?._id, messages.length, markRead])
   // Draft is seeded from (and saved to) a per-conversation store, so switching
   // chats shows that chat's own unsent text and restores it on return.
   const [draft, setDraft] = useState(() => draftStore.get(conv._id) || '')

--- a/src/components/Chat/chat.scss
+++ b/src/components/Chat/chat.scss
@@ -359,6 +359,23 @@ $chat-z: 1200;
   .chat-conv-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent-primary); flex: 0 0 auto; }
 }
 
+.chat-mark-all-read {
+  margin: 8px 12px;
+  padding: 8px 12px;
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+  flex: 0 0 auto;
+
+  &:hover:not(:disabled) { background: var(--bg-hover); color: var(--text-primary); }
+  &:disabled { opacity: 0.6; cursor: default; }
+}
+
 .chat-empty { padding: 24px 20px; text-align: center; color: var(--text-muted); font-size: 13px; line-height: 1.5; }
 
 /* ---- Thread ---- */

--- a/src/components/HiveAvatar/AvatarSync.jsx
+++ b/src/components/HiveAvatar/AvatarSync.jsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { useAppStore } from '../../lib/store';
+import { fetchProfile } from '../../utils/profileMeta';
+import { setResolvedAvatar, reconcileAvatarOverride } from '../../utils/avatarCache';
+
+/**
+ * Reads the logged-in user's profile_image out of their Hive metadata once per
+ * session and hands it to the avatar cache, so their own face comes from the
+ * immutable image URL instead of the hive proxy — which caches for 24h in the
+ * browser and would otherwise show them a stale picture for a day after they
+ * change it.
+ *
+ * Renders nothing. Mounted once at the app root.
+ */
+export default function AvatarSync() {
+  const user = useAppStore((s) => s.user);
+  const authenticated = useAppStore((s) => s.authenticated);
+
+  useEffect(() => {
+    if (!authenticated || !user) return;
+    let alive = true;
+    (async () => {
+      const profile = await fetchProfile(user);
+      if (!alive || profile == null) return;
+      reconcileAvatarOverride(user, profile.profile_image);
+      setResolvedAvatar(user, profile.profile_image || '');
+    })();
+    return () => { alive = false; };
+  }, [authenticated, user]);
+
+  return null;
+}

--- a/src/components/HiveAvatar/HiveAvatar.jsx
+++ b/src/components/HiveAvatar/HiveAvatar.jsx
@@ -1,5 +1,6 @@
 import { forwardRef } from 'react';
 import PremiumBadge from '../PremiumBadge/PremiumBadge';
+import { useAvatarUrl } from '../../utils/avatarCache';
 import './HiveAvatar.scss';
 
 /**
@@ -33,12 +34,11 @@ const HiveAvatar = forwardRef(function HiveAvatar(
   },
   ref,
 ) {
+  // Hook first: it has to run on every render, including the empty-username one.
+  // Serves a just-uploaded picture directly instead of the cached hive proxy
+  // copy (see utils/avatarCache).
+  const url = useAvatarUrl(username, size || 'small');
   if (!username) return null;
-  // Honor the "no size segment" form some callers use — Hive returns
-  // a medium-ish default for the bare `/avatar` URL.
-  const url = size
-    ? `https://images.hive.blog/u/${encodeURIComponent(username)}/avatar/${size}`
-    : `https://images.hive.blog/u/${encodeURIComponent(username)}/avatar/small`;
   return (
     <span
       className={`hive-avatar${className ? ` ${className}` : ''}`}

--- a/src/components/InterestsPrompt/InterestsPrompt.jsx
+++ b/src/components/InterestsPrompt/InterestsPrompt.jsx
@@ -4,6 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useAppStore } from '../../lib/store';
 import { fetchUserInterests, saveInterestsToHive } from '../../utils/interests';
+import { useWelcomeActive } from '../../utils/welcomeGate';
 import { refreshHomeFeeds } from '../../utils/feedSeed';
 import TagsV2Picker from '../tooltip/TagsV2Picker';
 import './InterestsPrompt.scss';
@@ -35,9 +36,12 @@ export default function InterestsPrompt() {
   const [open, setOpen] = useState(false);
   const [selected, setSelected] = useState([]);
   const [saving, setSaving] = useState(false);
+  // The welcome flow gets the screen to itself; we re-run once it's done.
+  const welcomeActive = useWelcomeActive();
 
   useEffect(() => {
     if (!authenticated || !user || wasPrompted(user)) return;
+    if (welcomeActive) return;
     let alive = true;
     // Small delay so we don't collide with the login flow / other modals.
     const t = setTimeout(async () => {
@@ -53,7 +57,7 @@ export default function InterestsPrompt() {
       setOpen(true);
     }, 1200);
     return () => { alive = false; clearTimeout(t); };
-  }, [authenticated, user]);
+  }, [authenticated, user, welcomeActive]);
 
   if (!open) return null;
 

--- a/src/components/NewFromFollowing/NewFromFollowing.jsx
+++ b/src/components/NewFromFollowing/NewFromFollowing.jsx
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa';
+import { NEW_FROM_FOLLOWING_URL } from '../../utils/config';
+import { useAppStore } from '../../lib/store';
+import AuthorBadge from '../AuthorBadge/AuthorBadge';
+import './NewFromFollowing.scss';
+
+/**
+ * "New from creators you follow" — a rail of creator badges for people whose
+ * recent uploads this viewer hasn't watched yet.
+ *
+ * The checker (`/feeds/new-from-following`) does the work: last 7 days, creators
+ * from the viewer's Hive following list, minus anything already in watch_history
+ * or dismissed. It returns creators with unwatched shorts/videos counts, never a
+ * video list, so this stays a couple of KB no matter how much was posted.
+ *
+ * No follow button by design: everyone here is someone you already follow.
+ */
+
+const REFRESH_MS = 5 * 60 * 1000;
+
+// "3 shorts / 2 videos", dropping whichever side is zero, singular when it's one.
+function countsLabel({ shorts = 0, videos = 0 }) {
+  const parts = [];
+  if (shorts) parts.push(`${shorts} short${shorts === 1 ? '' : 's'}`);
+  if (videos) parts.push(`${videos} video${videos === 1 ? '' : 's'}`);
+  return parts.join(' / ');
+}
+
+export default function NewFromFollowing() {
+  const authenticated = useAppStore((s) => s.authenticated);
+  const user = useAppStore((s) => s.user);
+  const showNsfw = useAppStore((s) => s.showNsfw);
+
+  const { data } = useQuery({
+    queryKey: ['new-from-following', user, showNsfw],
+    enabled: !!authenticated && !!user,
+    staleTime: REFRESH_MS,
+    gcTime: 2 * REFRESH_MS,
+    retry: 1,
+    queryFn: async () => {
+      const params = { currentuser: user, limit: 30 };
+      if (showNsfw) params.nsfw = 'true';
+      const res = await axios.get(NEW_FROM_FOLLOWING_URL, { params });
+      return res.data;
+    },
+  });
+
+  const creators = data?.creators || [];
+
+  // Arrow controls, same behaviour as the stories row above: each arrow only
+  // appears when there's actually something to scroll to on that side.
+  const railRef = useRef(null);
+  const [showLeft, setShowLeft] = useState(false);
+  const [showRight, setShowRight] = useState(false);
+
+  const checkArrows = useCallback(() => {
+    const el = railRef.current;
+    if (!el) return;
+    setShowLeft(el.scrollLeft > 10);
+    setShowRight(el.scrollLeft < el.scrollWidth - el.clientWidth - 10);
+  }, []);
+
+  useEffect(() => {
+    const el = railRef.current;
+    if (!el) return;
+    checkArrows();
+    el.addEventListener('scroll', checkArrows);
+    // Badge widths settle after the avatars load, which changes scrollWidth.
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(checkArrows) : null;
+    ro?.observe(el);
+    return () => {
+      el.removeEventListener('scroll', checkArrows);
+      ro?.disconnect();
+    };
+  }, [checkArrows, creators.length]);
+
+  const scroll = (direction) => {
+    railRef.current?.scrollBy({ left: direction === 'left' ? -240 : 240, behavior: 'smooth' });
+  };
+
+  // Nothing new is the normal state for plenty of viewers — show nothing at all
+  // rather than an empty box that never fills.
+  if (!authenticated || !creators.length) return null;
+
+  // No visible heading by request — the badges speak for themselves. The
+  // aria-label keeps the section named for screen readers.
+  return (
+    <section className="new-from-following" aria-label="New from creators you follow">
+      <div className="nff-wrapper">
+        {showLeft && (
+          <button type="button" className="nff-scroll-btn left" onClick={() => scroll('left')} aria-label="Scroll left">
+            <FaChevronLeft />
+          </button>
+        )}
+        {showRight && (
+          <button type="button" className="nff-scroll-btn right" onClick={() => scroll('right')} aria-label="Scroll right">
+            <FaChevronRight />
+          </button>
+        )}
+        <div className="nff-rail" ref={railRef}>
+        {creators.map((c) => (
+          <AuthorBadge
+            key={c.username}
+            author={c.username}
+            subtitle={countsLabel(c)}
+            // Straight to the tab that holds the new work when it's all shorts.
+            tabHint={c.videos ? undefined : 'shorts'}
+          />
+        ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/NewFromFollowing/NewFromFollowing.scss
+++ b/src/components/NewFromFollowing/NewFromFollowing.scss
@@ -1,0 +1,81 @@
+@use "../../mixins.scss" as *;
+
+.new-from-following {
+  margin: 0 0 14px;
+
+  // Holds the rail plus its arrows, which sit on top of the row edges.
+  .nff-wrapper {
+    position: relative;
+  }
+
+  // Same arrows as the stories row above (see ShortsStories.scss): only rendered
+  // when there's something to scroll to, and never on a phone, where you swipe.
+  .nff-scroll-btn {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 5;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border-radius: 50%;
+    background: var(--card-bg);
+    border: 1px solid var(--border-light);
+    color: var(--text-primary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+
+    &:hover {
+      background: var(--accent-primary);
+      color: #fff;
+      transform: translateY(-50%) scale(1.1);
+    }
+
+    &.left { left: -10px; }
+    &.right { right: -10px; }
+
+    svg { font-size: 12px; }
+
+    @include respond(phone) {
+      display: none;
+    }
+  }
+
+  // One swipeable row. Badges keep their natural width; the rail scrolls rather
+  // than wrapping, so the section height never depends on how many creators
+  // posted this week.
+  .nff-rail {
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding-bottom: 2px;
+    scroll-behavior: smooth;
+    scroll-snap-type: x proximity;
+    -webkit-overflow-scrolling: touch;
+
+    // No visible scrollbar — the arrows and swipe are the affordance.
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+    &::-webkit-scrollbar { display: none; }
+
+    .author-badge {
+      flex: 0 0 auto;
+      scroll-snap-align: start;
+      // Breathing room inside the pill. Small on the left so the round avatar
+      // isn't pushed off-centre, wider on the right where the text ends.
+      padding: 4px 14px 4px 4px;
+      gap: 8px;
+    }
+
+    .author-name,
+    .followers-count {
+      font-weight: 400;
+      color: var(--text-primary);
+    }
+  }
+}

--- a/src/components/ProfileHeader/ProfileHeader.jsx
+++ b/src/components/ProfileHeader/ProfileHeader.jsx
@@ -1,6 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { Camera } from 'lucide-react';
 import HiveAvatar from '../HiveAvatar/HiveAvatar';
 import { getHiveClient } from '../../utils/hiveNode';
+import { fetchProfile } from '../../utils/profileMeta';
+import { setResolvedAvatar } from '../../utils/avatarCache';
 import './ProfileHeader.scss';
 
 /**
@@ -28,14 +31,22 @@ export default function ProfileHeader({
   badges,
   actions,
   avatarBadgeSize = 16,
+  refreshKey = 0,
+  showHandle = false,
+  onAvatarClick,
 }) {
   const [hiveBio, setHiveBio] = useState('');
+  const [hiveName, setHiveName] = useState('');
+  const [hiveLocation, setHiveLocation] = useState('');
 
+  const wantsBio = fetchBio && !bio;
   useEffect(() => {
-    if (!fetchBio || bio || !username) return;
+    if (!wantsBio || !username) return;
     let cancelled = false;
     (async () => {
       try {
+        // bridge, not the raw account: it also answers for communities, whose
+        // "about" doesn't live in account metadata.
         const profile = await getHiveClient().call('bridge', 'get_profile', { account: username });
         if (!cancelled) setHiveBio(profile?.metadata?.profile?.about || '');
       } catch {
@@ -43,9 +54,51 @@ export default function ProfileHeader({
       }
     })();
     return () => { cancelled = true; };
-  }, [fetchBio, bio, username]);
+    // refreshKey lets a caller re-read the profile after it was edited.
+  }, [wantsBio, username, refreshKey]);
+
+  // The display name comes from the account metadata rather than bridge, which
+  // truncates it to 20 characters ("badadib tibbis te...").
+  useEffect(() => {
+    if (!showHandle || !username) return;
+    let cancelled = false;
+    (async () => {
+      const profile = await fetchProfile(username);
+      if (cancelled || !profile) return;
+      setHiveName(profile.name || '');
+      setHiveLocation(profile.location || '');
+      // We already have their metadata, so hand the real picture to the avatar
+      // cache rather than leaving the header on the day-cached hive proxy.
+      setResolvedAvatar(username, profile.profile_image || '');
+    })();
+    return () => { cancelled = true; };
+  }, [showHandle, username, refreshKey]);
 
   const bioText = bio || hiveBio;
+  // With showHandle, a display name becomes the heading and the account name
+  // moves underneath as @handle. No display name set: heading stays the account
+  // name, and we don't repeat it as a handle right below itself.
+  const displayName = showHandle && hiveName.trim() ? hiveName.trim() : '';
+  const locationText = hiveLocation.trim();
+  const heading = displayName || name || username;
+  const avatarClickable = typeof onAvatarClick === 'function';
+
+  // Keep the avatar exactly as tall as the identity lines beside it (display
+  // name, @handle, bio, location). Measured rather than done in CSS: a flex
+  // item resolves its width from content before the cross-axis stretch, so
+  // "square as tall as my sibling" isn't expressible with aspect-ratio.
+  const metaRef = useRef(null);
+  const [avatarSize, setAvatarSize] = useState(0);
+  useLayoutEffect(() => {
+    const el = metaRef.current;
+    if (!el) return;
+    const measure = () => setAvatarSize(el.offsetHeight);
+    measure();
+    if (typeof ResizeObserver === 'undefined') return;   // fine, CSS min-* holds
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [heading, bioText, locationText, badges]);
 
   return (
     <div className="profile-card">
@@ -59,19 +112,46 @@ export default function ProfileHeader({
       <div className="profile-body">
         <div className="top-section">
           <div className="left-info">
-            <div className="avatar">
+            {/* Avatar + identity lines: the avatar is sized off this row, so it
+                matches the text lines and stops above the badges. */}
+            <div className="identity-row">
+            <div
+              className={`avatar${avatarClickable ? ' avatar--clickable' : ''}`}
+              style={avatarSize ? { width: avatarSize, height: avatarSize } : undefined}
+              {...(avatarClickable ? {
+                role: 'button',
+                tabIndex: 0,
+                title: 'Edit your profile',
+                onClick: onAvatarClick,
+                onKeyDown: (e) => {
+                  if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onAvatarClick(); }
+                },
+              } : {})}
+            >
               <HiveAvatar
                 username={username}
                 size={null}
-                alt={`${name || username} avatar`}
+                alt={`${heading} avatar`}
                 badgeSize={avatarBadgeSize}
               />
+              {avatarClickable ? (
+                <span className="avatar-edit-overlay" aria-hidden="true">
+                  <Camera size={22} />
+                </span>
+              ) : null}
             </div>
-            <div className="user-meta">
-              <h2>{name || username}</h2>
+            <div className="user-meta" ref={metaRef}>
+              <h2>{heading}</h2>
+              {displayName ? <span className="profile-handle">@{username}</span> : null}
               {bioText ? <p className="profile-bio">{bioText}</p> : null}
-              {badges ? <div className="user-badges">{badges}</div> : null}
+              {locationText ? (
+                <p className="profile-location">
+                  <span className="profile-location-label">Location:</span> {locationText}
+                </p>
+              ) : null}
             </div>
+            </div>
+            {badges ? <div className="user-badges">{badges}</div> : null}
           </div>
           {actions ? <div className="button-group">{actions}</div> : null}
         </div>

--- a/src/components/ProfileHeader/ProfileHeader.scss
+++ b/src/components/ProfileHeader/ProfileHeader.scss
@@ -68,12 +68,35 @@
 
       .left-info {
         display: flex;
-        gap: 1rem;
-        align-items: flex-end;
+        flex-direction: column;
+
+        // Avatar + the identity lines only. The avatar stretches to THIS row,
+        // so it spans display name / @handle / bio / location and stops there;
+        // the badges sit underneath it, outside the stretch.
+        .identity-row {
+          display: flex;
+          gap: 1rem;
+          align-items: flex-start;
+          // Offset lives here rather than on .user-meta so the avatar and the
+          // first line of text share a top edge. It absorbs the 10px that used
+          // to sit on the h2 (removed so the measured height is exactly the
+          // text), leaving every page's spacing where it was.
+          margin-top: 50px;
+          @include mix.respond(phone) {
+            margin-top: 32px;
+          }
 
         .avatar {
-          height: 5rem;
-          width: 5rem;
+          // Size is set inline by ProfileHeader, which measures the identity
+          // lines next to it (flexbox can't do "square as tall as my sibling":
+          // it resolves width from content before stretching height, which
+          // gives a capsule). min-* is the old fixed size and the pre-measure
+          // fallback, so it never renders smaller than it used to.
+          position: relative;
+          align-self: flex-start;
+          box-sizing: border-box;
+          min-height: 5rem;
+          min-width: 5rem;
           border-radius: 999px;
           border: 4px solid #020617;
           background: #0f172a;
@@ -84,12 +107,56 @@
           box-shadow: 0 8px 16px rgba(0, 0, 0, 0.35);
           flex-shrink: 0;
 
-          @media (min-width: 640px) {
-            height: 6rem;
-            width: 6rem;
+          // On a phone the text block wraps to many lines, and a square that
+          // tall would eat the width the text needs. Cap it there only.
+          @media (max-width: 639px) {
+            max-height: 7rem;
+            max-width: 7rem;
           }
 
+          @media (min-width: 640px) {
+            min-height: 6rem;
+            min-width: 6rem;
+          }
+
+          // Own profile: the avatar opens the edit dialog.
+          &--clickable {
+            cursor: pointer;
+            transition: border-color 0.2s ease;
+
+            &:hover,
+            &:focus-visible {
+              border-color: var(--accent-primary, #e53935);
+            }
+
+            &:hover .avatar-edit-overlay,
+            &:focus-visible .avatar-edit-overlay {
+              opacity: 1;
+            }
+          }
+
+          .avatar-edit-overlay {
+            position: absolute;
+            inset: 0;
+            z-index: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            border-radius: 50%;
+            background: rgba(2, 6, 23, 0.55);
+            color: #fff;
+            opacity: 0;
+            transition: opacity 0.2s ease;
+            pointer-events: none;
+          }
+
+          // Out of flow on purpose: in flow, the source image's intrinsic size
+          // (avatars are 500px squares) becomes the box's content width, and
+          // with aspect-ratio that made the whole row 500px tall. Absolute
+          // means the box is sized only by the row, and the image follows it.
           .hive-avatar {
+            position: absolute;
+            inset: 0;
             width: 100%;
             height: 100%;
           }
@@ -103,16 +170,14 @@
         }
 
         .user-meta {
-          margin-top: 40px;
           min-width: 0;
-          @include mix.respond(phone) {
-            margin-top: 20px;
-          }
 
           // Name — default 3Speak font (Roboto), just bigger. Replaces the old
           // outlined / uppercase text-stroke treatment.
           h2 {
-            margin-top: 10px;
+            // No top margin: the row's margin-top covers it, and this way the
+            // measured block height is exactly the text lines.
+            margin-top: 0;
             font-size: 34px;
             font-weight: 700;
             color: #fff;
@@ -120,7 +185,20 @@
             word-break: break-word;
             @include mix.respond(phone) {
               font-size: 24px;
-              margin-top: 12px;
+            }
+          }
+
+          // @account, directly under a display name.
+          .profile-handle {
+            display: block;
+            margin-top: 0.15rem;
+            color: #94a3b8;
+            font-size: 0.95rem;
+            font-weight: 500;
+            line-height: 1.2;
+            word-break: break-all;
+            @include mix.respond(phone) {
+              font-size: 0.85rem;
             }
           }
 
@@ -133,7 +211,24 @@
             max-width: 60ch;
           }
 
-          .user-badges {
+          // Location, under the bio.
+          .profile-location {
+            margin-top: 0.25rem;
+            color: #cbd5e1;
+            font-size: 0.85rem;
+            line-height: 1.4;
+
+            .profile-location-label {
+              color: #94a3b8;
+            }
+          }
+
+          }
+        }
+
+        // Under the avatar + identity row, so the avatar never stretches to
+        // cover the badges.
+        .user-badges {
             margin-top: 0.5rem;
             display: flex;
             flex-wrap: wrap;
@@ -162,7 +257,6 @@
             .divider {
               margin: 0 4px;
             }
-          }
         }
       }
 

--- a/src/components/SuggestedCreators/SuggestedCreators.jsx
+++ b/src/components/SuggestedCreators/SuggestedCreators.jsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useState, useCallback } from 'react';
+import { useEffect, useMemo, useState, useCallback, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { toast } from 'sonner';
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa';
 import { SUGGESTED_CREATORS_URL } from '../../utils/config';
 import { feedParams } from '../../utils/feedParams';
 import { getFeedSeed } from '../../utils/feedSeed';
@@ -14,10 +15,8 @@ import { getTagLabel, getTagEmoji } from '../../utils/tagsV2';
 import HiveAvatar from '../HiveAvatar/HiveAvatar';
 import './SuggestedCreators.scss';
 
-// One deterministic top slice is fetched; the client presents it per tab (discover =
-// seeded-random, interests = top) and per viewport (mobile scrolls, desktop fits).
-const FETCH_LIMIT = 20;    // the pool we pick from — also the discover "top 20"
-const MOBILE_MAX = 15;     // how many the mobile scroller shows
+const FETCH_LIMIT = 20;   // the pool we pick from
+const MAX_SHOWN = 15;     // how many tiles the scroller holds
 
 const fmtFollowers = (n) => {
   if (n == null) return null;
@@ -47,46 +46,40 @@ function seededShuffle(arr, seed) {
 }
 
 /**
- * "Follow these" — a rail of creator tiles interleaved into the discover / interests
- * grids (checker `/feeds/suggested-creators`: interest-matched creators ranked by
- * recent views + comments + reshares, minus the caller and who they follow).
+ * "Follow these" — a horizontal rail of creator tiles interleaved into the discover /
+ * interests grids (checker `/feeds/suggested-creators`: interest-matched creators).
  *
- * Layout is viewport-dependent, by request:
- *   - MOBILE  → a horizontal scroller (fixed-width tiles, swipe sideways).
- *   - DESKTOP → a fit-to-width grid of exactly `perRow` tiles (measured by the
- *               parent from the live grid width), so it fills the row edge-to-edge
- *               with NO horizontal scroll — as many as fit, no more.
- *
- * Tab difference: discover shows a seeded-random slice of the top 20; interests the
- * deterministic top. Both draw from ONE shared fetch.
+ * Behaves like the shorts-stories row: a swipe-able scroller with a hidden scrollbar
+ * and prev/next arrows on desktop (mobile uses swipe). Hidden entirely when logged out.
  */
-export default function SuggestedCreators({ variant = 'discover', perRow = 0 }) {
+export default function SuggestedCreators({ variant = 'discover' }) {
   const user = useAppStore((s) => s.user);
   const interests = useAppStore((s) => s.interests);
   const hasInterests = Array.isArray(interests) && interests.length > 0;
-
-  const [isPhone, setIsPhone] = useState(
-    () => typeof window !== 'undefined' && window.matchMedia('(max-width: 600px)').matches,
-  );
-  useEffect(() => {
-    const mq = window.matchMedia('(max-width: 600px)');
-    const on = () => setIsPhone(mq.matches);
-    mq.addEventListener('change', on);
-    return () => mq.removeEventListener('change', on);
-  }, []);
 
   const [followSet, setFollowSet] = useState(null);      // null = not resolved yet
   const [justFollowed, setJustFollowed] = useState({});  // name -> true
   const [pending, setPending] = useState({});
   const [followerCounts, setFollowerCounts] = useState({});
 
-  // ONE deterministic top-N fetch, shared by both tabs (the URL is identical), then
-  // sliced/shuffled client-side. feedParams() carries interests + currentuser, so the
+  // Horizontal scroller with prev/next arrows — same pattern as ShortsStories.
+  const scrollRef = useRef(null);
+  const [showLeft, setShowLeft] = useState(false);
+  const [showRight, setShowRight] = useState(false);
+  const checkScrollButtons = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setShowLeft(el.scrollLeft > 10);
+    setShowRight(el.scrollLeft < el.scrollWidth - el.clientWidth - 10);
+  }, []);
+  const scroll = (dir) => scrollRef.current?.scrollBy({ left: dir === 'left' ? -240 : 240, behavior: 'smooth' });
+
+  // ONE deterministic top-N fetch. feedParams() carries interests + currentuser, so the
   // server already excludes the caller and who they follow.
   const params = feedParams();
   const { data: suggested } = useQuery({
     queryKey: ['suggested-creators', params],
-    enabled: hasInterests,
+    enabled: hasInterests && !!user,
     queryFn: async () => {
       const res = await axios.get(`${SUGGESTED_CREATORS_URL}?limit=${FETCH_LIMIT}${params}`);
       return res.data?.creators || [];
@@ -97,8 +90,7 @@ export default function SuggestedCreators({ variant = 'discover', perRow = 0 }) 
   });
 
   // Belt-and-suspenders follow filter (the server excludes follows too, but its set
-  // can be a cold miss on the first request). Logged out → empty set; the row still
-  // shows and the follow button prompts a login.
+  // can be a cold miss on the first request).
   useEffect(() => {
     let alive = true;
     if (!user) { setFollowSet(new Set()); return undefined; }
@@ -116,22 +108,18 @@ export default function SuggestedCreators({ variant = 'discover', perRow = 0 }) 
         name: (c.author || '').toLowerCase(),
         displayName: c.display_name || c.author,
         avatar: c.avatar,
-        // Why we surfaced them: the topic most of their recent videos are tagged in
-        // (checker's basisTopic), falling back to the first matched interest topic.
         basis: c.basisTopic || (Array.isArray(c.matchedTopics) ? c.matchedTopics[0] : null),
       }))
       .filter((c) => c.name && c.name !== (user || '').toLowerCase())
       .filter((c) => !followSet.has(c.name) || justFollowed[c.name]);
   }, [suggested, followSet, user, justFollowed]);
 
-  // What actually renders: discover reshuffles (seeded, stable per session); the count
-  // is `perRow` on desktop (fit exactly, no scroll) or MOBILE_MAX on the phone scroller.
+  // What renders: discover reshuffles (seeded, stable per session); interests keeps order.
   const creators = useMemo(() => {
     if (!pool.length) return [];
     const ordered = variant === 'discover' ? seededShuffle(pool, getFeedSeed()) : pool;
-    const count = isPhone ? MOBILE_MAX : (perRow || 0);
-    return count > 0 ? ordered.slice(0, count) : [];
-  }, [pool, variant, isPhone, perRow]);
+    return ordered.slice(0, MAX_SHOWN);
+  }, [pool, variant]);
 
   // Follower counts, once per creator that makes the cut.
   useEffect(() => {
@@ -149,6 +137,19 @@ export default function SuggestedCreators({ variant = 'discover', perRow = 0 }) 
     });
     return () => { alive = false; };
   }, [creators, followerCounts]);
+
+  // Keep the arrow visibility in sync with scroll position + list/viewport changes.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return undefined;
+    checkScrollButtons();
+    el.addEventListener('scroll', checkScrollButtons, { passive: true });
+    window.addEventListener('resize', checkScrollButtons);
+    return () => {
+      el.removeEventListener('scroll', checkScrollButtons);
+      window.removeEventListener('resize', checkScrollButtons);
+    };
+  }, [creators, checkScrollButtons]);
 
   const handleFollow = useCallback(async (name) => {
     if (!isLoggedIn() || !user) {
@@ -168,48 +169,55 @@ export default function SuggestedCreators({ variant = 'discover', perRow = 0 }) 
     }
   }, [user]);
 
-  if (!hasInterests || !creators.length) return null;
-
-  // Desktop: a grid of exactly this many columns (tiles stretch to fill via 1fr, so
-  // the row is edge-to-edge). Mobile: the base `.sc-row` is a flex scroller.
-  const gridMode = !isPhone;
-  const cols = Math.min(perRow || creators.length, creators.length);
+  // Hide entirely when logged out (interests can linger in the persisted store).
+  if (!user || !hasInterests || !creators.length) return null;
 
   return (
     <section className="suggested-creators">
-      <div
-        className={`sc-row${gridMode ? ' sc-row--grid' : ''}`}
-        style={gridMode ? { gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` } : undefined}
-      >
-        {creators.map((c) => {
-          const followed = !!justFollowed[c.name];
-          const followers = fmtFollowers(followerCounts[c.name]);
-          return (
-            <div className="sc-card" key={c.name}>
-              <Link to={`/p/${c.name}`} className="sc-avatar" title={`@${c.name}`}>
-                <HiveAvatar username={c.name} size={null} alt="" badgeSize={12} />
-              </Link>
-              <Link to={`/p/${c.name}`} className="sc-name" title={`@${c.name}`}>@{c.name}</Link>
-              {c.basis && (
-                <span className="sc-basis" title={`Mostly posts ${getTagLabel(c.basis)}`}>
-                  <span className="sc-basis-emoji">{getTagEmoji(c.basis)}</span>
-                  {getTagLabel(c.basis)}
+      <div className="sc-scroll-wrapper">
+        {showLeft && (
+          <button className="sc-scroll-btn left" onClick={() => scroll('left')} aria-label="Scroll left">
+            <FaChevronLeft />
+          </button>
+        )}
+
+        <div className="sc-row" ref={scrollRef}>
+          {creators.map((c) => {
+            const followed = !!justFollowed[c.name];
+            const followers = fmtFollowers(followerCounts[c.name]);
+            return (
+              <div className="sc-card" key={c.name}>
+                <Link to={`/p/${c.name}`} className="sc-avatar" title={`@${c.name}`}>
+                  <HiveAvatar username={c.name} size={null} alt="" badgeSize={12} />
+                </Link>
+                <Link to={`/p/${c.name}`} className="sc-name" title={`@${c.name}`}>@{c.name}</Link>
+                {c.basis && (
+                  <span className="sc-basis" title={`Mostly posts ${getTagLabel(c.basis)}`}>
+                    <span className="sc-basis-emoji">{getTagEmoji(c.basis)}</span>
+                    {getTagLabel(c.basis)}
+                  </span>
+                )}
+                <span className="sc-followers">
+                  {followers != null ? `${followers} follower${followers === '1' ? '' : 's'}` : ' '}
                 </span>
-              )}
-              <span className="sc-followers">
-                {followers != null ? `${followers} follower${followers === '1' ? '' : 's'}` : ' '}
-              </span>
-              <button
-                type="button"
-                className={`sc-follow${followed ? ' followed' : ''}`}
-                onClick={() => !followed && handleFollow(c.name)}
-                disabled={followed || !!pending[c.name]}
-              >
-                {followed ? 'Following' : (pending[c.name] ? '…' : 'Follow')}
-              </button>
-            </div>
-          );
-        })}
+                <button
+                  type="button"
+                  className={`sc-follow${followed ? ' followed' : ''}`}
+                  onClick={() => !followed && handleFollow(c.name)}
+                  disabled={followed || !!pending[c.name]}
+                >
+                  {followed ? 'Following' : (pending[c.name] ? '…' : 'Follow')}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+
+        {showRight && (
+          <button className="sc-scroll-btn right" onClick={() => scroll('right')} aria-label="Scroll right">
+            <FaChevronRight />
+          </button>
+        )}
       </div>
     </section>
   );

--- a/src/components/SuggestedCreators/SuggestedCreators.scss
+++ b/src/components/SuggestedCreators/SuggestedCreators.scss
@@ -1,41 +1,67 @@
 @use "../../mixins.scss" as mix;
 
-// "Follow these" — a rail of creator tiles interleaved into the video grid on the
-// discover / interests tabs. No title; compact, so it sits in the feed like a normal
-// row (the grid gap handles the spacing around it).
+// "Follow these" — a horizontal rail of creator tiles interleaved into the discover /
+// interests grids. Behaves like the shorts-stories row: swipe-able scroller, hidden
+// scrollbar, prev/next arrows on desktop.
 .suggested-creators {
   margin: 0;
 
-  // BASE = the mobile horizontal scroller: fixed-width tiles, swipe sideways.
+  .sc-scroll-wrapper {
+    position: relative;
+  }
+
+  // The scroller — fixed-width tiles, swipe sideways, scrollbar hidden.
   .sc-row {
     display: flex;
     gap: 10px;
     overflow-x: auto;
-    padding-bottom: 4px;
-    scrollbar-width: none;
-    &::-webkit-scrollbar { display: none; }
+    padding-bottom: 2px;
+    scroll-behavior: smooth;
+    scrollbar-width: none;          // Firefox
+    -ms-overflow-style: none;       // old Edge
+    &::-webkit-scrollbar { display: none; } // WebKit
   }
 
-  // DESKTOP = a fit-to-width grid of exactly `perRow` columns (set inline). Tiles
-  // stretch to fill via `minmax(0, 1fr)`, so the row is edge-to-edge with NO scroll —
-  // only as many tiles as fit are requested/shown.
-  .sc-row--grid {
-    display: grid;
-    gap: 10px;
-    overflow: visible;
-    padding-bottom: 0;
+  // Prev/next arrows — shown on desktop only (mobile swipes), exactly like the
+  // stories row. Visibility is driven by scroll position (showLeft / showRight).
+  .sc-scroll-btn {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 3;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    border: none;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+    transition: background 0.15s ease;
+
+    &:hover { background: rgba(0, 0, 0, 0.82); }
+    &.left { left: -4px; }
+    &.right { right: -4px; }
+    svg { font-size: 14px; }
+
+    @include mix.respond(phone) { display: none; }
   }
 
+  // Compact tile — small avatar so the rail is no taller than a feed video card.
+  // Height is content-driven; `align-self: start` on the grid-item wrapper below
+  // stops it stretching to fill a tall row in the large/TV grid.
   .sc-card {
-    // Scroller mode: fixed width so tiles don't collapse. Grid mode overrides below.
     flex: 0 0 auto;
-    width: 198px;
+    width: 150px;
     min-width: 0;
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 9px;
-    padding: 12px 15px;
+    gap: 5px;
+    padding: 10px;
     border-radius: 14px;
     border: 1px solid var(--border-light);
     background: var(--card-bg);
@@ -44,27 +70,18 @@
 
     &:hover { border-color: var(--border-color); }
 
-    @include mix.respond(phone) {
-      width: 180px;
-      padding: 12px 12px;
-    }
-  }
-
-  // In grid mode the track sizes the card — drop the fixed width so it fills 1fr.
-  .sc-row--grid .sc-card {
-    flex: initial;
-    width: auto;
+    @include mix.respond(phone) { width: 140px; }
   }
 
   .sc-avatar {
     display: block;
-    width: 100px;   // 1.2x the previous 84px
-    height: 100px;
+    width: 54px;
+    height: 54px;
     line-height: 0;
 
     img {
-      width: 100px;
-      height: 100px;
+      width: 54px;
+      height: 54px;
       border-radius: 50%;
       object-fit: cover;
     }
@@ -72,11 +89,10 @@
 
   .sc-name {
     max-width: 100%;
-    font-size: 16px;
+    font-size: 14px;
     font-weight: 600;
     color: var(--text-primary);
     text-decoration: none;
-    // Long Hive names must not stretch the card.
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -90,38 +106,37 @@
     align-items: center;
     gap: 4px;
     max-width: 100%;
-    padding: 3px 12px;
+    padding: 2px 10px;
     border-radius: 999px;
     background: var(--bg-hover, rgba(150, 150, 150, 0.14));
     color: var(--text-secondary);
-    font-size: 13px;
+    font-size: 12px;
     font-weight: 600;
-    line-height: 1.4;
-    // Long topic labels must not stretch the tile.
+    line-height: 1.35;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 
-    .sc-basis-emoji { font-size: 14px; line-height: 1; }
+    .sc-basis-emoji { font-size: 13px; line-height: 1; }
   }
 
   // Reserves its line even while the count is still loading, so cards don't jump.
   .sc-followers {
-    min-height: 22px;
-    font-size: 13px;
+    min-height: 15px;
+    font-size: 12px;
     color: var(--text-secondary);
   }
 
   // Red outline, never a red fill (app-wide convention for red controls).
   .sc-follow {
     width: 100%;
-    margin-top: 3px;
-    padding: 9px 0;
+    margin-top: 2px;
+    padding: 4px 0;
     border-radius: 999px;
     border: 1px solid var(--accent-primary);
     background: transparent;
     color: var(--accent-primary);
-    font-size: 14px;
+    font-size: 12px;
     font-weight: 700;
     cursor: pointer;
     transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
@@ -137,4 +152,19 @@
 
     &:disabled:not(.followed) { opacity: 0.6; cursor: default; }
   }
+
+  // Respect the card-size setting — track the smaller video tiles in "small" mode.
+  html[data-card-size="small"] & {
+    .sc-card { width: 132px; padding: 9px; }
+    .sc-avatar,
+    .sc-avatar img { width: 46px; height: 46px; }
+    .sc-name { font-size: 13px; }
+  }
+}
+
+// The generic grid-item wrapper Card3 emits for an interleaved row. In the large /
+// "TV" home grid the rows are `1fr` tall — top-align the creator rail so it can never
+// stretch to fill one (that stretch is what made the tiles look "large-card" tall).
+.card-interleave:has(.suggested-creators) {
+  align-self: start;
 }

--- a/src/components/Userprofilepage/UserProfilePage.jsx
+++ b/src/components/Userprofilepage/UserProfilePage.jsx
@@ -447,6 +447,7 @@ const {
         username={user}
         name={user}
         fetchBio
+        showHandle
         badges={
           <>
             <span className="status-dot">

--- a/src/components/WelcomePrompt/ProfileEditModal.jsx
+++ b/src/components/WelcomePrompt/ProfileEditModal.jsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { X } from 'lucide-react';
+import { fetchProfile } from '../../utils/profileMeta';
+import { reconcileAvatarOverride } from '../../utils/avatarCache';
+import ProfileFields, { useProfileEditor } from './ProfileFields';
+import './WelcomePrompt.scss';
+
+/**
+ * "Edit" on your own profile page: the same picture / name / bio / location
+ * form the welcome flow uses, on its own. Controlled by the caller.
+ *
+ * `onSaved` fires after a successful broadcast so the page can refresh whatever
+ * it renders from the profile.
+ */
+export default function ProfileEditModal({ open, username, onClose, onSaved }) {
+  const { form, seed, setField, pickImage, uploading, saving, save } = useProfileEditor(username);
+  const [loading, setLoading] = useState(false);
+
+  // Load the current profile every time it opens, so the form always reflects
+  // what is on chain right now rather than a stale copy from a previous open.
+  useEffect(() => {
+    if (!open || !username) return;
+    let alive = true;
+    setLoading(true);
+    (async () => {
+      const profile = await fetchProfile(username);
+      if (!alive) return;
+      if (profile) {
+        reconcileAvatarOverride(username, profile.profile_image);
+        seed(profile);
+      }
+      setLoading(false);
+    })();
+    return () => { alive = false; };
+  }, [open, username, seed]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e) => { if (e.key === 'Escape' && !saving) onClose && onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, saving, onClose]);
+
+  if (!open) return null;
+
+  const submit = async () => {
+    const ok = await save('Profile updated');
+    if (ok) {
+      if (onSaved) onSaved(form);
+      if (onClose) onClose();
+    }
+  };
+
+  return createPortal(
+    <div
+      className="welcome-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Edit your profile"
+      onClick={() => { if (!saving && onClose) onClose(); }}
+    >
+      <div className="welcome-modal" onClick={(e) => e.stopPropagation()}>
+        <button
+          type="button"
+          className="welcome-close"
+          onClick={() => onClose && onClose()}
+          disabled={saving}
+          aria-label="Close"
+        >
+          <X size={18} />
+        </button>
+
+        <div className="welcome-head">
+          <h2>Edit your profile</h2>
+          <p>
+            Your picture, name and bio show on your profile and next to everything you post.
+          </p>
+        </div>
+
+        {loading ? (
+          <p className="welcome-loading">Loading your profile…</p>
+        ) : (
+          <ProfileFields
+            username={username}
+            form={form}
+            setField={setField}
+            pickImage={pickImage}
+            uploading={uploading}
+            saving={saving}
+          />
+        )}
+
+        <p className="welcome-fineprint">
+          Saved to your Hive account, so every Hive app shows the same profile.
+        </p>
+
+        <div className="welcome-actions">
+          <button type="button" className="welcome-skip" onClick={() => onClose && onClose()} disabled={saving}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="welcome-primary"
+            onClick={submit}
+            disabled={saving || uploading || loading}
+          >
+            {saving ? 'Saving…' : 'Save changes'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/WelcomePrompt/ProfileFields.jsx
+++ b/src/components/WelcomePrompt/ProfileFields.jsx
@@ -1,0 +1,160 @@
+import { useCallback, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { Camera, MapPin, Loader2 } from 'lucide-react';
+import { saveProfileToHive } from '../../utils/profileMeta';
+import { uploadThumbnail } from '../../utils/uploadThumbnail';
+import { setAvatarOverride, clearAvatarOverride, useAvatarUrl } from '../../utils/avatarCache';
+
+// The profile picture / display name / bio / location block, shared by the
+// new-user welcome flow and the "Edit" button on your own profile page.
+
+export const NAME_MAX = 30;
+export const ABOUT_MAX = 160;
+export const LOCATION_MAX = 30;
+const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
+const EMPTY = { name: '', about: '', location: '', profile_image: '' };
+const FIELDS = ['name', 'about', 'location', 'profile_image'];
+
+/**
+ * Form state + upload + save for the profile block. `seed` fills it from an
+ * already-fetched Hive profile; `save` broadcasts and resolves true on success.
+ */
+export function useProfileEditor(username) {
+  const [form, setForm] = useState(EMPTY);
+  const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState(false);
+
+  const seed = useCallback((profile) => {
+    setForm({
+      name: profile?.name || '',
+      about: profile?.about || '',
+      location: profile?.location || '',
+      profile_image: profile?.profile_image || '',
+    });
+  }, []);
+
+  const setField = useCallback(
+    (key) => (e) => setForm((f) => ({ ...f, [key]: e.target.value })),
+    [],
+  );
+
+  const pickImage = useCallback(async (e) => {
+    const file = e.target.files && e.target.files[0];
+    e.target.value = '';
+    if (!file) return;
+    if (!file.type.startsWith('image/')) {
+      toast.error('Please choose an image file');
+      return;
+    }
+    if (file.size > MAX_IMAGE_BYTES) {
+      toast.error('That image is over 8MB, please pick a smaller one');
+      return;
+    }
+    setUploading(true);
+    try {
+      // preferStatic: delegated logins (ButrAuth, HiveSigner) can't sign the
+      // hive.blog challenge client-side, so skip that fallback.
+      const url = await uploadThumbnail(file, username, { preferStatic: true });
+      setForm((f) => ({ ...f, profile_image: url }));
+    } catch (err) {
+      toast.error(err?.message || 'Could not upload that image');
+    } finally {
+      setUploading(false);
+    }
+  }, [username]);
+
+  const hasAnything = FIELDS.some((k) => String(form[k] || '').trim());
+
+  const save = useCallback(async (successMessage = 'Profile saved') => {
+    if (!username) return false;
+    setSaving(true);
+    try {
+      await saveProfileToHive(username, form);
+      // Render the picture we just uploaded straight away: the hive avatar
+      // proxy would keep serving the old one for a while.
+      if (form.profile_image) setAvatarOverride(username, form.profile_image);
+      else clearAvatarOverride(username);
+      toast.success(successMessage);
+      return true;
+    } catch (e) {
+      toast.error(e?.message || 'Could not save your profile');
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  }, [username, form]);
+
+  return { form, seed, setForm, setField, pickImage, uploading, saving, hasAnything, save };
+}
+
+export default function ProfileFields({ username, form, setField, pickImage, uploading, saving }) {
+  const fileRef = useRef(null);
+  const currentAvatar = useAvatarUrl(username, null);
+  const avatar = form.profile_image || currentAvatar;
+
+  return (
+    <>
+      <div className="welcome-avatar-row">
+        <button
+          type="button"
+          className="welcome-avatar"
+          onClick={() => fileRef.current && fileRef.current.click()}
+          disabled={uploading || saving}
+          aria-label="Upload a profile picture"
+        >
+          <img src={avatar} alt="" onError={(e) => { e.target.style.visibility = 'hidden'; }} />
+          <span className="welcome-avatar-badge">
+            {uploading ? <Loader2 size={15} className="welcome-spin" /> : <Camera size={15} />}
+          </span>
+        </button>
+        <div className="welcome-avatar-text">
+          <strong>Profile picture</strong>
+          <span>{uploading ? 'Uploading…' : 'A face or a logo works best. JPG or PNG, up to 8MB.'}</span>
+        </div>
+        <input ref={fileRef} type="file" accept="image/*" onChange={pickImage} style={{ display: 'none' }} />
+      </div>
+
+      <label className="welcome-field">
+        <span className="welcome-label">Display name</span>
+        <input
+          type="text"
+          value={form.name}
+          onChange={setField('name')}
+          maxLength={NAME_MAX}
+          placeholder={`How should we call you? (@${username})`}
+          disabled={saving}
+        />
+      </label>
+
+      <label className="welcome-field">
+        <span className="welcome-label">
+          Short bio
+          <em>{form.about.length}/{ABOUT_MAX}</em>
+        </span>
+        <textarea
+          rows={3}
+          value={form.about}
+          onChange={setField('about')}
+          maxLength={ABOUT_MAX}
+          placeholder="What do you make, and what should people expect from you?"
+          disabled={saving}
+        />
+      </label>
+
+      <label className="welcome-field">
+        <span className="welcome-label">Location <em>optional</em></span>
+        <div className="welcome-input-icon">
+          <MapPin size={15} />
+          <input
+            type="text"
+            value={form.location}
+            onChange={setField('location')}
+            maxLength={LOCATION_MAX}
+            placeholder="Where in the world are you?"
+            disabled={saving}
+          />
+        </div>
+      </label>
+    </>
+  );
+}

--- a/src/components/WelcomePrompt/WelcomePrompt.jsx
+++ b/src/components/WelcomePrompt/WelcomePrompt.jsx
@@ -1,0 +1,193 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Video, Zap, Radio, Users, MessageCircle, Sparkles } from 'lucide-react';
+import { useAppStore } from '../../lib/store';
+import { isManteAuthLogin } from '../../hive-api/aioha';
+import { fetchProfile, isProfileEmpty } from '../../utils/profileMeta';
+import { reconcileAvatarOverride } from '../../utils/avatarCache';
+import { setWelcomeActive } from '../../utils/welcomeGate';
+import ProfileFields, { useProfileEditor } from './ProfileFields';
+import './WelcomePrompt.scss';
+
+// Per-account "already welcomed" flag (browser storage), so nobody gets the
+// intro twice. Set when they save, skip, or when we find a profile that is
+// already filled in.
+const WELCOMED_KEY = '3speak_welcomed';
+const loadWelcomed = () => {
+  try { return JSON.parse(localStorage.getItem(WELCOMED_KEY) || '[]'); } catch { return []; }
+};
+const wasWelcomed = (username) => loadWelcomed().includes(username);
+const markWelcomed = (username) => {
+  try {
+    const set = new Set(loadWelcomed());
+    set.add(username);
+    localStorage.setItem(WELCOMED_KEY, JSON.stringify([...set]));
+  } catch { /* ignore storage errors */ }
+};
+
+// This is a new-signup flow: it only ever runs for an account with nothing in
+// its profile yet. The flag widens WHICH logins are eligible (on preview, any
+// login rather than ButrAuth only); it does not make a set-up account see it.
+const SHOW_FOR_EVERY_LOGIN = import.meta.env.VITE_WELCOME_PROMPT_ALL === 'true';
+
+// ?welcome=1 replays the flow even for an account that already dismissed it,
+// so it stays reviewable without clearing localStorage by hand.
+const isForced = () => {
+  try { return new URLSearchParams(window.location.search).get('welcome') === '1'; } catch { return false; }
+};
+
+const THINGS_YOU_CAN_DO = [
+  { Icon: Video, title: 'Post videos', text: 'Upload long form video that stays yours, on a chain nobody can quietly delete it from.' },
+  { Icon: Zap, title: 'Film shorts', text: 'Something quick, vertical and easy to share. Great for finding your first viewers.' },
+  { Icon: Radio, title: 'Go live', text: 'Stream to your people, bring guests on stage, and keep the recording afterwards.' },
+  { Icon: Users, title: 'Build a community', text: 'Start a space around what you care about, or join one that is already buzzing.' },
+  { Icon: MessageCircle, title: 'Make real friends', text: 'Comment, chat and collaborate with actual humans who show up for each other.' },
+  { Icon: Sparkles, title: 'Get inspired, get involved', text: 'Discover creators, support the ones you love, and earn while you are at it.' },
+];
+
+export default function WelcomePrompt() {
+  const user = useAppStore((s) => s.user);
+  const authenticated = useAppStore((s) => s.authenticated);
+
+  const [open, setOpen] = useState(false);
+  const [step, setStep] = useState(0);
+  const editor = useProfileEditor(user);
+  const { form, seed, setField, pickImage, uploading, saving, hasAnything, save } = editor;
+
+  useEffect(() => {
+    const forced = isForced();
+    if (!authenticated || !user || (wasWelcomed(user) && !forced)) {
+      setOpen(false);                  // e.g. they logged out mid-flow
+      setWelcomeActive(false);
+      return;
+    }
+    // Off preview this is a ButrAuth-signup flow only: every other login came
+    // in with a wallet they already use elsewhere on Hive.
+    if (!SHOW_FOR_EVERY_LOGIN && !forced && !isManteAuthLogin()) return;
+
+    // Claim the modal slot before InterestsPrompt's timer fires, then release
+    // it again if we decide not to show.
+    setWelcomeActive(true);
+    let alive = true;
+    (async () => {
+      const profile = await fetchProfile(user);
+      if (!alive) return;
+      if (profile == null) {           // couldn't read Hive, try again next session
+        setWelcomeActive(false);
+        return;
+      }
+      reconcileAvatarOverride(user, profile.profile_image);
+      // Anything already filled in (picture, display name, bio, location, cover)
+      // means this isn't a fresh account, so no intro. ?welcome=1 still replays
+      // it for review.
+      if (!forced && !isProfileEmpty(profile)) {
+        markWelcomed(user);            // already set up, never ask again
+        setWelcomeActive(false);
+        return;
+      }
+      seed(profile);
+      setStep(0);
+      setOpen(true);
+    })();
+    return () => { alive = false; };
+  }, [authenticated, user, seed]);
+
+  const finish = () => {
+    if (user) markWelcomed(user);
+    setOpen(false);
+    setWelcomeActive(false);
+  };
+
+  // Escape closes it. The backdrop deliberately doesn't: a stray click would
+  // burn the one welcome this account ever gets.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e) => { if (e.key === 'Escape' && !saving) finish(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, saving, user]);
+
+  if (!open) return null;
+
+  const submit = async () => {
+    // Nothing filled in, so don't spend a transaction on an empty profile.
+    if (!hasAnything) { finish(); return; }
+    const ok = await save('Your profile is live. Welcome to 3Speak!');
+    if (ok) finish();
+  };
+
+  return createPortal(
+    <div className="welcome-overlay" role="dialog" aria-modal="true" aria-label="Welcome to 3Speak">
+      <div className="welcome-modal">
+        {step === 0 ? (
+          <>
+            <div className="welcome-hero">
+              <span className="welcome-wave" aria-hidden="true">👋</span>
+              <h2>Welcome to 3Speak</h2>
+              <p className="welcome-hero-sub">
+                Hey <strong>@{user}</strong>, you made it. 3Speak is a creator owned video platform
+                built on Hive: your account, your audience and your content belong to you, not to us.
+              </p>
+            </div>
+
+            <div className="welcome-grid">
+              {THINGS_YOU_CAN_DO.map(({ Icon, title, text }) => (
+                <div className="welcome-card" key={title}>
+                  <span className="welcome-card-icon"><Icon size={18} /></span>
+                  <div>
+                    <h4>{title}</h4>
+                    <p>{text}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <p className="welcome-note">
+              One last thing before you dive in: let people know who they are watching.
+            </p>
+
+            <div className="welcome-actions">
+              <button type="button" className="welcome-skip" onClick={finish}>Maybe later</button>
+              <button type="button" className="welcome-primary" onClick={() => setStep(1)}>
+                Set up my profile
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="welcome-head">
+              <h2>Let people know who you are</h2>
+              <p>
+                This is what shows on your profile and next to everything you post.
+                You can change it any time from your profile.
+              </p>
+            </div>
+
+            <ProfileFields
+              username={user}
+              form={form}
+              setField={setField}
+              pickImage={pickImage}
+              uploading={uploading}
+              saving={saving}
+            />
+
+            <p className="welcome-fineprint">
+              Saved to your Hive account, so every Hive app shows the same profile.
+            </p>
+
+            <div className="welcome-actions">
+              <button type="button" className="welcome-skip" onClick={finish} disabled={saving}>
+                Skip for now
+              </button>
+              <button type="button" className="welcome-primary" onClick={submit} disabled={saving || uploading}>
+                {saving ? 'Saving…' : 'Save and start exploring'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/WelcomePrompt/WelcomePrompt.scss
+++ b/src/components/WelcomePrompt/WelcomePrompt.scss
@@ -1,0 +1,375 @@
+@use "../../mixins.scss" as *;
+
+.welcome-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1500; // above the other app-root prompts
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.62);
+  backdrop-filter: blur(4px);
+
+  @include respond(phone) {
+    align-items: flex-end;
+    padding: 0;
+  }
+}
+
+.welcome-modal {
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 560px;
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: 26px 26px 22px;
+  background: var(--bg-secondary, #1a1a1a);
+  color: var(--text-primary, #f1f1f1);
+  border: 1px solid var(--border-light, #2d2d2d);
+  border-radius: 18px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+  animation: welcome-pop 0.24s ease-out;
+
+  @include respond(phone) {
+    max-width: 100%;
+    max-height: 92vh;
+    border-radius: 18px 18px 0 0;
+    padding: 22px 18px calc(18px + env(safe-area-inset-bottom, 0px));
+    animation: welcome-slide-up 0.28s ease forwards;
+  }
+}
+
+@keyframes welcome-pop {
+  from { opacity: 0; transform: translateY(12px) scale(0.98); }
+  to   { opacity: 1; transform: none; }
+}
+
+@keyframes welcome-slide-up {
+  from { transform: translateY(100%); }
+  to   { transform: none; }
+}
+
+/* Close button, used by the standalone edit dialog */
+.welcome-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  border-radius: 8px;
+  background: var(--bg-hover, rgba(255, 255, 255, 0.08));
+  color: var(--text-secondary, #aaa);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+
+  &:hover:not(:disabled) {
+    background: var(--bg-elevated, #2d2d2d);
+    color: var(--text-primary, #f1f1f1);
+  }
+
+  &:disabled { opacity: 0.5; cursor: default; }
+}
+
+.welcome-loading {
+  margin: 0 0 16px;
+  padding: 26px 0;
+  text-align: center;
+  font-size: 13px;
+  color: var(--text-secondary, #aaa);
+}
+
+/* ---------- step 1: the welcome ---------- */
+
+.welcome-hero {
+  text-align: center;
+  margin-bottom: 20px;
+
+  .welcome-wave {
+    display: inline-block;
+    font-size: 34px;
+    line-height: 1;
+    margin-bottom: 8px;
+  }
+
+  h2 {
+    margin: 0 0 8px;
+    font-size: 24px;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+  }
+}
+
+.welcome-hero-sub {
+  margin: 0 auto;
+  max-width: 44ch;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--text-secondary, #aaa);
+
+  strong { color: var(--accent-primary, #ff5252); font-weight: 700; }
+}
+
+.welcome-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-bottom: 16px;
+
+  @include respond(phone) {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+}
+
+.welcome-card {
+  display: flex;
+  gap: 10px;
+  padding: 12px;
+  border-radius: 12px;
+  background: var(--bg-tertiary, #242424);
+  border: 1px solid var(--border-light, #2d2d2d);
+
+  h4 {
+    margin: 0 0 3px;
+    font-size: 13.5px;
+    font-weight: 700;
+    color: var(--text-primary, #f1f1f1);
+  }
+
+  p {
+    margin: 0;
+    font-size: 12.5px;
+    line-height: 1.45;
+    color: var(--text-secondary, #aaa);
+  }
+}
+
+.welcome-card-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 32px;
+  width: 32px;
+  height: 32px;
+  border-radius: 9px;
+  background: var(--accent-light, rgba(255, 82, 82, 0.15));
+  color: var(--accent-primary, #ff5252);
+}
+
+.welcome-note {
+  margin: 0 0 18px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--text-secondary, #aaa);
+}
+
+/* ---------- step 2: the profile form ---------- */
+
+.welcome-head {
+  margin-bottom: 18px;
+  padding-right: 40px; // clears the close button when there is one
+
+  h2 {
+    margin: 0 0 6px;
+    font-size: 20px;
+    font-weight: 800;
+    letter-spacing: -0.01em;
+  }
+
+  p {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--text-secondary, #aaa);
+  }
+}
+
+.welcome-avatar-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px;
+  margin-bottom: 16px;
+  border-radius: 12px;
+  background: var(--bg-tertiary, #242424);
+  border: 1px solid var(--border-light, #2d2d2d);
+}
+
+.welcome-avatar {
+  position: relative;
+  flex: 0 0 72px;
+  width: 72px;
+  height: 72px;
+  padding: 0;
+  border: 2px solid var(--border-color, #3d3d3d);
+  border-radius: 50%;
+  background: var(--bg-elevated, #2d2d2d);
+  cursor: pointer;
+  overflow: visible;
+  transition: border-color 0.2s ease;
+
+  &:hover:not(:disabled) { border-color: var(--accent-primary, #ff5252); }
+  &:disabled { cursor: default; opacity: 0.8; }
+
+  img {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    object-fit: cover;
+    display: block;
+  }
+}
+
+.welcome-avatar-badge {
+  position: absolute;
+  right: -2px;
+  bottom: -2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: var(--accent-primary, #ff5252);
+  color: #fff;
+  border: 2px solid var(--bg-secondary, #1a1a1a);
+}
+
+.welcome-spin { animation: welcome-rotate 0.9s linear infinite; }
+@keyframes welcome-rotate { to { transform: rotate(360deg); } }
+
+.welcome-avatar-text {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+
+  strong { font-size: 14px; font-weight: 700; }
+  span { font-size: 12.5px; line-height: 1.4; color: var(--text-secondary, #aaa); }
+}
+
+.welcome-field {
+  display: block;
+  margin-bottom: 14px;
+
+  input,
+  textarea {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 10px 12px;
+    font-size: 14px;
+    font-family: inherit;
+    color: var(--text-primary, #f1f1f1);
+    background: var(--input-bg, #2d2d2d);
+    border: 1px solid var(--input-border, #3d3d3d);
+    border-radius: 10px;
+    outline: none;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+    &::placeholder { color: var(--text-muted, #717171); }
+
+    &:focus {
+      border-color: var(--accent-primary, #ff5252);
+      box-shadow: 0 0 0 3px var(--input-focus, rgba(255, 82, 82, 0.3));
+    }
+
+    &:disabled { opacity: 0.6; }
+  }
+
+  textarea { resize: vertical; line-height: 1.5; }
+}
+
+.welcome-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text-secondary, #aaa);
+
+  em {
+    font-style: normal;
+    font-weight: 500;
+    font-size: 11.5px;
+    color: var(--text-muted, #717171);
+  }
+}
+
+.welcome-input-icon {
+  position: relative;
+  display: flex;
+  align-items: center;
+
+  svg {
+    position: absolute;
+    left: 11px;
+    color: var(--text-muted, #717171);
+    pointer-events: none;
+  }
+
+  input { padding-left: 34px; }
+}
+
+.welcome-fineprint {
+  margin: 0 0 16px;
+  font-size: 11.5px;
+  color: var(--text-muted, #717171);
+}
+
+/* ---------- shared actions ---------- */
+
+.welcome-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+
+  @include respond(phone) {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+}
+
+.welcome-skip,
+.welcome-primary {
+  padding: 11px 18px;
+  font-size: 14px;
+  font-weight: 600;
+  font-family: inherit;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, opacity 0.2s ease;
+
+  &:disabled { opacity: 0.6; cursor: default; }
+}
+
+.welcome-skip {
+  background: transparent;
+  color: var(--text-secondary, #aaa);
+  border: 1px solid var(--border-color, #3d3d3d);
+
+  &:hover:not(:disabled) {
+    color: var(--text-primary, #f1f1f1);
+    background: var(--bg-hover, rgba(255, 255, 255, 0.08));
+  }
+}
+
+.welcome-primary {
+  background: var(--accent-primary, #ff5252);
+  color: #fff;
+  border: 1px solid var(--accent-primary, #ff5252);
+
+  &:hover:not(:disabled) {
+    background: var(--accent-hover, #ff1744);
+    border-color: var(--accent-hover, #ff1744);
+  }
+}

--- a/src/components/nav/Nav.jsx
+++ b/src/components/nav/Nav.jsx
@@ -9,7 +9,7 @@ import { IoCloudUploadSharp } from "react-icons/io5";
 import { useEffect, useRef, useState } from "react";
 import NavSearch from "./NavSearch";
 import { TiThMenu } from "react-icons/ti";
-import { MdOutlineSearch, MdGraphicEq, MdPlaylistPlay, MdWatchLater, MdHistory, MdKeyboardArrowDown } from "react-icons/md";
+import { MdOutlineSearch, MdGraphicEq, MdPlaylistPlay, MdWatchLater, MdHistory, MdKeyboardArrowDown, MdAdd } from "react-icons/md";
 import { FaMedal } from "react-icons/fa6";
 import { useMyPlaylists } from "../../hooks/useMyPlaylists";
 import ShortsIcon from "../icons/ShortsIcon";
@@ -20,6 +20,7 @@ import PremiumBadge from "../PremiumBadge/PremiumBadge";
 import { FiSettings, FiLogIn } from "react-icons/fi";
 import SettingsModal from "../SettingsModal/SettingsModal";
 import { ENABLE_BUTRAUTH } from "../../utils/config";
+import { useAvatarUrl } from "../../utils/avatarCache";
 
 function NavPlaylistsDropdown({ user }) {
   const [open, setOpen] = useState(false);
@@ -79,8 +80,12 @@ function NavUploadDropdown() {
 
   return (
     <div className="nav-upload-wrapper" ref={ref}>
+      {/* Two icons, one shown per breakpoint: the labelled cloud button on
+          desktop, a bare "+" on mobile where this replaces the bottom bar's
+          centre item and has to fit next to the avatar. */}
       <div className="nav-upload-btn" onClick={() => setOpen(!open)} title="Share">
-        <IoCloudUploadSharp size={18} />
+        <IoCloudUploadSharp size={18} className="nav-upload-icon-desktop" />
+        <MdAdd size={21} className="nav-upload-icon-mobile" />
         <span className="nav-upload-label">Share</span>
       </div>
       {open && (
@@ -95,6 +100,9 @@ function NavUploadDropdown() {
 function Nav({ setSideBar, toggleProfileNav, openLoginModal }) {
   const { authenticated, LogOut, user, initializeTheme, theme } = useAppStore();
   const sidebarHidden = useAppStore((s) => s.sidebarHidden);
+  // Shows a just-uploaded profile picture immediately instead of the cached
+  // hive proxy copy (utils/avatarCache).
+  const myAvatar = useAvatarUrl(user, 'small');
   const location = useLocation();
   const [nav, setNav] = useState(false)
    const sideNavRef = useRef(null); // Ref for the side nav container
@@ -215,7 +223,7 @@ function Nav({ setSideBar, toggleProfileNav, openLoginModal }) {
           <NotificationBell />
           <FiSettings size={19} className="nav-settings-btn" onClick={() => setSettingsOpen(true)} title="Settings" />
           <span className="nav-avatar-wrap" onClick={toggleProfileNav}>
-            <img src={`https://images.hive.blog/u/${user}/avatar/small`} alt="" />
+            <img src={myAvatar} alt="" />
             <PremiumBadge username={user} size={10} className="nav-avatar-premium" />
           </span>
         </div>

--- a/src/components/nav/ProfileNav.jsx
+++ b/src/components/nav/ProfileNav.jsx
@@ -20,6 +20,7 @@ import { getVotePower } from '../../utils/hiveUtils';
 import { getHiveUrl, ensureHealthyNode } from '../../utils/hiveNode';
 import LabeledToggle from '../LabeledToggle/LabeledToggle';
 import SettingsModal from '../SettingsModal/SettingsModal';
+import { useAvatarUrl } from '../../utils/avatarCache';
 
 
 
@@ -29,6 +30,8 @@ function ProfileNav({ isVisible, onclose, toggleAddAccount, openLoginModal }) {
   const navigate = useNavigate()
   const { user, theme, showNsfw, setShowNsfw, toggleTheme, sidebarHidden, setSidebarHidden, LogOut } = useAppStore();
   const isManteAuth = localStorage.getItem("manteauth_login") === "true";
+  // Serves a freshly uploaded picture instead of the cached hive proxy copy.
+  const myAvatar = useAvatarUrl(user, null);
   const [votingPower, setVotingPower] = useState(0);
   const [rc, setRc] = useState(0);
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -68,7 +71,7 @@ function ProfileNav({ isVisible, onclose, toggleAddAccount, openLoginModal }) {
 
         <div className='pro-top-wrap'style={{ backgroundImage: `url(https://images.hive.blog/u/${user}/cover)`, backgroundSize: "cover", backgroundPosition: "center",}}> 
             {/* <img className='' src={getUserProfile?.images?.cover} alt="" /> */}
-            <img className='avatar-img' src={`https://images.hive.blog/u/${user}/avatar`}  alt="" />
+            <img className='avatar-img' src={myAvatar}  alt="" />
             <span className='username'>{user}</span>
             <div className="power-wrap">
             <div className="wrap-in">

--- a/src/components/nav/nav.scss
+++ b/src/components/nav/nav.scss
@@ -1,4 +1,28 @@
 @use "../../mixins.scss" as mix;
+
+// Mobile form of the top-bar Share control: a "+" in the same red ring as the
+// desktop button, shrunk to the footprint of the search / settings icons beside
+// it (a ring needs a couple of px more than a bare glyph, hence 26 not 19).
+// Included inside .nav-upload-wrapper under the phone/tab breakpoints.
+@mixin nav-upload-compact {
+  .nav-upload-btn {
+    width: 26px;
+    height: 26px;
+    padding: 0;
+    gap: 0;
+    border-radius: 50%;   // border + colour stay inherited from the base rule
+  }
+
+  .nav-upload-label,
+  .nav-upload-icon-desktop { display: none; }
+
+  .nav-upload-icon-mobile {
+    display: block;
+    width: 18px;
+    height: 18px;
+  }
+}
+
 .nav-container {
   display: flex;
   align-items: center;
@@ -307,10 +331,10 @@
     .nav-upload-wrapper {
       position: relative;
 
-      // Share now lives in the mobile bottom nav (the centre "+"), so hide the
-      // top-nav Share button wherever the bottom nav is shown (phone + tab).
-      @include mix.respond(phone) { display: none; }
-      @include mix.respond(tab)   { display: none; }
+      // The "+" lives up here on mobile now (the bottom bar's centre item is
+      // Chat), so it shows at every width — just in a compact round form below
+      // the bottom-nav breakpoint (see the overrides at the end of this block).
+      .nav-upload-icon-mobile { display: none; }
 
       .nav-upload-btn {
         display: flex;
@@ -378,6 +402,12 @@
           }
         }
       }
+
+      // Compact "+" wherever the bottom nav is shown. Placed AFTER .nav-upload-btn
+      // on purpose: a media query adds no specificity, so an earlier block would
+      // lose to the base rule below it.
+      @include mix.respond(phone) { @include nav-upload-compact; }
+      @include mix.respond(tab)   { @include nav-upload-compact; }
     }
 
     > span {

--- a/src/hooks/useServerUnread.js
+++ b/src/hooks/useServerUnread.js
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getChatClient } from '../lib/snapieChat';
+
+const POLL_MS = 20000;
+
+/**
+ * Unread counts read STRAIGHT FROM THE SERVER, never cached client-side.
+ *
+ * The SDK's useUnreadCount keeps its own running copy, which can drift up and
+ * never come back down: a user sat on a badge of 3 while /unread reported 0 for
+ * them, because nothing resynced the local number to the authoritative one. So
+ * ask the server instead — on mount, whenever the tab regains focus, and on a
+ * short interval — and treat its answer as the only truth.
+ *
+ * Returns { unreadCount, byConversation, refresh }. `refresh` is exposed so a
+ * caller can resync immediately after marking something read.
+ */
+export function useServerUnread(enabled = true) {
+  const [state, setState] = useState({ unreadCount: 0, byConversation: null });
+  const alive = useRef(true);
+
+  const refresh = useCallback(async () => {
+    if (!enabled) return;
+    try {
+      const client = getChatClient();
+      if (!client?.isAuthenticated?.()) return;
+      const res = await client.getUnread();
+      if (!alive.current || !res) return;
+      setState({
+        unreadCount: Number(res.unread ?? res.total ?? 0) || 0,
+        byConversation: res.conversations || res.byConversation || null,
+      });
+    } catch {
+      // Transient (offline, 5xx): keep the last answer rather than inventing one.
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    alive.current = true;
+    refresh();
+    const id = setInterval(refresh, POLL_MS);
+    const onWake = () => refresh();
+    window.addEventListener('focus', onWake);
+    document.addEventListener('visibilitychange', onWake);
+    return () => {
+      alive.current = false;
+      clearInterval(id);
+      window.removeEventListener('focus', onWake);
+      document.removeEventListener('visibilitychange', onWake);
+    };
+  }, [refresh]);
+
+  return { ...state, refresh };
+}
+
+export default useServerUnread;

--- a/src/page/HomeGrouped.jsx
+++ b/src/page/HomeGrouped.jsx
@@ -12,6 +12,7 @@ import useViewCounts from "../hooks/useViewCounts";
 import { useAppStore } from "../lib/store";
 import { getFeedSeed, refreshHomeFeeds } from "../utils/feedSeed";
 import ShortsStories from "../components/ShortsStories/ShortsStories";
+import NewFromFollowing from "../components/NewFromFollowing/NewFromFollowing";
 import SuggestedCreators from "../components/SuggestedCreators/SuggestedCreators";
 import { useLiveStreams } from "../hooks/useLiveStreams";
 import PullToRefresh from "../components/PullToRefresh/PullToRefresh";
@@ -782,6 +783,8 @@ const HomeGrouped = () => {
     <PullToRefresh onRefresh={handleRefresh}>
     <div className="home-grouped-container home-tabbed" data-card-size={homeCardSize || 'large'}>
       <ShortsStories />
+      {/* Logged-in only, and renders nothing when there's nothing unwatched. */}
+      <NewFromFollowing />
 
       <div className={`home-tabs home-tabs--bar${drag ? ' is-dragging' : ''}`} role="tablist" ref={tabBarRef}>
         {displaySections.map((s) => (

--- a/src/page/ProfilePage.jsx
+++ b/src/page/ProfilePage.jsx
@@ -46,6 +46,8 @@ import UserAudioList from "../components/Userprofilepage/UserAudioList";
 import { createPlaylist } from "../utils/playlistOperations";
 import { useQueryClient } from "@tanstack/react-query";
 import ProfileHeader from "../components/ProfileHeader/ProfileHeader";
+import ProfileEditModal from "../components/WelcomePrompt/ProfileEditModal";
+import { FiEdit2 } from "react-icons/fi";
 
 // Reserved playlist name for Watch Later
 const WATCH_LATER_NAME = 'Watch Later';
@@ -98,6 +100,9 @@ function ProfilePage() {
   const [showSocialLinkModal, setShowSocialLinkModal] = useState(false);
   const [showEditHint, setShowEditHint] = useState(false);
   const [socialLinksRefreshKey, setSocialLinksRefreshKey] = useState(0);
+  const [editProfileOpen, setEditProfileOpen] = useState(false);
+  // Bumped after a profile save so the header re-reads the bio from Hive.
+  const [profileRefreshKey, setProfileRefreshKey] = useState(0);
 
   // Fetch user's playlists (all - public and private)
   const { data: playlists = [], isLoading: playlistsLoading, refetch: refetchPlaylists } = useMyPlaylists();
@@ -444,6 +449,9 @@ function ProfilePage() {
         username={user}
         name={user}
         fetchBio
+        showHandle
+        refreshKey={profileRefreshKey}
+        onAvatarClick={() => setEditProfileOpen(true)}
         badges={
           <>
             <span className="status-dot">
@@ -468,6 +476,14 @@ function ProfilePage() {
         }
         actions={
           <>
+            <button
+              className="btn btn-secondary"
+              onClick={() => setEditProfileOpen(true)}
+              title="Edit your picture, name, bio and location"
+            >
+              <FiEdit2 className="icon" /> Edit
+            </button>
+
             <button
               className="btn btn-primary"
               onClick={() => setShow("follower")}
@@ -734,6 +750,13 @@ function ProfilePage() {
       <EditVideoHintModal
         isOpen={showEditHint}
         onClose={() => setShowEditHint(false)}
+      />
+
+      <ProfileEditModal
+        open={editProfileOpen}
+        username={user}
+        onClose={() => setEditProfileOpen(false)}
+        onSaved={() => setProfileRefreshKey((k) => k + 1)}
       />
     </div>
   );

--- a/src/utils/avatarCache.js
+++ b/src/utils/avatarCache.js
@@ -1,0 +1,145 @@
+import { useEffect, useState } from 'react';
+
+// images.hive.blog/u/<name>/avatar resolves profile_image server-side, but it
+// answers with `cache-control: public, max-age=86400`. So a browser that ever
+// loaded your old picture keeps showing it for a DAY after you change it, no
+// matter what the chain says — it reads as "my upload didn't work".
+//
+// Two layers fix that, both preferred over the proxy URL:
+//   1. override — the exact image WE just uploaded, set the moment it's saved.
+//   2. resolved — profile_image read straight out of the account's
+//      posting_json_metadata. Those URLs are content addressed, so they are
+//      immutable and can never go stale.
+// The proxy stays as the fallback: it generates a default face for accounts
+// with no picture at all.
+
+const KEY = '3speak_avatar_override';
+const RESOLVED_KEY = '3speak_avatar_resolved';
+const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;   // the proxy is long past stale by then
+// A fresh write needs a block or two before it reads back from the chain, so a
+// reconcile in that window would throw away the URL we just set.
+const RECONCILE_GRACE_MS = 2 * 60 * 1000;
+
+let overrides = null;
+let resolved = null;
+const subscribers = new Set();
+
+const clean = (u) => String(u || '').trim().replace(/^@/, '').toLowerCase();
+
+function readStore(key) {
+  try { return JSON.parse(localStorage.getItem(key) || '{}') || {}; }
+  catch { return {}; }
+}
+
+function load() {
+  if (!overrides) overrides = readStore(KEY);
+  return overrides;
+}
+
+function loadResolved() {
+  if (!resolved) resolved = readStore(RESOLVED_KEY);
+  return resolved;
+}
+
+function notify() {
+  subscribers.forEach((fn) => fn());
+}
+
+function persist() {
+  try { localStorage.setItem(KEY, JSON.stringify(overrides || {})); } catch { /* ignore */ }
+  notify();
+}
+
+/**
+ * The standard Hive avatar URL. A falsy `size` keeps the bare `/avatar` form
+ * (bigger default image), which some call sites render at 90px and up.
+ */
+export function hiveAvatarUrl(username, size = 'small') {
+  const u = encodeURIComponent(clean(username));
+  return size
+    ? `https://images.hive.blog/u/${u}/avatar/${size}`
+    : `https://images.hive.blog/u/${u}/avatar`;
+}
+
+/** Remember the image we just uploaded for this account. */
+export function setAvatarOverride(username, url) {
+  const u = clean(username);
+  if (!u) return;
+  load();
+  if (!url) delete overrides[u];
+  else overrides[u] = { url, ts: Date.now() };
+  persist();
+}
+
+export function getAvatarOverride(username) {
+  const u = clean(username);
+  if (!u) return null;
+  const entry = load()[u];
+  if (!entry || !entry.url) return null;
+  if (Date.now() - (entry.ts || 0) > MAX_AGE_MS) {
+    delete overrides[u];
+    persist();
+    return null;
+  }
+  return entry.url;
+}
+
+export function clearAvatarOverride(username) {
+  setAvatarOverride(username, null);
+}
+
+/**
+ * Compare our override against what the chain now says. If they match, the write
+ * landed and we keep serving the direct URL until the proxy catches up. If they
+ * differ, the picture was changed somewhere else (or our write never landed), so
+ * the override is wrong and goes away.
+ */
+export function reconcileAvatarOverride(username, chainUrl) {
+  const u = clean(username);
+  if (!u) return;
+  const entry = load()[u];
+  if (!entry) return;
+  if (Date.now() - (entry.ts || 0) < RECONCILE_GRACE_MS) return;  // too soon to judge
+  if (String(chainUrl || '') !== entry.url) {
+    delete overrides[u];
+    persist();
+  }
+}
+
+/**
+ * Remember the profile_image this account actually has on chain. Pass '' when
+ * they have none, so we fall back to the proxy's generated default.
+ */
+export function setResolvedAvatar(username, url) {
+  const u = clean(username);
+  if (!u) return;
+  loadResolved();
+  const next = String(url || '');
+  if (resolved[u] === next) return;              // nothing changed, don't re-render
+  resolved[u] = next;
+  try { localStorage.setItem(RESOLVED_KEY, JSON.stringify(resolved)); } catch { /* ignore */ }
+  notify();
+}
+
+export function getResolvedAvatar(username) {
+  const u = clean(username);
+  if (!u) return null;
+  return loadResolved()[u] || null;
+}
+
+/**
+ * Avatar URL for a username: the picture we just uploaded, else the one the
+ * chain says they have, else the (day-cached) hive proxy. Re-renders the caller
+ * when any of that changes, so a new picture appears the moment it's saved.
+ */
+export function useAvatarUrl(username, size = 'small') {
+  const [, bump] = useState(0);
+  useEffect(() => {
+    const fn = () => bump((n) => n + 1);
+    subscribers.add(fn);
+    return () => { subscribers.delete(fn); };
+  }, []);
+  return getAvatarOverride(username)
+    || getResolvedAvatar(username)
+    || hiveAvatarUrl(username, size);
+}

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -37,6 +37,9 @@ const INTERESTS_FEED_URL = `${CHECKER_URL}/feeds/interests`;
 // "Follow these" creator suggestions — interest-matched creators ranked by recent
 // engagement (views+comments+reshares). Backs the rail on the discover/interests tabs.
 const SUGGESTED_CREATORS_URL = `${CHECKER_URL}/feeds/suggested-creators`;
+// Creators you follow who posted something in the last week that you haven't
+// watched yet. Returns creators + unwatched shorts/videos counts, not videos.
+const NEW_FROM_FOLLOWING_URL = `${CHECKER_URL}/feeds/new-from-following`;
 const NEW_CONTENT_URL = `${CHECKER_URL}/feeds/new`;
 const FIRST_UPLOADS_URL = `${CHECKER_URL}/feeds/firstUploads`;
 // Max length of a Short, in seconds. Every encoder node supports 2 minutes; keep
@@ -261,6 +264,7 @@ export {
   DISCOVER_FEED_URL,
   INTERESTS_FEED_URL,
   SUGGESTED_CREATORS_URL,
+  NEW_FROM_FOLLOWING_URL,
   NEW_CONTENT_URL,
   FIRST_UPLOADS_URL,
   SHORTS_MAX_DURATION_SEC,

--- a/src/utils/playerUrl.js
+++ b/src/utils/playerUrl.js
@@ -20,8 +20,15 @@ const PROBE_TIMEOUT_MS = 2000;
 // the health pick resolves.
 const CANDIDATES = [...new Set((PLAYER_URLS || []).filter(Boolean))];
 
+// A pin written earlier in the session can name a backend that is no longer a
+// candidate — e.g. prod dropping the dev player from VITE_PLAYER_URLS after a
+// session pinned it during a play.3speak.tv outage. Only honour a pin that is
+// still in the configured list, otherwise ignore it and re-probe.
 function sessionUrl() {
-  try { return sessionStorage.getItem(SESSION_KEY) || null; } catch { return null; }
+  try {
+    const u = sessionStorage.getItem(SESSION_KEY);
+    return u && CANDIDATES.includes(u) ? u : null;
+  } catch { return null; }
 }
 function pin(url) {
   try { sessionStorage.setItem(SESSION_KEY, url); } catch { /* storage disabled */ }

--- a/src/utils/profileMeta.js
+++ b/src/utils/profileMeta.js
@@ -1,0 +1,103 @@
+import { getAccounts } from '../hive-api/hiveApi';
+import { broadcastWithAioha, KeyTypes } from '../hive-api/aioha';
+
+// Read/write the standard Hive `profile` block (display name, bio, location,
+// avatar) that every Hive app renders. It lives inside the account's
+// posting_json_metadata, so a plain posting-authority signature is enough —
+// which is what lets @threespeak write it on behalf of delegated logins
+// (ButrAuth / HiveSigner) with no wallet prompt.
+
+const clean = (u) => String(u || '').trim().replace(/^@/, '').toLowerCase();
+
+function parseMeta(raw) {
+  try {
+    if (typeof raw === 'string') return JSON.parse(raw || '{}') || {};
+    if (raw && typeof raw === 'object') return raw;
+  } catch { /* malformed metadata — treat as empty */ }
+  return {};
+}
+
+// The fields the welcome flow is allowed to write. Anything else already in the
+// profile (cover_image, website, …) is copied through untouched.
+export const EDITABLE_PROFILE_FIELDS = ['name', 'about', 'location', 'profile_image'];
+
+// Fields that count as "this account has been set up already".
+const PRESENCE_FIELDS = ['name', 'about', 'location', 'profile_image', 'cover_image'];
+
+/**
+ * Pull the profile object out of an already-fetched account. Prefers
+ * posting_json_metadata (where profiles live today) and falls back to the
+ * legacy json_metadata so older accounts don't look empty.
+ */
+export function readProfileFromAccount(account) {
+  if (!account) return {};
+  const posting = parseMeta(account.posting_json_metadata);
+  if (posting.profile && typeof posting.profile === 'object') return posting.profile;
+  const legacy = parseMeta(account.json_metadata);
+  if (legacy.profile && typeof legacy.profile === 'object') return legacy.profile;
+  return {};
+}
+
+/**
+ * Fetch a user's Hive profile. Returns the profile object, or null when the
+ * lookup itself failed — so callers can tell "no profile" from "couldn't read".
+ */
+export async function fetchProfile(username) {
+  const u = clean(username);
+  if (!u) return null;
+  try {
+    const [account] = await getAccounts([u]);
+    if (!account) return null;
+    return readProfileFromAccount(account);
+  } catch {
+    return null;
+  }
+}
+
+/** True when nothing a human would recognise as "their profile" is filled in. */
+export function isProfileEmpty(profile) {
+  if (!profile) return true;
+  return !PRESENCE_FIELDS.some((k) => String(profile[k] || '').trim());
+}
+
+/**
+ * Persist profile fields into the account's posting_json_metadata via an
+ * account_update2, merging so `3speak.interests`, spotlight data and any other
+ * app's keys survive. An empty value clears that field.
+ *
+ * json_metadata is sent as '' which means "leave unchanged" on-chain, so only
+ * posting_json_metadata is written and posting authority suffices.
+ */
+export async function saveProfileToHive(username, fields) {
+  const u = clean(username);
+  if (!u) throw new Error('Not logged in');
+
+  // Fetch fresh so a concurrent edit elsewhere isn't clobbered.
+  const [account] = await getAccounts([u]);
+  if (!account) throw new Error(`Hive account @${u} not found`);
+
+  const meta = parseMeta(account.posting_json_metadata);
+  const profile = { ...readProfileFromAccount(account) };
+
+  for (const key of EDITABLE_PROFILE_FIELDS) {
+    if (!(key in (fields || {}))) continue;
+    const value = String(fields[key] ?? '').trim();
+    if (value) profile[key] = value;
+    else delete profile[key];
+  }
+  // Condenser stamps version 2 on profiles; keep it so other apps parse ours
+  // the same way they parse everyone else's.
+  if (!profile.version) profile.version = 2;
+
+  meta.profile = profile;
+
+  const op = ['account_update2', {
+    account: u,
+    json_metadata: '',
+    posting_json_metadata: JSON.stringify(meta),
+    extensions: [],
+  }];
+  const result = await broadcastWithAioha([op], KeyTypes.Posting);
+  if (!result || !result.success) throw new Error('Could not save your profile to Hive');
+  return profile;
+}

--- a/src/utils/reputation.js
+++ b/src/utils/reputation.js
@@ -5,7 +5,7 @@
  * Based on snapie.io implementation
  */
 
-const REPUTATION_API = 'https://api.syncad.com/reputation-api/accounts';
+import { hiveClient } from './hiveNode';
 
 export const LOW_REP_THRESHOLD = 15;
 
@@ -14,8 +14,11 @@ const repCache = new Map();
 const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
 
 /**
- * Get user reputation from Syncad API
- * Returns the raw reputation score (can be negative)
+ * Get user reputation from the app's own Hive RPC pool (hiveNode.js — health-picked
+ * node + dhive failover). `bridge.get_profile` returns the human-readable score
+ * (e.g. 73.54), the same scale the old third-party endpoint returned; the raw
+ * `reputation` field on condenser_api accounts is 0 since it left consensus, so
+ * bridge is the lookup to use. Negative = spammer.
  * @param {string} username - Hive username
  * @returns {Promise<number>} - Reputation score
  */
@@ -27,23 +30,19 @@ export async function getUserReputation(username) {
       return cached.rep;
     }
 
-    const response = await fetch(`${REPUTATION_API}/${username}/reputation`);
-    
-    if (!response.ok) {
-      return 25; // Default to neutral reputation on error
-    }
+    const profile = await hiveClient.call('bridge', 'get_profile', { account: username });
 
-    const reputation = await response.json();
-    // 0 means no reputation data (new account) — treat as neutral (25)
-    const score = reputation || 25;
+    // No profile / no reputation data (new account) — treat as neutral (25)
+    const score = Number(profile?.reputation);
+    const rep = Number.isFinite(score) && score !== 0 ? score : 25;
 
     // Cache the result
     repCache.set(username, {
-      rep: score,
+      rep,
       timestamp: Date.now()
     });
 
-    return score;
+    return rep;
   } catch (error) {
     console.error('Error fetching reputation for', username, error);
     return 25; // Default to neutral on error (fail-open)
@@ -117,6 +116,38 @@ function collectAllAuthors(content) {
 }
 
 /**
+ * Seed the cache from `author_reputation`, the raw bigint Hive already ships on
+ * every comment from condenser_api.get_content_replies. Comment threads therefore
+ * cost ZERO extra RPCs — without this a 24-reply thread would fire 24
+ * bridge.get_profile calls at the shared node. Items without the field fall
+ * through to the normal lookup.
+ * @param {Array} content - Array of comments/posts (possibly nested)
+ */
+function seedFromAuthorReputation(content) {
+  const now = Date.now();
+
+  function seed(items) {
+    for (const item of items) {
+      const authorName = typeof item.author === 'string'
+        ? item.author
+        : item.author?.username;
+
+      if (authorName && item.author_reputation != null && !repCache.has(authorName)) {
+        const score = hiveRepToScore(item.author_reputation);
+        if (score != null) repCache.set(authorName, { rep: score, timestamp: now });
+      }
+
+      const nested = item.children || item.replies;
+      if (nested && nested.length > 0) {
+        seed(nested);
+      }
+    }
+  }
+
+  seed(content);
+}
+
+/**
  * Filter content by reputation
  * Removes items from authors with negative reputation (spammers/bots)
  * Also filters nested children/replies recursively
@@ -129,8 +160,9 @@ function collectAllAuthors(content) {
  */
 export async function filterByReputation(content) {
   if (!content || content.length === 0) return [];
-  
+
   // Pre-fetch all reputations in parallel (huge performance win!)
+  seedFromAuthorReputation(content);
   const allAuthors = collectAllAuthors(content);
   const reputations = await batchGetReputations(allAuthors);
   
@@ -183,6 +215,7 @@ export async function filterByReputation(content) {
 export async function markByReputation(content) {
   if (!content || content.length === 0) return [];
 
+  seedFromAuthorReputation(content);
   const allAuthors = collectAllAuthors(content);
   const reputations = await batchGetReputations(allAuthors);
 

--- a/src/utils/welcomeGate.js
+++ b/src/utils/welcomeGate.js
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+// One-modal-at-a-time gate for the app-root prompts. The welcome flow claims
+// the slot synchronously when it decides it may run, so InterestsPrompt (which
+// pops on a 1.2s timer) waits instead of landing on top of it.
+
+let active = false;
+const subscribers = new Set();
+
+export function setWelcomeActive(next) {
+  const value = !!next;
+  if (value === active) return;
+  active = value;
+  subscribers.forEach((fn) => fn(value));
+}
+
+export function isWelcomeActive() {
+  return active;
+}
+
+/** Re-renders the caller whenever the welcome flow opens or finishes. */
+export function useWelcomeActive() {
+  const [value, setValue] = useState(active);
+  useEffect(() => {
+    subscribers.add(setValue);
+    setValue(active);
+    return () => { subscribers.delete(setValue); };
+  }, []);
+  return value;
+}

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.78.4';
+export const APP_VERSION = '1.78.11';


### PR DESCRIPTION
This pull request introduces several user experience improvements, especially around chat and content discovery, and refines the mobile navigation. The most significant updates include moving the Chat feature to the center of the mobile bottom navigation bar (with a live unread badge), ensuring unread counts are always accurate and synchronized with the server, and adding hover descriptions for shorts. There are also enhancements for new users, profile editing, and content display, as reflected in the updated changelog.

**Navigation and Chat Experience:**
- Moved the Chat button to the center of the mobile bottom navigation bar, replacing the Share button, and added a live unread badge that polls the server for accurate unread counts. The Share/upload feature is now in the top bar. The Chat button prompts login if the user is not authenticated. [[1]](diffhunk://#diff-42c45b2180116e9ac68c930a06260155b79c89887db3cbaddf7bb14d6eb5f81eL2-R2) [[2]](diffhunk://#diff-42c45b2180116e9ac68c930a06260155b79c89887db3cbaddf7bb14d6eb5f81eL11-L14) [[3]](diffhunk://#diff-42c45b2180116e9ac68c930a06260155b79c89887db3cbaddf7bb14d6eb5f81eR28-R59) [[4]](diffhunk://#diff-42c45b2180116e9ac68c930a06260155b79c89887db3cbaddf7bb14d6eb5f81eL74-R116) [[5]](diffhunk://#diff-42c45b2180116e9ac68c930a06260155b79c89887db3cbaddf7bb14d6eb5f81eL134-R161) [[6]](diffhunk://#diff-e54e09e0a2be49bce6150989c42dbc5bdc97700668be22317797f020b4ec157aR135-R153)
- The top-bar Chat button is now hidden on mobile/tablet when the bottom bar is visible, preventing duplicate navigation elements.
- Updated the unread count logic throughout the app to always use the server-truth (via the new `useServerUnread` hook), ensuring consistency between the badge and conversation lists. [[1]](diffhunk://#diff-111cfbd7fc69a4821db708c7a76e3faf9b7029c6f8ce23584c85df44f7fd6e9bL3-R12) [[2]](diffhunk://#diff-f0d83f0a5b8de4d2535de43f34a53f5423440339340d4622f5b5cb9195cdc007R19) [[3]](diffhunk://#diff-f0d83f0a5b8de4d2535de43f34a53f5423440339340d4622f5b5cb9195cdc007R445-R453)

**Content Discovery and Display:**
- Shorts cards now show a hover description, extracted from the caption or body, making it easier for users to preview content. [[1]](diffhunk://#diff-6ae7ad9f53a84c22304bfcdf83c50291913cbf8416e58c0dcc6e1627e6105d85R2) [[2]](diffhunk://#diff-6ae7ad9f53a84c22304bfcdf83c50291913cbf8416e58c0dcc6e1627e6105d85R57-R72) [[3]](diffhunk://#diff-6ae7ad9f53a84c22304bfcdf83c50291913cbf8416e58c0dcc6e1627e6105d85R180)
- The `AuthorBadge` component now supports a `subtitle` prop, allowing for more flexible display of creator information (such as "3 shorts / 2 videos" instead of just follower count). [[1]](diffhunk://#diff-ed2061a4b00704e8720bc093329f4b9c11ce2061a8d6048249a7e6e82af2ae68L10-R12) [[2]](diffhunk://#diff-ed2061a4b00704e8720bc093329f4b9c11ce2061a8d6048249a7e6e82af2ae68L94-R98)

**Changelog and New User Experience:**
- Updated the changelog with recent feature highlights, including improved discoverability, chat unread management, navigation changes, and a new welcome prompt for new users.
- Added components to support the new user welcome flow and profile synchronization. [[1]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R133-R134) [[2]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R670-R673)

**Dependency Updates:**
- Upgraded `@snapie/chat-client` to version 0.3.0 for improved chat integration.

These changes collectively improve navigation clarity, chat reliability, content discovery, and the onboarding experience.