### PR TITLE
Feat/august lunatics

### DIFF
--- a/default-cover.svg
+++ b/default-cover.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Default profile cover, used when an account has no cover_image of its own.
+     images.hive.blog would otherwise serve its own pale placeholder there.
+     Canvas is 1344x240 — the exact size hive serves every cover at — so this
+     scales and crops the same way a real banner does. Dark on purpose: the
+     header panel keeps its usual contrast and the measured luminance lands on
+     the same low scrim a dark photo would. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1344 240" width="1344" height="240">
+  <rect width="1344" height="240" fill="#22262b"/>
+  <g transform="translate(625.5 62) scale(0.62)">
+      <path fill="#E32933" d="M80.4,65.3c-5.3-5.4-12.8-8.7-22.4-9.9L83.4,30V7.5H7.2v24.7h43.3L27.6,55.4v17.5h9c1.3,0,2.6,0,3.8,0.1c6.5,0.3,11.3,1.3,14.4,3.1c3.7,2.1,5.6,5.4,5.6,9.8c0,4-1.4,7.2-4.4,9.5s-7.3,3.5-13.1,3.5c-7.4,0-14.6-2.3-21.6-6.8L3.7,109.7c10.9,9.4,24.4,14,40.5,14c13.8,0,24.7-3.3,32.5-9.9S88.4,98.2,88.4,87C88.4,78,85.8,70.7,80.4,65.3z"/>
+      <path fill="#6DC5D7" d="M70.5,118.1c-8.8-3.8-15.7-8.9-20.8-15.4L64,86.1c4.3,4.8,9.7,8.5,16,11.1s13.1,4,20.1,4c6.2,0,11-1,14.4-3.1c3.4-2.1,5.1-4.9,5.1-8.5c0-2.9-1.2-5.3-3.6-7.2c-2.4-2-6.3-3.6-11.8-4.9l-17.9-4.1C75,70.7,66.8,66.8,61.5,61.6c-5.3-5.2-7.9-11.7-7.9-19.5c0-10.4,4.1-18.7,12.2-25.1C74,10.7,85.1,7.5,99,7.5c9.7,0,18.4,1.5,26.3,4.6s14.2,7.4,18.9,12.9l-14.1,17.1c-9.4-8.1-20-12.1-31.8-12.1c-6.1,0-10.6,1-13.7,3c-3.1,2-4.7,4.8-4.7,8.2c0,2.7,1.2,4.9,3.5,6.6c2.3,1.7,6.3,3.1,11.9,4.4l19,4.5c11.3,2.5,19.3,6.2,24.2,11.4s7.4,11.6,7.4,19.6c0,11.1-4.1,19.9-12.2,26.3c-8.1,6.4-19.4,9.6-33.9,9.6C89.1,123.7,79.3,121.8,70.5,118.1z"/>
+      <path fill="#313886" d="M80,97.2c-6.3-2.7-11.7-6.4-16-11.1l-5.4,6.3c-0.6,1-1.3,1.8-2.2,2.6l-6.6,7.8c5,6.5,11.9,11.6,20.7,15.3c2.3-1.2,4.4-2.6,6.3-4.3c4.7-4,7.9-8.8,9.8-14.4C84.3,98.8,82.1,98.1,80,97.2z"/>
+      <path fill="#313886" d="M53.6,42.1c0,7.8,2.6,14.3,7.9,19.5c5.2,5.1,13.3,8.9,24.2,11.5c-1.3-2.9-3-5.5-5.3-7.8c-5.3-5.4-12.8-8.7-22.4-9.9L83.4,30V9.2c-6.9,1.5-12.7,4.1-17.5,7.9C57.7,23.4,53.6,31.8,53.6,42.1z"/>
+  </g>
+  <text x="672" y="196" text-anchor="middle" fill="#ffffff" fill-opacity="0.92"
+        font-family="Roboto, 'Helvetica Neue', Arial, sans-serif"
+        font-size="26" font-weight="600" letter-spacing="0.4">Real Stories. Real People.</text>
+</svg>

--- a/src/components/Userprofilepage/ChannelTrailer.jsx
+++ b/src/components/Userprofilepage/ChannelTrailer.jsx
@@ -38,7 +38,7 @@ export function useChannelTrailer(username) {
   });
 }
 
-export default function ChannelTrailer({ username, isOwnProfile = false }) {
+export default function ChannelTrailer({ username, isOwnProfile = false, onOpenCommunityTab }) {
   const { data: trailer } = useChannelTrailer(username);
   const [attached, setAttached] = useState(false);
   const [muted, setMuted] = useState(true);
@@ -195,12 +195,27 @@ export default function ChannelTrailer({ username, isOwnProfile = false }) {
           </div>
         ) : null}
         {description ? <p className="ct-desc">{description}</p> : null}
+        {/* The description clips (CSS mask-fade) at the player's height, so a
+            long post always has a way out to the full text on the watch page —
+            same destination as clicking the title. */}
+        {description ? (
+          <Link className="ct-readmore" to={`/watch?v=${author}/${permlink}`}>Read more</Link>
+        ) : null}
       </div>
 
-      {/* Newest community note fills the other half beside the player. */}
+      {/* Newest community note fills the other half beside the player. Desktop
+          only (hidden on phones via CSS). Wrapped in .community-snaps so the
+          SnapCard picks up the same card styling the Community tab gives it —
+          those styles are scoped under that class. Clamped tighter than the
+          Community tab's own cards (maxVh 0.16 vs 0.33) so the card fits the
+          trailer row without being cropped. onOpenCommunityTab makes "Read
+          more" and the comment button hand off to the Community tab instead
+          of expanding/opening inline — there's no room for that here. */}
       {latestSnap ? (
         <div className="channel-trailer-snap">
-          <SnapCard snap={latestSnap} />
+          <div className="community-snaps">
+            <SnapCard snap={latestSnap} maxVh={0.16} onOpenTab={onOpenCommunityTab} />
+          </div>
         </div>
       ) : null}
     </div>

--- a/src/components/Userprofilepage/ChannelTrailer.scss
+++ b/src/components/Userprofilepage/ChannelTrailer.scss
@@ -48,26 +48,18 @@
   }
 }
 
-// The two side columns split what's left beside the player, and each is exactly
-// the player's height. Overflow is clipped, not scrolled: a scrollbar next to an
-// autoplaying video reads as a second, competing pane.
+// The two side columns split what's left beside the player. Widths always match;
+// height handling differs (see each block below).
 .channel-trailer-meta,
 .channel-trailer-snap {
   flex: 0 1 auto;
   width: calc((100% - var(--ct-player-w) - (2 * var(--ct-gap))) / 2);
   min-width: 240px;
-  height: var(--ct-player-h);
-  overflow: hidden;
-  // Fade the last visible line so a clipped block looks deliberate.
-  mask-image: linear-gradient(to bottom, #000 82%, transparent 100%);
-  -webkit-mask-image: linear-gradient(to bottom, #000 82%, transparent 100%);
 
   @include mix.respond(phone) {
     // Stacked: no player height to match, and the halving only makes sense
     // side by side.
     width: 100%;
-    height: auto;
-    max-height: 7.5rem;
   }
 }
 
@@ -76,6 +68,13 @@
   flex-direction: column;
   gap: 0.5rem;
   padding-top: 0.15rem;
+  height: var(--ct-player-h);
+
+  @include mix.respond(phone) {
+    height: auto;
+    max-height: 7.5rem;
+    overflow: hidden;
+  }
 
   .ct-title {
     font-size: 1.15rem;
@@ -83,6 +82,7 @@
     line-height: 1.25;
     color: var(--text-primary);
     text-decoration: none;
+    flex: 0 0 auto;
 
     &:hover { color: var(--accent-primary); }
 
@@ -99,26 +99,73 @@
     gap: 0.4rem;
     font-size: 0.8rem;
     color: var(--text-muted);
+    flex: 0 0 auto;
 
     .ct-dot { opacity: 0.7; }
   }
 
+  // The description is the only part that clips — title/sub/read-more stay put,
+  // and "Read more" (a sibling, not a mask victim) is always fully visible.
   .ct-desc {
     margin: 0;
     font-size: 0.9rem;
     line-height: 1.5;
     color: var(--text-secondary);
     white-space: pre-line;   // keep the author's paragraph breaks
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
+    mask-image: linear-gradient(to bottom, #000 75%, transparent 100%);
+    -webkit-mask-image: linear-gradient(to bottom, #000 75%, transparent 100%);
+
+    @include mix.respond(phone) {
+      mask-image: none;
+      -webkit-mask-image: none;
+    }
+  }
+
+  .ct-readmore {
+    flex: 0 0 auto;
+    align-self: flex-start;
+    background: none;
+    border: none;
+    padding: 0;
+    color: var(--accent-primary);
+    font-size: 0.82rem;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+
+    &:hover { text-decoration: underline; }
   }
 }
 
 // SnapCard is built for a centred 720px column; here it just fills its slot.
+// Unlike .channel-trailer-meta, this ISN'T clipped to the player's height —
+// SnapCard's own body clamp (maxVh={0.16}, passed from ChannelTrailer) already
+// keeps the card short; capping the column on top of that was what cropped the
+// card's own "Read more"/actions row. A max-height safety net still applies,
+// but as a scroll, never a hard clip, so those controls stay reachable.
 .channel-trailer-snap {
+  max-height: var(--ct-player-h);
+  overflow-y: auto;
+
+  // Desktop only — on phones the trailer stacks and the snap just clutters it.
+  @include mix.respond(phone) {
+    display: none;
+  }
+
   .community-snaps,
   .snap-card {
     max-width: none;
     margin: 0;
     width: 100%;
+  }
+
+  // Strip only the container's own 8px 0 40px — the .snap-card keeps its
+  // internal 14px 16px card padding.
+  .community-snaps {
+    padding: 0;
   }
 }
 

--- a/src/components/Userprofilepage/CommunitySnaps.jsx
+++ b/src/components/Userprofilepage/CommunitySnaps.jsx
@@ -38,7 +38,10 @@ async function fetchReplies(author, permlink) {
 // Body with "read more"/"show less" — a very long snap is capped at a fraction of
 // the viewport (`maxVh`), but only when it actually overflows (no fade on short
 // posts). The feed uses a tighter cap than the profile tab.
-function SnapBody({ body, maxVh = 0.33 }) {
+// `onReadMore`, when given, replaces the expand-in-place toggle with a plain
+// navigation (used on the Overview page, where the card is too short a preview
+// to expand inline — "Read more" instead jumps to the full Community tab).
+function SnapBody({ body, maxVh = 0.33, onReadMore }) {
   const [html, setHtml] = useState('');
   const [expanded, setExpanded] = useState(false);
   const [overflowing, setOverflowing] = useState(false);
@@ -84,8 +87,8 @@ function SnapBody({ body, maxVh = 0.33 }) {
         dangerouslySetInnerHTML={{ __html: html }}
       />
       {overflowing && (
-        <button type="button" className="snap-readmore" onClick={() => setExpanded((e) => !e)}>
-          {expanded ? 'Show less' : 'Read more'}
+        <button type="button" className="snap-readmore" onClick={onReadMore || (() => setExpanded((e) => !e))}>
+          {onReadMore ? 'Read more' : (expanded ? 'Show less' : 'Read more')}
         </button>
       )}
     </div>
@@ -198,7 +201,7 @@ function SnapComment({ comment }) {
   );
 }
 
-function SnapComments({ owner, permlink, onCommented }) {
+function SnapComments({ owner, permlink, onCommented, autoFocus = false }) {
   const { data: comments = [], isLoading, refetch } = useQuery({
     queryKey: ['snap-comments', owner, permlink],
     queryFn: () => fetchReplies(owner, permlink),
@@ -207,7 +210,7 @@ function SnapComments({ owner, permlink, onCommented }) {
 
   return (
     <div className="snap-comments">
-      <ReplyBox parentAuthor={owner} parentPermlink={permlink} onSigned={onCommented} onPosted={refetch} />
+      <ReplyBox parentAuthor={owner} parentPermlink={permlink} onSigned={onCommented} onPosted={refetch} autoFocus={autoFocus} />
       {isLoading ? (
         <div className="snap-comments-status">Loading comments…</div>
       ) : comments.length === 0 ? (
@@ -394,14 +397,31 @@ function SnapCommentsModal({ owner, permlink, onClose, onCommented }) {
   );
 }
 
-export function SnapCard({ snap, feedMode = false, onRemove }) {
+// `onOpenTab(permlink)` marks the card as an OVERVIEW preview: "Read more" and
+// the comment button stop expanding/opening inline (there's no room for that in
+// a preview rail) and instead hand off to the Community tab — same pattern the
+// feed's comments-popup uses, just landing on a full tab instead of a modal.
+// `maxVh` overrides the default profile-tab clamp (33vh) for tighter spots, e.g.
+// the trailer's side-by-side snap column.
+// `autoOpenComments` is the landing side of that hand-off: the Community tab
+// passes it on the ONE card the visitor was routed to, so its thread opens (and
+// the reply box grabs focus) without another click.
+export function SnapCard({ snap, feedMode = false, onRemove, onOpenTab, maxVh, autoOpenComments = false }) {
   const user = useAppStore((s) => s.user);
   const client = getHiveClient();
   const queryClient = useQueryClient();
-  const [showComments, setShowComments] = useState(false);
+  const [showComments, setShowComments] = useState(autoOpenComments);
   const [commentsPopup, setCommentsPopup] = useState(false);
   const [editing, setEditing] = useState(false);
   const [localEdit, setLocalEdit] = useState(null); // optimistic body/tags after an edit
+  const cardRef = useRef(null);
+
+  // Scroll the targeted card into view once — the tab can land anywhere in a
+  // long list, so the visitor needs to actually see the thread that opened.
+  useEffect(() => {
+    if (autoOpenComments) cardRef.current?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Vote-dialog state (the reused CommentVoteTooltip owns the actual vote).
   const [showVote, setShowVote] = useState(false);
@@ -470,7 +490,7 @@ export function SnapCard({ snap, feedMode = false, onRemove }) {
   const tags = effTags.filter((t) => t && t !== 'nsfw' && t !== SNAP_TAG);
 
   return (
-    <article className="snap-card">
+    <article className={`snap-card${autoOpenComments ? ' snap-card--highlighted' : ''}`} ref={cardRef}>
       <div className={`snap-card-head${feedMode ? ' snap-card-head--feed' : ''}`}>
         {/* In the home feed the snap is from any creator — show the author badge so
             the viewer can follow them right there; on a profile Community tab it's
@@ -507,7 +527,11 @@ export function SnapCard({ snap, feedMode = false, onRemove }) {
           onSaved={(edit) => { setLocalEdit(edit); setEditing(false); }}
         />
       ) : (
-        <SnapBody body={effBody} maxVh={feedMode ? 0.15 : 0.33} />
+        <SnapBody
+          body={effBody}
+          maxVh={maxVh ?? (feedMode ? 0.15 : 0.33)}
+          onReadMore={onOpenTab ? () => onOpenTab(snap.permlink) : undefined}
+        />
       )}
 
       {!editing && tags.length > 0 && (
@@ -542,7 +566,9 @@ export function SnapCard({ snap, feedMode = false, onRemove }) {
         <button
           type="button"
           className={`snap-action${showComments || commentsPopup ? ' active' : ''}`}
-          onClick={() => (feedMode ? setCommentsPopup(true) : setShowComments((v) => !v))}
+          onClick={() => (onOpenTab
+            ? onOpenTab(snap.permlink, { openComments: true })
+            : feedMode ? setCommentsPopup(true) : setShowComments((v) => !v))}
         >
           <BiCommentDetail />
           <span>{comments}</span>
@@ -550,9 +576,10 @@ export function SnapCard({ snap, feedMode = false, onRemove }) {
       </div>
 
       {/* Profile tab expands the thread inline; the feed opens a popup so the
-          grid row doesn't stretch. */}
+          grid row doesn't stretch. autoFocus only on the card the visitor was
+          actually routed here for — not every already-expanded thread. */}
       {showComments && !feedMode && (
-        <SnapComments owner={snap.owner} permlink={snap.permlink} onCommented={onCommented} />
+        <SnapComments owner={snap.owner} permlink={snap.permlink} onCommented={onCommented} autoFocus={autoOpenComments} />
       )}
       {commentsPopup && (
         <SnapCommentsModal
@@ -572,7 +599,13 @@ export function SnapCard({ snap, feedMode = false, onRemove }) {
  */
 // `limit` renders only the newest N, and `hideEmpty` skips the empty-state
 // block entirely — both for the Overview tab's preview row.
-export default function CommunitySnaps({ user, canPost = false, limit = 0, hideEmpty = false }) {
+// `targetPermlink` + `openComments` land the visitor on one specific snap after
+// being routed here from the Overview page's trailer/preview cards — see
+// UserProfilePage's `?snap=`/`comments=1` query params.
+// `onOpenTab`, when given, marks every card as an OVERVIEW preview (see SnapCard)
+// — used only for the Overview page's own "Community" rail, never on the actual
+// Community tab, where cards behave normally (expand/open inline).
+export default function CommunitySnaps({ user, canPost = false, limit = 0, hideEmpty = false, targetPermlink = null, openComments = false, onOpenTab = null }) {
   const [optimistic, setOptimistic] = useState([]);
   const queryClient = useQueryClient();
 
@@ -615,7 +648,14 @@ export default function CommunitySnaps({ user, canPost = false, limit = 0, hideE
       ) : (
         <div className="snap-list">
           {(limit > 0 ? snaps.slice(0, limit) : snaps)
-            .map((s) => <SnapCard key={s._id || `${s.owner}/${s.permlink}`} snap={s} />)}
+            .map((s) => (
+              <SnapCard
+                key={s._id || `${s.owner}/${s.permlink}`}
+                snap={s}
+                onOpenTab={onOpenTab}
+                autoOpenComments={openComments && !!targetPermlink && s.permlink === targetPermlink}
+              />
+            ))}
         </div>
       )}
     </div>

--- a/src/components/Userprofilepage/CommunitySnaps.scss
+++ b/src/components/Userprofilepage/CommunitySnaps.scss
@@ -291,6 +291,14 @@
     border-radius: 12px;
     padding: 14px 16px;
 
+    // The one card a visitor was routed to from Overview (comment button →
+    // Community tab, comments pre-opened). A brief ring, not a permanent
+    // background change — it's a "here it is", not a new steady state.
+    &--highlighted {
+      border-color: var(--accent-primary, #e53935);
+      box-shadow: 0 0 0 1px var(--accent-primary, #e53935);
+    }
+
     .snap-card-head {
       display: flex;
       align-items: center;

--- a/src/components/Userprofilepage/ProfileOverview.jsx
+++ b/src/components/Userprofilepage/ProfileOverview.jsx
@@ -73,9 +73,13 @@ export default function ProfileOverview({
   const shortSlice = shorts.slice(0, RAIL_COUNT);
   const playlistSlice = playlists.slice(0, perRow);
 
+  // Community cards route through here for "Read more" and the comment button —
+  // `permlink`/`opts` come straight from SnapCard's onOpenTab(permlink, opts).
+  const openCommunityTab = (permlink, opts) => onOpenTab('community', permlink, opts);
+
   return (
     <div className="profile-overview">
-      <ChannelTrailer username={username} isOwnProfile={isOwnProfile} />
+      <ChannelTrailer username={username} isOwnProfile={isOwnProfile} onOpenCommunityTab={openCommunityTab} />
 
       <Section title="Videos" count={videoSlice.length} onViewMore={() => onOpenTab('video')}>
         <Card3
@@ -111,7 +115,7 @@ export default function ProfileOverview({
             <h3>Community</h3>
             <button type="button" className="pov-more" onClick={() => onOpenTab('community')}>View more</button>
           </div>
-          <CommunitySnaps user={username} limit={perRow} hideEmpty />
+          <CommunitySnaps user={username} limit={perRow} hideEmpty onOpenTab={openCommunityTab} />
         </section>
       )}
 

--- a/src/components/Userprofilepage/ProfileOverview.scss
+++ b/src/components/Userprofilepage/ProfileOverview.scss
@@ -90,6 +90,15 @@
     }
   }
 
+  // Video/playlist/audio tiles are fixed-aspect, so clipping vertical overflow
+  // on the row is a no-op for them. Snap cards are text and now size to their
+  // own (already height-capped) content — `overflow-y: hidden` above would clip
+  // that height right back off, so this rail alone scrolls both axes instead.
+  .snap-list {
+    overflow-y: visible;
+    align-items: flex-start;
+  }
+
   // CommunitySnaps is a centred 720px column in its own tab; as a rail it has to
   // give that up or the row starts a third of the way across the page.
   .community-snaps {
@@ -98,11 +107,12 @@
     padding: 0;
   }
 
-  // A snap has no natural height limit (long posts truncate at "Read more"), so
-  // cap it here — one over-long post shouldn't set the height of the whole rail.
+  // SnapCard clamps its OWN body (33vh, "Read more" beneath it) — that's already
+  // the height limit for an over-long post. A second, shorter cap here on top of
+  // that clipped the card's own "Read more"/actions row instead of the rail ever
+  // reaching 320px. Cards size to their (already-clamped) content instead.
   .snap-list > * {
-    max-height: 320px;
-    overflow: hidden;
+    height: auto;
   }
 
   // Fixed widths per kind, so a rail reads as a row of comparable things.

--- a/src/components/Userprofilepage/UserProfilePage.jsx
+++ b/src/components/Userprofilepage/UserProfilePage.jsx
@@ -13,7 +13,7 @@ import { Quantum } from 'ldrs/react'
 import 'ldrs/react/Quantum.css'
 import { useInfiniteQuery, useQuery, useQueryClient as useReactQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
-import { MY_VIDEOS_URL } from '../../utils/config';
+import { MY_VIDEOS_URL, CHECKER_URL } from '../../utils/config';
 import Card3 from '../Cards/Card3';
 import { IoMdShare, IoMdAdd } from 'react-icons/io';
 import { MdAdd, MdClose, MdPlayArrow, MdFlag, MdChatBubbleOutline } from 'react-icons/md';
@@ -87,11 +87,22 @@ function UserProfilePage() {
 
     // Switch tab AND reflect it in the URL so browser back-navigation
     // (e.g. returning from an opened short/playlist) lands on the same tab.
-    const selectTab = useCallback((tab) => {
+    // `permlink`/`opts` are the Overview page's community cards routing to one
+    // specific snap (`opts.openComments` additionally opens + focuses its thread)
+    // — see ProfileOverview's openCommunityTab and SnapCard's onOpenTab.
+    const selectTab = useCallback((tab, permlink, opts) => {
       setShow(tab);
-      const q = tab && tab !== 'overview' ? `?tab=${tab}` : '';
+      const params = new URLSearchParams();
+      if (tab && tab !== 'overview') params.set('tab', tab);
+      if (permlink) params.set('snap', permlink);
+      if (opts?.openComments) params.set('comments', '1');
+      const q = params.toString() ? `?${params.toString()}` : '';
       navigate(`${location.pathname}${q}`, { replace: true });
     }, [navigate, location.pathname]);
+
+    // The specific snap an Overview card routed here for (if any).
+    const targetSnap = searchParams.get('snap') || null;
+    const openSnapComments = searchParams.get('comments') === '1';
 
     // Tabs are a horizontal scroll rail, so the selected one can start out
     // off-screen — most obviously when a deep link lands on a late tab like
@@ -137,6 +148,30 @@ function UserProfilePage() {
       staleTime: 60 * 1000,
     });
     const snapCount = snapCountData?.total || 0;
+
+    // Video/shorts counts for their tab headers — SAME query key ProfileStats
+    // uses for the "50 videos / 14 shorts" stat line, so this is a cache hit,
+    // not a second request.
+    const { data: profileCounts } = useQuery({
+      queryKey: ['profile-counts', user],
+      queryFn: async () => (await axios.get(`${CHECKER_URL}/user/${encodeURIComponent(user)}/counts`)).data,
+      enabled: !!user && user !== 'unknown',
+      staleTime: 5 * 60 * 1000,
+      retry: 1,
+    });
+    const videoCount = profileCounts?.videos || 0;
+    const shortsCount = profileCounts?.shorts || 0;
+
+    // Audio count for its tab header — the /audio endpoint already returns a
+    // `total` alongside the page of items; limit=1 keeps this a count-only call.
+    const { data: audioCountData } = useQuery({
+      queryKey: ['audio-count', user],
+      queryFn: async () => (await axios.get(`${CHECKER_URL}/audio?owner=${encodeURIComponent(user)}&limit=1`)).data,
+      enabled: !!user && user !== 'unknown',
+      staleTime: 5 * 60 * 1000,
+      retry: 1,
+    });
+    const audioCount = audioCountData?.total || 0;
 
     // The Streams tab only exists when there's something to show — a running
     // OpenPods session, or the VOD of a finished one. Counts both.
@@ -201,10 +236,11 @@ function UserProfilePage() {
     // Redirect to /profile if viewing own profile
     useEffect(() => {
       if (isOwnProfile) {
-        // Preserve the tab parameter when redirecting
-        const tab = searchParams.get('tab');
-        const redirectUrl = tab ? `/profile?tab=${tab}` : '/profile';
-        navigate(redirectUrl, { replace: true });
+        // Carry the WHOLE query through, not just `tab` — the Overview page's
+        // community cards also pass `snap`/`comments`, and dropping those landed
+        // the owner on a bare Community tab instead of the snap they clicked.
+        const qs = searchParams.toString();
+        navigate(qs ? `/profile?${qs}` : '/profile', { replace: true });
       }
     }, [isOwnProfile, navigate, searchParams]);
 
@@ -558,9 +594,15 @@ const {
       <div className="toggle-wrap">
         <div className="wrap" ref={tabsRef}>
           <span className={show === "overview" ? "active" : ""} onClick={() => selectTab("overview")}>Overview</span>
-          <span className={show === "video" ? "active" : ""} onClick={() => selectTab("video")}>Videos</span>
-          <span className={show === "shorts" ? "active" : ""} onClick={() => selectTab("shorts")}>Shorts</span>
-          <span className={show === "audio" ? "active" : ""} onClick={() => selectTab("audio")}>Audio</span>
+          <span className={show === "video" ? "active" : ""} onClick={() => selectTab("video")}>
+            Videos {videoCount > 0 && `(${videoCount})`}
+          </span>
+          <span className={show === "shorts" ? "active" : ""} onClick={() => selectTab("shorts")}>
+            Shorts {shortsCount > 0 && `(${shortsCount})`}
+          </span>
+          <span className={show === "audio" ? "active" : ""} onClick={() => selectTab("audio")}>
+            Audio {audioCount > 0 && `(${audioCount})`}
+          </span>
           {streamCount > 0 && (
             <span className={show === "streams" ? "active" : ""} onClick={() => selectTab("streams")}>
               Streams ({streamCount})
@@ -625,7 +667,7 @@ const {
   ) : show === "streams" ? (
     <ProfileStreams user={user} getViewCount={getViewCount} />
   ) : show === "community" ? (
-    <CommunitySnaps user={user} canPost={false} />
+    <CommunitySnaps user={user} canPost={false} targetPermlink={targetSnap} openComments={openSnapComments} />
   ) : show === "links" ? (
     <SpotlightEditor username={user} />
   ) : show === "stats" ? (

--- a/src/components/embed-studio/EmbedUploadProgressBar.jsx
+++ b/src/components/embed-studio/EmbedUploadProgressBar.jsx
@@ -1,6 +1,20 @@
 import { useEffect, useRef, useState } from 'react';
+import { Ring2 } from 'ldrs/react';
+import 'ldrs/react/Ring2.css';
 import { useEmbedUpload } from '../../context/EmbedUploadContext';
 import './EmbedUploadProgressBar.scss';
+
+// Compact byte formatter for the diagnostics line — one decimal under 10 units so
+// a slow trickle still visibly moves (9.4 MB → 9.6 MB), whole numbers above.
+function fmtBytes(n) {
+  if (!Number.isFinite(n) || n < 0) return '—';
+  if (n < 1024) return `${n} B`;
+  const units = ['KB', 'MB', 'GB'];
+  let v = n / 1024;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i += 1; }
+  return `${v < 10 ? v.toFixed(1) : Math.round(v)} ${units[i]}`;
+}
 
 /**
  * Thin progress bar for the background video upload that starts on the
@@ -10,7 +24,10 @@ import './EmbedUploadProgressBar.scss';
  * and for prefilled flows (nothing to upload).
  */
 export default function EmbedUploadProgressBar() {
-  const { videoUploadStatus, uploadProgress, uploading, prefilled, selectedEndpoint } = useEmbedUpload();
+  const {
+    videoUploadStatus, uploadProgress, uploading, prefilled, selectedEndpoint,
+    statusText, uploadDetail,
+  } = useEmbedUpload();
   const rootRef = useRef(null);
   const [matchWidth, setMatchWidth] = useState(null);
 
@@ -45,13 +62,46 @@ export default function EmbedUploadProgressBar() {
     videoUploadStatus === 'done'
       ? 'Video uploaded — finish your details to publish.'
       : videoUploadStatus === 'error'
-        ? 'Background upload didn’t finish — it will retry when you publish.'
+        ? (statusText || 'Background upload didn’t finish — it will retry when you publish.')
         : `Uploading your video… ${pct}%`;
 
   // Show just the hostname of the chosen upload server.
   const endpointHost = selectedEndpoint
     ? selectedEndpoint.replace(/^https?:\/\//, '').replace(/\/+$/, '')
     : '';
+
+  // A percentage alone cannot tell "slow" from "wedged" — the exact confusion an
+  // upload stuck at 0% causes. This line says which method is in play, which step
+  // it is on, and whether bytes are actually moving, so a stall is legible.
+  const d = uploadDetail || {};
+  const bits = [];
+  if (d.method) bits.push(d.method === 'reliable' ? 'Reliable upload' : 'Resumable upload');
+  if (d.phase) bits.push(d.phase);
+  if (d.attempts > 1 && d.attempt) bits.push(`attempt ${d.attempt}/${d.attempts}`);
+  if (Number.isFinite(d.sent) && Number.isFinite(d.total) && d.total > 0) {
+    // "sent" is bytes pushed into the socket; "confirmed" is what the server
+    // acknowledged. A proxy that swallows uploads makes those two diverge, so
+    // show both whenever they disagree.
+    bits.push(
+      Number.isFinite(d.acked) && d.acked !== d.sent
+        ? `${fmtBytes(d.sent)} sent · ${fmtBytes(d.acked)} confirmed of ${fmtBytes(d.total)}`
+        : `${fmtBytes(d.sent)} of ${fmtBytes(d.total)}`,
+    );
+  }
+  if (Number.isFinite(d.chunksTotal) && d.chunksTotal > 0) {
+    bits.push(`chunk ${d.chunksDone ?? 0}/${d.chunksTotal}`);
+  }
+  const detailLine = bits.join(' · ');
+  const showWaiting = d.waitingOn && videoUploadStatus !== 'done';
+
+  // Spin only while we are ATTEMPTING something with nothing to show for it yet:
+  // an outstanding request (waitingOn), or an upload that has not moved a byte.
+  // Once bytes flow the bar itself conveys motion, and a spinner next to a
+  // climbing percentage is just noise.
+  const isWaiting =
+    videoUploadStatus !== 'done' &&
+    videoUploadStatus !== 'error' &&
+    (!!d.waitingOn || pct === 0);
 
   return (
     <div
@@ -63,6 +113,19 @@ export default function EmbedUploadProgressBar() {
         <div className="embed-upload-progress-fill" style={{ width: `${pct}%` }} />
       </div>
       <span className="embed-upload-progress-label">{label}</span>
+      {(detailLine || isWaiting) && (
+        <div className="embed-upload-progress-detailrow">
+          <span className="embed-upload-progress-detail">{detailLine}</span>
+          {isWaiting && (
+            <span className="embed-upload-progress-spinner" aria-hidden="true">
+              <Ring2 size="14" stroke="2" strokeLength="0.25" bgOpacity="0.1" speed="0.9" color="currentColor" />
+            </span>
+          )}
+        </div>
+      )}
+      {showWaiting && (
+        <span className="embed-upload-progress-waiting">Waiting on: {d.waitingOn}</span>
+      )}
       {endpointHost && (
         <span className="embed-upload-progress-endpoint">Upload server: {endpointHost}</span>
       )}

--- a/src/components/embed-studio/EmbedUploadProgressBar.scss
+++ b/src/components/embed-studio/EmbedUploadProgressBar.scss
@@ -22,9 +22,50 @@
     transition: width 0.3s ease;
   }
 
+  // Detail text + spinner share a row, spinner pushed to the right edge. The row
+  // owns the colour because Ring2 draws with `currentColor`, which resolves
+  // through its shadow DOM from this element's computed colour — so the indicator
+  // matches the line it belongs to, in either theme, with no second palette.
+  .embed-upload-progress-detailrow {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--text-muted, #999);
+  }
+
+  .embed-upload-progress-spinner {
+    display: inline-flex;
+    line-height: 0;
+    flex-shrink: 0;      // never squeezed by a long detail string
+    margin-left: auto;   // hold the right edge even when the text wraps
+  }
+
   .embed-upload-progress-label {
     font-size: 12.5px;
     color: var(--text-secondary, #777);
+  }
+
+  // Which method / step / byte counters. Sits directly under the label so the
+  // "is it moving?" question is answered without opening devtools.
+  // Same typography as the "Upload server:" line below — these are all machine
+  // facts (counters, endpoints), so they read as one block rather than three
+  // competing styles.
+  .embed-upload-progress-detail {
+    font-size: 11.5px;
+    color: var(--text-muted, #999);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    line-height: 1.35;
+  }
+
+  // The specific request being awaited, incl. its deadline. Monospace because it
+  // names an endpoint path.
+  .embed-upload-progress-waiting {
+    font-size: 11px;
+    color: var(--text-muted, #999);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    opacity: 0.85;
+    line-height: 1.35;
+    word-break: break-word;
   }
 
   .embed-upload-progress-endpoint {

--- a/src/components/embed-studio/EmbedVideoUploadStep1.jsx
+++ b/src/components/embed-studio/EmbedVideoUploadStep1.jsx
@@ -372,7 +372,16 @@ function EmbedVideoUploadStep1() {
                           checked={!!faults.blackholeChunks}
                           onChange={(e) => applyFault({ blackholeChunks: e.target.checked })}
                         />
-                        <span>Black-hole the fallback&rsquo;s chunks — the reported bug. Expect: bar stalls, then the 45s stall-watchdog cuts in and retries (before the fix it hung at 0% forever).</span>
+                        <span>Black-hole the chunk protocol — the reported bug. Swallows the session <em>create</em> POST too, not just the data chunks. Expect: &ldquo;Starting upload…&rdquo;, ~50s of &ldquo;Connection unstable — retrying… (n/3)&rdquo;, then it gives up on chunks and <strong>the single-request last resort takes over and finishes the upload</strong>. Before the fix, create had no deadline at all and the bar sat at 0% forever with nothing on screen.</span>
+                      </label>
+
+                      <label style={{ display: 'flex', gap: '8px', alignItems: 'flex-start', cursor: 'pointer', marginBottom: '5px' }}>
+                        <input
+                          type="checkbox"
+                          checked={!!faults.blackholeSimple}
+                          onChange={(e) => applyFault({ blackholeSimple: e.target.checked })}
+                        />
+                        <span>Black-hole the single-request fallback too — total blackout, every transport dead. Only useful with the box above ticked. Expect: all three tiers tried in order, then a clean <em>Request timed out</em> failure. Nothing can upload under this by construction; it verifies we FAIL LOUDLY rather than hang.</span>
                       </label>
 
                       <label style={{ display: 'flex', gap: '8px', alignItems: 'flex-start', cursor: 'pointer' }}>
@@ -385,7 +394,11 @@ function EmbedVideoUploadStep1() {
                       </label>
 
                       <p style={{ margin: '6px 0 0', opacity: 0.75 }}>
-                        Tick the first two together to reproduce the exact user report. Clears when the tab closes.
+                        Tick the first two together to reproduce the exact user report — it should now RECOVER via the
+                        single-request tier instead of hanging. Add the third for a total blackout. Clears when the tab closes.
+                        <br />
+                        These simulate 100% loss, not a slow link: under a black-hole nothing gets through no matter how
+                        long you wait, so &ldquo;upload anyway, just slowly&rdquo; is only meaningful for the flaky/throttled cases below.
                         <br />
                         For a genuinely SLOW upload (the 408s), DevTools throttling does <strong>not</strong> work —
                         browser throttling is request-level, so the request body already went out at full speed.

--- a/src/components/nav/NotificationBell.jsx
+++ b/src/components/nav/NotificationBell.jsx
@@ -8,6 +8,7 @@ import {
   getNotificationActor,
   getNotificationTypeLabel,
   formatNotifTime,
+  formatNotificationMsg,
   getNotificationPostKey,
 } from '../../utils/notificationHelpers';
 import {
@@ -189,8 +190,6 @@ function NotificationBell() {
                     key={group.id}
                     className={`notif-row${unread ? ' notif-row-unread' : ''}${tier ? ` notif-${tier}` : ''}`}
                     onClick={() => handleRowClick(n)}
-                    onMouseEnter={() => setHoveredId(group.id)}
-                    onMouseLeave={() => setHoveredId(null)}
                   >
                     <div className="notif-avatar-wrap">
                       {actor && (
@@ -200,7 +199,7 @@ function NotificationBell() {
                     </div>
                     <div className="notif-body">
                       <div className="notif-msg">
-                        {n.msg || getNotificationTypeLabel(n.type)}
+                        {formatNotificationMsg(n.msg) || getNotificationTypeLabel(n.type)}
                       </div>
                       <div className="notif-meta">
                         <span className="notif-type">{getNotificationTypeLabel(n.type)}</span>
@@ -212,18 +211,12 @@ function NotificationBell() {
                       <img className="notif-3speak-icon" src={threeSpeakLogo} alt="3Speak" title="3Speak video" />
                     )}
                     {unread && <span className="notif-unread-dot" aria-hidden="true" />}
-
-                    {/* Rich preview tooltip */}
-                    {hoveredId === group.id && n.msg && (
-                      <div className="notif-tooltip">
-                        <div className="notif-tooltip-msg">{n.msg}</div>
-                        {tier && (
-                          <span className="notif-tooltip-tier">
-                            {tier === 'whale' ? '🐋 Whale' : '🐬 Orca'} account
-                          </span>
-                        )}
-                      </div>
-                    )}
+                    {/* No hover tooltip on single rows: it repeated `n.msg`, which is
+                        already the row's own text above, and restated a tier the
+                        badge beside the avatar already shows. It covered the rows
+                        below it to tell you nothing new. The GROUPED row keeps its
+                        tooltip because that one does add something: the collapsed
+                        row says "2 Follows" without naming who. */}
                   </li>
                 );
               })}

--- a/src/components/tooltip/TagsV2Picker.jsx
+++ b/src/components/tooltip/TagsV2Picker.jsx
@@ -41,13 +41,17 @@ function TagsV2Picker({
   const [query, setQuery] = useState('');
   const q = query.trim().toLowerCase();
 
-  // Search → flat list of matches. Topics always; categories only in single mode
-  // (they aren't selectable interests in multi).
+  // Search → flat list of matches. Both topics AND categories, in both modes: a
+  // whole area is a selectable interest now, so it has to be findable by typing
+  // its name and not only by browsing the tiles.
   const matches = useMemo(() => {
     if (!q) return null;
     const out = [];
     for (const cat of TAG_CATEGORIES) {
-      if (!multi && cat.label.toLowerCase().includes(q)) {
+      // Categories are searchable in BOTH modes now. They used to be hidden from
+      // multi-select results, which made a whole area findable by browsing but not
+      // by typing its name — the one way most people look for it.
+      if (cat.label.toLowerCase().includes(q)) {
         out.push({ slug: cat.slug, label: cat.label, emoji: cat.emoji, isCat: true });
       }
       for (const t of cat.topics) {
@@ -65,8 +69,16 @@ function TagsV2Picker({
 
   const pickCategory = (slug) => {
     if (disabled) return;
-    if (multi) setOpenCatMulti((prev) => (prev === slug ? null : slug)); // expand/collapse
-    else onChange(value === slug ? '' : slug);                            // select/clear
+    if (multi) {
+      // Clicking a whole area SELECTS it, which is what people expect from a tile
+      // that looks like every other pickable chip. It used to only expand, so a
+      // parent category was browsable but unpickable. It still expands too, so the
+      // topics stay one click away if you want to narrow down instead.
+      toggleMulti(slug);
+      setOpenCatMulti((prev) => (prev === slug ? null : slug));
+    } else {
+      onChange(value === slug ? '' : slug);                              // select/clear
+    }
   };
 
   const pickTopic = (slug) => {
@@ -154,10 +166,13 @@ function TagsV2Picker({
                 <button
                   type="button"
                   key={cat.slug}
-                  className={`tagsv2-cat${isOpen ? ' open' : ''}${value === cat.slug ? ' selected' : ''}${cnt > 0 ? ' has-selected' : ''}`}
+                  // `value === cat.slug` only ever worked in single mode: in multi,
+                  // `value` is an ARRAY, so a selected category could never render
+                  // as selected. isSel() handles both shapes.
+                  className={`tagsv2-cat${isOpen ? ' open' : ''}${isSel(cat.slug) ? ' selected' : ''}${cnt > 0 ? ' has-selected' : ''}`}
                   onClick={() => pickCategory(cat.slug)}
                   disabled={disabled}
-                  aria-pressed={isOpen}
+                  aria-pressed={isSel(cat.slug)}
                 >
                   <span className="tagsv2-emoji">{cat.emoji}</span>
                   <span className="tagsv2-label">{cat.label}</span>
@@ -172,7 +187,9 @@ function TagsV2Picker({
             <div className="tagsv2-topics">
               <p className="tagsv2-hint">
                 {multi
-                  ? 'Pick the topics you care about:'
+                  ? (isSel(openCategory.slug)
+                      ? `All of ${openCategory.label} is selected. Add individual topics only to go narrower:`
+                      : 'Or pick individual topics:')
                   : isCategorySlug(value)
                     ? 'Good enough — or get more specific (optional):'
                     : 'More specific:'}

--- a/src/context/EmbedUploadContext.jsx
+++ b/src/context/EmbedUploadContext.jsx
@@ -154,6 +154,18 @@ export function EmbedUploadProvider({ children }) {
   const [completed, setCompleted] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
   const [statusText, setStatusText] = useState('');
+  // Structured detail for the progress bar's diagnostics line. The percentage
+  // alone cannot distinguish "slow" from "wedged", which is the whole problem
+  // with an upload that sits at 0%: the user needs to see WHICH method is in
+  // play, WHAT it is waiting on, and whether bytes are actually moving.
+  //   method:  'resumable' (TUS) | 'reliable' (chunked fallback)
+  //   phase:   short human label for the current step
+  //   sent/total, chunksDone/chunksTotal: byte + chunk counters (may be absent)
+  //   attempt/attempts: retry position, when retrying
+  const [uploadDetail, setUploadDetail] = useState(null);
+  const patchUploadDetail = useCallback((patch) => {
+    setUploadDetail((prev) => ({ ...(prev || {}), ...patch }));
+  }, []);
   const [statusMessages, setStatusMessages] = useState([]);
   const [embedUrl, setEmbedUrl] = useState('');
   // Hive permlink of the just-published post — used by the success screen to
@@ -274,6 +286,7 @@ export function EmbedUploadProvider({ children }) {
     setCompleted(false);
     setUploadProgress(0);
     setStatusText('');
+    setUploadDetail(null);
     setStatusMessages([]);
     setEmbedUrl('');
     setPublishedPermlink('');
@@ -426,11 +439,25 @@ export function EmbedUploadProvider({ children }) {
       // accept and then black-hole. First ack ⇒ PATCH works ⇒ disarm the watchdog.
       onChunkComplete: (chunkSize, bytesAccepted) => {
         if (bytesAccepted > 0 && !firstAck) { firstAck = true; clearWatchdog(); }
+        // Server-confirmed bytes. Distinct from onProgress below, which is only
+        // "pushed into the socket" — the gap between the two is exactly what a
+        // black-holing proxy looks like, so show both.
+        patchUploadDetail({ acked: bytesAccepted, phase: 'Uploading' });
       },
       onProgress: (bytesUploaded, bytesTotal) => {
         const pct = Math.round((bytesUploaded / bytesTotal) * 100);
         setUploadProgress(pct);
         setStatusText(`Uploading video... ${pct}%`);
+        patchUploadDetail({
+          method: 'resumable',
+          phase: firstAck ? 'Uploading' : 'Waiting for first server ack…',
+          // Keep the spinner up through the pre-ack window even though bytes are
+          // leaving: that gap is exactly where a PATCH-eating proxy hides, so
+          // "sending, nothing acknowledged" must not look like healthy progress.
+          waitingOn: firstAck ? undefined : 'first server ack — 15s watchdog',
+          sent: bytesUploaded,
+          total: bytesTotal,
+        });
       },
       onSuccess: () => { clearWatchdog(); resolveDone(); },
       onAfterResponse: (req, res) => {
@@ -492,8 +519,10 @@ export function EmbedUploadProvider({ children }) {
       let selfAborted = null;
       let lastByteAt = Date.now();
       let stallTimer = null;
+      let deadlineTimer = null;
       const done = () => {
         if (stallTimer) { clearInterval(stallTimer); stallTimer = null; }
+        if (deadlineTimer) { clearTimeout(deadlineTimer); deadlineTimer = null; }
         uploadXhrsRef.current.delete(xhr);
       };
 
@@ -508,6 +537,11 @@ export function EmbedUploadProvider({ children }) {
           if (Date.now() - lastByteAt > opts.stallMs) {
             selfAborted = 'STALLED';
             try { xhr.abort(); } catch { /* already gone */ }
+            // Settle directly, same reasoning as the deadline below: a swallowed
+            // request may never dispatch ANY event, so the watchdog cannot depend
+            // on abort() producing one.
+            done();
+            reject(Object.assign(new Error('Upload stalled — no data moved'), { code: 'STALLED', retryable: true }));
           }
         }, 2000);
       }
@@ -519,6 +553,24 @@ export function EmbedUploadProvider({ children }) {
           done();
           reject(Object.assign(new Error('Request timed out'), { code: 'TIMEOUT', retryable: true }));
         };
+        // `xhr.timeout` only starts counting once send() actually dispatches the
+        // request. A middlebox that swallows the request whole never lets it get
+        // that far, so ontimeout never fires and the promise hangs forever — the
+        // "stuck at 0%, upload never starts" report. Own the deadline ourselves so
+        // it holds even when the request never leaves. Slightly later than
+        // xhr.timeout so the native event wins when the request DID go out.
+        //
+        // Settle the promise HERE rather than relying on abort() to fire onabort:
+        // when the request never really left, there is no guarantee any event is
+        // dispatched at all, and a deadline that depends on the very machinery it
+        // is guarding against is not a deadline. reject() after settle is a no-op,
+        // so the native onabort path staying is harmless.
+        deadlineTimer = setTimeout(() => {
+          selfAborted = 'TIMEOUT';
+          try { xhr.abort(); } catch { /* already gone */ }
+          done();
+          reject(Object.assign(new Error('Request timed out'), { code: 'TIMEOUT', retryable: true }));
+        }, opts.timeoutMs + 1000);
       }
       xhr.onload = () => {
         done();
@@ -534,7 +586,10 @@ export function EmbedUploadProvider({ children }) {
       xhr.onabort = () => {
         done();
         if (selfAborted) {
-          reject(Object.assign(new Error('Upload stalled — no data moved'), { code: selfAborted, retryable: true }));
+          const msg = selfAborted === 'TIMEOUT'
+            ? 'Request timed out'
+            : 'Upload stalled — no data moved';
+          reject(Object.assign(new Error(msg), { code: selfAborted, retryable: true }));
         } else {
           reject(Object.assign(new Error('Aborted'), { code: 'ABORTED' }));
         }
@@ -592,7 +647,7 @@ export function EmbedUploadProvider({ children }) {
     try { stored = localStorage.getItem(fpKey); } catch { /* ignore */ }
     if (stored) {
       try {
-        const st = await postForm(`${base}/upload/chunk/status`, { sessionId: stored });
+        const st = await postForm(`${base}/upload/chunk/status`, { sessionId: stored }, null, { timeoutMs: 15000 });
         if (st && Number.isFinite(st.totalChunks)) {
           sessionId = stored;
           totalChunks = st.totalChunks;
@@ -612,13 +667,59 @@ export function EmbedUploadProvider({ children }) {
       embedFromServer = tokenRes.data?.embed_url || '';
       if (!token) throw new Error('Failed to obtain upload token');
 
-      const created = await postForm(`${base}/upload/chunk/create`, {
-        token,
-        filename: file.name,
-        duration: String(Math.round(videoDuration)),
-        size: String(size),
-        chunkSize: String(chunkSize),
-      });
+      // The control-plane calls (create/status/finish) carry no payload worth
+      // speaking of, so the byte-based stall watchdog cannot guard them — nothing
+      // ever "moves" for it to notice. They get a hard deadline instead, and
+      // create is retried: a middlebox that swallows chunk POSTs swallows THIS
+      // one too, and an unguarded create is precisely the failure where the bar
+      // sits at 0% and the upload never starts at all.
+      // Short deadline on purpose: create carries a handful of form fields, so if
+      // it has not answered in 15s the path is dead, not slow. A long timeout here
+      // buys nothing and just leaves the bar sitting at 0% with no explanation.
+      const CREATE_TIMEOUT_MS = 15000;
+      const CREATE_ATTEMPTS = 3;
+      let created = null;
+      let createErr = null;
+      for (let attempt = 0; attempt < CREATE_ATTEMPTS && !created; attempt++) {
+        // Say something BEFORE the first attempt too. Otherwise the whole first
+        // deadline elapses with the bar frozen at 0% and no status change, which
+        // reads exactly like the hang this guard was added to prevent.
+        setStatusText(attempt === 0
+          ? 'Starting upload…'
+          : `Connection unstable — retrying… (${attempt + 1}/${CREATE_ATTEMPTS})`);
+        patchUploadDetail({
+          method: 'reliable',
+          phase: attempt === 0 ? 'Opening upload session' : 'Retrying upload session',
+          waitingOn: `POST /upload/chunk/create — ${CREATE_TIMEOUT_MS / 1000}s deadline`,
+          attempt: attempt + 1,
+          attempts: CREATE_ATTEMPTS,
+          sent: 0,
+          total: size,
+        });
+        if (attempt > 0) {
+          await sleep(2000 * attempt);
+        }
+        try {
+          created = await postForm(
+            `${base}/upload/chunk/create`,
+            {
+              token,
+              filename: file.name,
+              duration: String(Math.round(videoDuration)),
+              size: String(size),
+              chunkSize: String(chunkSize),
+            },
+            null,
+            { timeoutMs: CREATE_TIMEOUT_MS },
+          );
+        } catch (e) {
+          if (e?.code === 'ABORTED') throw e;   // user hit reset — stop
+          createErr = e;
+        }
+      }
+      if (!created) {
+        throw createErr || new Error('Could not start the upload — please retry');
+      }
       sessionId = created.sessionId;
       totalChunks = created.totalChunks;
       chunkSize = created.chunkSize;
@@ -638,6 +739,18 @@ export function EmbedUploadProvider({ children }) {
       const pct = size ? Math.min(99, Math.floor((live / size) * 100)) : 0;
       setUploadProgress(pct);
       setStatusText(`Uploading video... ${pct}%`);
+      patchUploadDetail({
+        method: 'reliable',
+        phase: 'Uploading',
+        waitingOn: undefined,   // session is open; we are moving, not waiting
+        attempt: undefined,
+        attempts: undefined,
+        sent: live,
+        acked: serverBytes,
+        total: size,
+        chunksDone: received.size,
+        chunksTotal: totalChunks,
+      });
     };
     paint();
 
@@ -719,9 +832,78 @@ export function EmbedUploadProvider({ children }) {
     await Promise.all(Array.from({ length: workers }, worker));
     if (failed) throw failed;
 
-    const fin = await postForm(`${base}/upload/chunk/finish`, { sessionId });
+    const fin = await postForm(`${base}/upload/chunk/finish`, { sessionId }, null, { timeoutMs: 60000 });
     try { localStorage.removeItem(fpKey); } catch { /* ignore */ }
     return fin.embed_url || embedFromServer || '';
+  }, [user, fromStories, videoFile, videoDuration, postForm]);
+
+  // TIER 3, last resort: ONE multipart POST carrying the whole file.
+  //
+  // Why it can help when the other two are dead: it is the smallest possible
+  // request shape. No PATCH (tier 1's weak spot), no session handshake and no
+  // repeated same-shaped POSTs (tier 2's), just a single ordinary form upload of
+  // the kind every proxy on earth already passes. A middlebox that mangles the
+  // chunk protocol often waves this straight through.
+  //
+  // The trade is real and it is why this is LAST, not first: there is no resume.
+  // One drop and the whole file starts over, so on a genuinely bad link this can
+  // burn a lot of bandwidth for nothing. Guarded by stallMs (byte-based) and
+  // deliberately NOT by a hard timeout — a slow-but-moving upload must never be
+  // killed for being slow, which is the whole point of offering it.
+  const runSimpleUpload = useCallback(async () => {
+    const base = (EMBED_API_URL || '').replace(/\/+$/, '');
+    const file = videoFile;
+    if (!file) throw new Error('No video selected');
+    const size = file.size;
+
+    setStatusText('Trying one last method — sending in a single request…');
+    patchUploadDetail({
+      method: 'single-shot',
+      phase: 'Sending whole file in one request (no resume)',
+      waitingOn: 'POST /upload/simple',
+      attempt: undefined,
+      attempts: undefined,
+      chunksDone: undefined,
+      chunksTotal: undefined,
+      acked: undefined,
+      sent: 0,
+      total: size,
+    });
+
+    const tokenRes = await axios.post(
+      `${base}/uploads/token`,
+      { owner: user, frontend_app: '3speak-tv', short: !!fromStories },
+      { headers: { 'X-API-Key': EMBED_API_KEY, 'Content-Type': 'application/json' } },
+    );
+    const token = tokenRes.data?.token;
+    if (!token) throw new Error('Failed to obtain upload token');
+
+    const res = await postForm(
+      `${base}/upload/simple`,
+      {
+        token,
+        filename: file.name,
+        duration: String(Math.round(videoDuration)),
+        frontend_app: '3speak-tv',
+      },
+      { file },
+      {
+        stallMs: 60000,
+        onProgress: (loaded) => {
+          const pct = size ? Math.min(99, Math.floor((loaded / size) * 100)) : 0;
+          setUploadProgress(pct);
+          setStatusText(`Uploading in a single request… ${pct}%`);
+          patchUploadDetail({
+            sent: loaded,
+            total: size,
+            waitingOn: loaded > 0 ? undefined : 'POST /upload/simple',
+          });
+        },
+      },
+    );
+
+    if (!res || !res.embed_url) throw new Error('Single-request upload did not return an embed URL');
+    return res.embed_url;
   }, [user, fromStories, videoFile, videoDuration, postForm]);
 
   // Upload with automatic fallback. Primary path is TUS on the least-busy host;
@@ -732,10 +914,24 @@ export function EmbedUploadProvider({ children }) {
   const runUploadWithFallback = useCallback(async (generatedPermlink) => {
     const reliableBase = (EMBED_API_URL || '').replace(/\/+$/, '');
 
+    // Chunked, then the single-request last resort if chunked itself is dead.
+    // A user reset (ABORTED) is deliberate and must never escalate to another
+    // attempt — only genuine transport failures fall through.
+    const chunkedThenSimple = async () => {
+      try {
+        return await runChunkedUpload();
+      } catch (chunkErr) {
+        if (chunkErr?.code === 'ABORTED') throw chunkErr;
+        console.warn('Chunked upload failed — trying single-request fallback', chunkErr);
+        toast.message('Still stuck — trying one last upload method.');
+        return await runSimpleUpload();
+      }
+    };
+
     if (forceReliableUpload || sessionForcedReliableRef.current) {
       chosenEmbedBaseRef.current = reliableBase;
       setSelectedEndpoint(reliableBase);
-      return await runChunkedUpload();
+      return await chunkedThenSimple();
     }
 
     const { base, uploadUrl } = await pickEmbedEndpoint();
@@ -752,11 +948,11 @@ export function EmbedUploadProvider({ children }) {
         setUploadProgress(0);
         chosenEmbedBaseRef.current = reliableBase;
         setSelectedEndpoint(reliableBase);
-        return await runChunkedUpload();
+        return await chunkedThenSimple();
       }
       throw err;
     }
-  }, [forceReliableUpload, runTusUpload, runChunkedUpload]);
+  }, [forceReliableUpload, runTusUpload, runChunkedUpload, runSimpleUpload]);
 
   // Kick off the background upload (called when the user reaches "Add details").
   // Idempotent: only starts once per selected video. The embed asset gets its own
@@ -795,6 +991,11 @@ export function EmbedUploadProvider({ children }) {
         earlyUploadStartedRef.current = false;
         earlyUploadPromiseRef.current = null;
         setVideoUploadStatus('error');
+        // Say WHY, in the bar the user is actually looking at. Without this the
+        // last thing on screen stays "retrying…" forever, which is
+        // indistinguishable from the hang these guards exist to prevent.
+        setStatusText(err?.message || 'Upload failed — please retry');
+        toast.error(err?.message || 'Upload failed — please retry');
         return '';
       }
     })();
@@ -1404,6 +1605,7 @@ export function EmbedUploadProvider({ children }) {
     completed, setCompleted,
     uploadProgress, setUploadProgress,
     statusText, setStatusText,
+    uploadDetail, setUploadDetail,
     statusMessages, setStatusMessages,
     embedUrl, setEmbedUrl,
     publishedPermlink,

--- a/src/hooks/useSubtitles.js
+++ b/src/hooks/useSubtitles.js
@@ -1,9 +1,29 @@
 import { useState, useEffect, useCallback } from 'react';
-import { TRANSLATE_API_URL } from '../utils/config';
+import { TRANSLATE_API_URL, CHECKER_URL } from '../utils/config';
 import { parseSrt } from '../utils/srtParser';
 
 const SUBTITLE_LANG_KEY = '3speak-subtitle-lang';
 const SUBTITLE_STYLE_KEY = '3speak-subtitle-style';
+
+// The CDN is fronted by a specific hot-pinning node — content not yet
+// propagated to IT 500s ("block was not found locally") even though
+// ipfs.3speak.tv already serves it fine. Try the CDN first (fast, direct);
+// on failure go through OUR OWN backend rather than fetching ipfs.3speak.tv
+// straight from the browser — that gateway sends `access-control-allow-origin`
+// TWICE on every response, which every real browser rejects outright
+// ("Failed to fetch", confirmed live) even though the value itself is fine.
+// The proxy fetches server-to-server (no CORS involved) and re-serves it
+// with a single, correct header via our own cors() middleware.
+async function fetchSrtWithFallback(cid) {
+  try {
+    const res = await fetch(`https://hotipfs-3speak-1.b-cdn.net/ipfs/${cid}`);
+    if (res.ok) return await res.text();
+  } catch { /* fall through to the proxy */ }
+
+  const res = await fetch(`${CHECKER_URL}/subtitle-proxy/${cid}`);
+  if (!res.ok) throw new Error(`subtitle-proxy responded ${res.status}`);
+  return await res.text();
+}
 
 const DEFAULT_STYLE = {
   fontSize: 'medium',
@@ -110,11 +130,7 @@ export default function useSubtitles(author, permlink, { autoEnglish = false } =
 
     (async () => {
       try {
-        const res = await fetch(
-          `https://hotipfs-3speak-1.b-cdn.net/ipfs/${langEntry.cid}`
-        );
-        if (cancelled) return;
-        const srtText = await res.text();
+        const srtText = await fetchSrtWithFallback(langEntry.cid);
         if (cancelled) return;
         const parsed = parseSrt(srtText);
         console.log('[useSubtitles] Parsed', parsed.length, 'cues from', langEntry.cid);

--- a/src/hooks/useWatchDuration.js
+++ b/src/hooks/useWatchDuration.js
@@ -80,7 +80,17 @@ export default function useWatchDuration({ api, author, permlink, playerState, e
       if (meta?.owner) owner = meta.owner;
       if (meta?.permlink) vPermlink = meta.permlink;
 
-      const duration = Number(playerState?.duration) || undefined;
+      // Prefer the STORED duration from the embed metadata we just resolved
+      // over playerState.duration. Under HLS/MSE the player's own duration,
+      // read at first play, can transiently report only the buffered-so-far
+      // segment span instead of the full manifest total — that race is what
+      // recorded 6s for a 120s video and poisoned retention/heatmap data.
+      // The live reading stays as the fallback for anything the metadata
+      // doesn't cover (e.g. legacy videos with no stored duration).
+      const storedDuration = Number(meta?.duration);
+      const duration = (Number.isFinite(storedDuration) && storedDuration > 0)
+        ? storedDuration
+        : (Number(playerState?.duration) || undefined);
       // A video lives in exactly one collection — try embed (also matches
       // hive_permlink) then legacy; whichever owns it opens the session.
       for (const type of ['embed', 'legacy']) {

--- a/src/page/Notifications.jsx
+++ b/src/page/Notifications.jsx
@@ -13,6 +13,7 @@ import {
   getNotificationActor,
   getNotificationTypeLabel,
   formatNotifTime,
+  formatNotificationMsg,
   getNotificationPostKey,
 } from '../utils/notificationHelpers';
 import {
@@ -491,7 +492,7 @@ function Notifications() {
                         </div>
                         <div className="notifications-body">
                           <div className="notifications-msg">
-                            {n.msg || getNotificationTypeLabel(n.type)}
+                            {formatNotificationMsg(n.msg) || getNotificationTypeLabel(n.type)}
                           </div>
                           <div className="notifications-meta">
                             <span className="notifications-type">{getNotificationTypeLabel(n.type)}</span>
@@ -714,7 +715,7 @@ function GroupRow({ group, isUnread, is3Speak, getWhaleTier, onClick }) {
               {tier && <span className={`notifications-tier-badge tier-${tier}`}>{tier === 'whale' ? '🐋' : '🐬'}</span>}
             </div>
             <div className="notifications-body">
-              <div className="notifications-msg">{n.msg}</div>
+              <div className="notifications-msg">{formatNotificationMsg(n.msg)}</div>
               <div className="notifications-meta">
                 <span className="notifications-time">{formatNotifTime(n.date)}</span>
               </div>

--- a/src/page/ProfilePage.jsx
+++ b/src/page/ProfilePage.jsx
@@ -6,7 +6,7 @@ import { toast } from "sonner";
 
 import { useAppStore } from "../lib/store";
 import { getFollowers } from "../hive-api/api";
-import { MY_VIDEOS_URL } from "../utils/config";
+import { MY_VIDEOS_URL, CHECKER_URL } from "../utils/config";
 
 import Card3 from "../components/Cards/Card3";
 import Follower from "../components/Userprofilepage/Follower";
@@ -90,11 +90,22 @@ function ProfilePage() {
 
   // Switch tab AND reflect it in the URL so browser back-navigation
   // (e.g. returning from an opened short/playlist) lands on the same tab.
-  const selectTab = useCallback((tab) => {
+  // `permlink`/`opts` are the Overview page's community cards routing to one
+  // specific snap (`opts.openComments` additionally opens + focuses its thread)
+  // — see ProfileOverview's openCommunityTab and SnapCard's onOpenTab.
+  const selectTab = useCallback((tab, permlink, opts) => {
     setShow(tab);
-    const q = tab && tab !== 'overview' ? `?tab=${tab}` : '';
+    const params = new URLSearchParams();
+    if (tab && tab !== 'overview') params.set('tab', tab);
+    if (permlink) params.set('snap', permlink);
+    if (opts?.openComments) params.set('comments', '1');
+    const q = params.toString() ? `?${params.toString()}` : '';
     navigate(`/profile${q}`, { replace: true });
   }, [navigate]);
+
+  // The specific snap an Overview card routed here for (if any).
+  const targetSnap = searchParams.get('snap') || null;
+  const openSnapComments = searchParams.get('comments') === '1';
 
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [newPlaylistName, setNewPlaylistName] = useState('');
@@ -321,6 +332,30 @@ function ProfilePage() {
   });
   const snapCount = snapCountData?.total || 0;
 
+  // Video/shorts counts for their tab headers — SAME query key ProfileStats
+  // uses for the "50 videos / 14 shorts" stat line, so this is a cache hit,
+  // not a second request.
+  const { data: profileCounts } = useQuery({
+    queryKey: ["profile-counts", user],
+    queryFn: async () => (await axios.get(`${CHECKER_URL}/user/${encodeURIComponent(user)}/counts`)).data,
+    enabled: !!user,
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+  const videoCount = profileCounts?.videos || 0;
+  const shortsCount = profileCounts?.shorts || 0;
+
+  // Audio count for its tab header — the /audio endpoint already returns a
+  // `total` alongside the page of items; limit=1 keeps this a count-only call.
+  const { data: audioCountData } = useQuery({
+    queryKey: ["audio-count", user],
+    queryFn: async () => (await axios.get(`${CHECKER_URL}/audio?owner=${encodeURIComponent(user)}&limit=1`)).data,
+    enabled: !!user,
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+  const audioCount = audioCountData?.total || 0;
+
   // Streams tab only exists when there's something to show — a running
   // OpenPods session, or the VOD of a finished one. Counts both.
   const { data: streamCount = 0 } = useQuery({
@@ -522,9 +557,15 @@ function ProfilePage() {
       <div className="toggle-wrap">
         <div className="wrap">
           <span className={show === "overview" ? "active" : ""} onClick={() => selectTab("overview")}>Overview</span>
-          <span className={show === "video" ? "active" : ""} onClick={() => selectTab("video")}>Videos</span>
-          <span className={show === "shorts" ? "active" : ""} onClick={() => selectTab("shorts")}>Shorts</span>
-          <span className={show === "audio" ? "active" : ""} onClick={() => selectTab("audio")}>Audio</span>
+          <span className={show === "video" ? "active" : ""} onClick={() => selectTab("video")}>
+            Videos {videoCount > 0 && `(${videoCount})`}
+          </span>
+          <span className={show === "shorts" ? "active" : ""} onClick={() => selectTab("shorts")}>
+            Shorts {shortsCount > 0 && `(${shortsCount})`}
+          </span>
+          <span className={show === "audio" ? "active" : ""} onClick={() => selectTab("audio")}>
+            Audio {audioCount > 0 && `(${audioCount})`}
+          </span>
           {streamCount > 0 && (
             <span className={show === "streams" ? "active" : ""} onClick={() => selectTab("streams")}>
               Streams ({streamCount})
@@ -588,6 +629,12 @@ function ProfilePage() {
         {show === "overview" ? (
           <ProfileOverview
             username={user}
+            /* /profile IS the signed-in user's own profile, and /p/<self>
+               redirects here, so this is unconditionally true. Without it
+               ChannelTrailer defaulted to isOwnProfile=false and swallowed the
+               "Add a channel trailer" prompt, leaving the feature undiscoverable
+               for anyone who hadn't already set one. */
+            isOwnProfile
             videos={videoListItems}
             shorts={shortsVideos}
             playlists={playlists}
@@ -624,7 +671,7 @@ function ProfilePage() {
         ) : show === "streams" ? (
           <ProfileStreams user={user} getViewCount={getViewCount} />
         ) : show === "community" ? (
-          <CommunitySnaps user={user} canPost={!!user} />
+          <CommunitySnaps user={user} canPost={!!user} targetPermlink={targetSnap} openComments={openSnapComments} />
         ) : show === "links" ? (
           <SpotlightEditor username={user} />
         ) : show === "stats" ? (

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -89,8 +89,11 @@ const FEATURE_EDITOR = import.meta.env.VITE_FEATURE_EDITOR === 'true';
 const COMPACT_SIDEBAR = import.meta.env.VITE_COMPACT_SIDEBAR === 'true';
 
 // 3Speak Embed upload (for video reactions)
-const EMBED_UPLOAD_URL = import.meta.env.VITE_EMBED_UPLOAD_URL || 'https://embed.3speak.tv/uploads';
-const EMBED_API_URL = import.meta.env.VITE_EMBED_API_URL || 'https://embed.3speak.tv';
+// Defaults point at embed2, NOT the legacy embed.3speak.tv: that box runs an
+// older build and is the one instance still missing the hive-link rebind guard,
+// so it must not be what an unset env var falls back to.
+const EMBED_UPLOAD_URL = import.meta.env.VITE_EMBED_UPLOAD_URL || 'https://embed2.3speak.tv/uploads';
+const EMBED_API_URL = import.meta.env.VITE_EMBED_API_URL || 'https://embed2.3speak.tv';
 const EMBED_API_KEY = import.meta.env.VITE_EMBED_API_KEY || '';
 
 // Pool of embed-upload server BASE hosts (no trailing /uploads), e.g.

--- a/src/utils/interests.js
+++ b/src/utils/interests.js
@@ -60,11 +60,44 @@ function parsePostingMeta(account) {
   return {};
 }
 
+// v1 slugs that v2 dropped, mapped to their nearest surviving topic so an old
+// pick keeps expressing something. `tutorial` was v1-only and the v2 auto-tagger
+// never emits it, so it matches literally zero videos site-wide; education is the
+// closest thing the taxonomy still has.
+const LEGACY_TAG_MIGRATIONS = { tutorial: 'education' };
+
+/**
+ * Canonicalise an interest list: migrate retired slugs, drop unknowns, dedupe.
+ *
+ * Both ends of this file used to filter against INTEREST_ID_SET, the RETIRED v1
+ * vocabulary of 16 tags, while the picker had long since moved to v2. So every
+ * one of the 7 categories AND every v2-only topic (programming, business,
+ * film-tv, lifestyle, comedy, story-time, commercial, diy-crafts, photography,
+ * pets, gardening, fitness, spirituality, politics) was silently discarded — on
+ * SAVE before broadcasting, and again on READ. Picking "Programming" appeared to
+ * work and stored nothing. Accept the full v2 vocabulary, keeping v1 ids valid so
+ * accounts saved by the old prod picker still load.
+ */
+function normalizeInterestList(list) {
+  const out = [];
+  const seen = new Set();
+  for (const raw of list || []) {
+    const t = String(raw || '').trim().toLowerCase().replace(/^#/, '');
+    if (!t) continue;
+    const slug = LEGACY_TAG_MIGRATIONS[t] || t;
+    if (!isKnownTagV2(slug) && !INTEREST_ID_SET.has(slug)) continue;
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    out.push(slug);
+  }
+  return out;
+}
+
 // Pull the saved interests out of an already-fetched account object.
 export function readInterestsFromAccount(account) {
   const meta = parsePostingMeta(account);
   const arr = meta && meta[META_NS] && meta[META_NS].interests;
-  return Array.isArray(arr) ? arr.filter((t) => INTEREST_ID_SET.has(t)) : [];
+  return Array.isArray(arr) ? normalizeInterestList(arr) : [];
 }
 
 // Fetch a user's saved interests from Hive. Returns an array, or null on a
@@ -88,8 +121,10 @@ export async function fetchUserInterests(username) {
 export async function saveInterestsToHive(username, interests) {
   const u = clean(username);
   if (!u) throw new Error('Not logged in');
-  const list = [...new Set((interests || []).map((t) => String(t).trim().toLowerCase()))]
-    .filter((t) => INTEREST_ID_SET.has(t));
+  // Same canonicalisation as the read path — this used to filter to the retired
+  // v1 vocabulary, which quietly dropped categories and v2-only topics on the way
+  // to the chain.
+  const list = normalizeInterestList(interests);
 
   // Merge into current metadata (fetch fresh so we don't clobber the profile).
   const [account] = await getAccounts([u]);

--- a/src/utils/notificationHelpers.js
+++ b/src/utils/notificationHelpers.js
@@ -90,6 +90,23 @@ export function getNotificationTypeLabel(type) {
   return TYPE_LABELS[type] || type || 'did something';
 }
 
+/**
+ * Tidy the notification text Hive hands us.
+ *
+ * `bridge.account_notifications` builds `msg` from a raw count with no
+ * pluralisation, so a mention of nobody else arrives as
+ * "@alice mentioned you and 0 others" and one other as "... and 1 others".
+ * Verified straight off the API, so this is upstream text, not ours to fix at
+ * the source: drop the clause when there is nobody else, and singularise it
+ * when there is exactly one. Any other count is already correct and untouched.
+ */
+export function formatNotificationMsg(msg) {
+  if (typeof msg !== 'string' || !msg) return msg;
+  return msg
+    .replace(/\s+and\s+0\s+others\b/i, '')
+    .replace(/\s+and\s+1\s+others\b/i, ' and 1 other');
+}
+
 /** Short relative time like "5m", "3h", "2d". */
 export function formatNotifTime(dateString) {
   if (!dateString) return '';

--- a/src/utils/uploadFaults.js
+++ b/src/utils/uploadFaults.js
@@ -29,7 +29,8 @@ export function canUseUploadFaults(user) {
 
 const DEFAULTS = {
   blockPatch: false,       // carrier eats the TUS PATCH → should trip the watchdog → auto-fallback
-  blackholeChunks: false,  // middlebox swallows the fallback's chunk POSTs → should trip the stall watchdog
+  blackholeChunks: false,  // middlebox swallows the chunk-protocol POSTs → create/stall watchdogs → tier 3
+  blackholeSimple: false,  // ALSO swallow the single-request last resort → total blackout, nothing can pass
   chunkFailRate: 0,        // 0..1 — flaky link: fail this share of chunk POSTs → should retry + resync
 };
 
@@ -56,12 +57,21 @@ export function clearUploadFaults() {
 }
 
 function isArmed(f) {
-  return !!(f.blockPatch || f.blackholeChunks || f.chunkFailRate > 0);
+  return !!(f.blockPatch || f.blackholeChunks || f.blackholeSimple || f.chunkFailRate > 0);
 }
 
 // Only ever touch the upload endpoints — never the rest of the app's traffic.
+//
+// The chunk PROTOCOL (create/status/finish + the data POSTs) and the
+// single-request last resort are DIFFERENT transports and must be blockable
+// independently. They used to share one matcher, which meant the "black-hole the
+// chunks" switch silently killed the single-request fallback too — so tier 3
+// could never be exercised, and the harness reported "nothing works" for a
+// network on which something would in fact have worked.
 const isTusUrl = (url) => /\/uploads(\/|$)/.test(url);
-const isChunkUrl = (url) => /\/upload\/(chunk|simple)/.test(url);
+const isChunkUrl = (url) => /\/upload\/chunk/.test(url);
+const isSimpleUrl = (url) => /\/upload\/simple/.test(url);
+const isUploadUrl = (url) => isTusUrl(url) || isChunkUrl(url) || isSimpleUrl(url);
 
 const log = (...a) => console.warn('[upload-faults]', ...a);
 
@@ -87,12 +97,13 @@ export function installUploadFaults() {
     const f = getUploadFaults();
     const { method = '', url = '' } = this.__fault || {};
 
-    if (isArmed(f) && (isTusUrl(url) || isChunkUrl(url))) {
+    if (isArmed(f) && isUploadUrl(url)) {
       // A black hole: the request leaves and NOTHING ever comes back. No response,
       // no error, no timeout — the case that hangs a naive uploader forever.
       const blackhole =
         (f.blockPatch && method === 'PATCH') ||
-        (f.blackholeChunks && method === 'POST' && isChunkUrl(url));
+        (f.blackholeChunks && method === 'POST' && isChunkUrl(url)) ||
+        (f.blackholeSimple && method === 'POST' && isSimpleUrl(url));
 
       if (blackhole) {
         log(`black-holed ${method} ${url}`);


### PR DESCRIPTION
This pull request introduces several improvements to the user profile's Overview and Community tabs, focusing on better integration between the channel trailer, community snaps, and the UI for reading and commenting on snaps. The changes enhance navigation, accessibility, and visual clarity, especially when routing users from overview previews to full community threads.

**Key changes include:**

### Improved Routing and Interaction between Overview and Community Tabs

- Added the ability for "Read more" and comment actions in the `ChannelTrailer` and Community preview rails to route users directly to the relevant snap in the Community tab, opening the comment thread and highlighting the targeted card. This is achieved by passing `onOpenCommunityTab`/`onOpenTab` handlers and new props like `autoOpenComments`, `targetPermlink`, and `openComments` through `ChannelTrailer`, `ProfileOverview`, `CommunitySnaps`, and `SnapCard`. [[1]](diffhunk://#diff-81e010d10dc97d6a044bb081b5a394207f142a69363b6af5170e1aef6619f2fdL41-R41) [[2]](diffhunk://#diff-81e010d10dc97d6a044bb081b5a394207f142a69363b6af5170e1aef6619f2fdR198-R218) [[3]](diffhunk://#diff-acc5398f36d96ca911094886733b2f75b702563a79de486dfb5b79a09f162280R76-R82) [[4]](diffhunk://#diff-acc5398f36d96ca911094886733b2f75b702563a79de486dfb5b79a09f162280L114-R118) [[5]](diffhunk://#diff-dde61efd883913a43b577a86874aefb5856e68a13bb4a0a9abb47643d07a1226L397-R424) [[6]](diffhunk://#diff-dde61efd883913a43b577a86874aefb5856e68a13bb4a0a9abb47643d07a1226L575-R608) [[7]](diffhunk://#diff-dde61efd883913a43b577a86874aefb5856e68a13bb4a0a9abb47643d07a1226L618-R658)

- The `SnapCard` component now visually highlights the card a user is routed to and automatically scrolls it into view, ensuring users can easily find the snap/thread they were directed to. [[1]](diffhunk://#diff-dde61efd883913a43b577a86874aefb5856e68a13bb4a0a9abb47643d07a1226L397-R424) [[2]](diffhunk://#diff-dde61efd883913a43b577a86874aefb5856e68a13bb4a0a9abb47643d07a1226L473-R493) [[3]](diffhunk://#diff-7f479813d225de3f68d38220638461a5d3e1e8007c5ffd85afe84fa837f9692fR294-R301)

### UI/UX Enhancements for Snap Previews and Comments

- "Read more" links in snap previews and the channel trailer now consistently navigate to the full content, rather than expanding inline in constrained spaces. The comment button similarly hands off to the Community tab when in preview mode. [[1]](diffhunk://#diff-81e010d10dc97d6a044bb081b5a394207f142a69363b6af5170e1aef6619f2fdR198-R218) [[2]](diffhunk://#diff-dde61efd883913a43b577a86874aefb5856e68a13bb4a0a9abb47643d07a1226L87-R91) [[3]](diffhunk://#diff-dde61efd883913a43b577a86874aefb5856e68a13bb4a0a9abb47643d07a1226L510-R534) [[4]](diffhunk://#diff-dde61efd883913a43b577a86874aefb5856e68a13bb4a0a9abb47643d07a1226L545-R582)

- The `SnapComments` component supports an `autoFocus` prop, ensuring the reply box is focused when a user is routed directly to a comment thread. [[1]](diffhunk://#diff-dde61efd883913a43b577a86874aefb5856e68a13bb4a0a9abb47643d07a1226L201-R204) [[2]](diffhunk://#diff-dde61efd883913a43b577a86874aefb5856e68a13bb4a0a9abb47643d07a1226L210-R213) [[3]](diffhunk://#diff-dde61efd883913a43b577a86874aefb5856e68a13bb4a0a9abb47643d07a1226L545-R582)

### Styling and Layout Refinements

- Adjusted the layout and clipping logic for the channel trailer's side columns and snap previews, ensuring that only descriptions are clipped with a fade, and "Read more" links remain visible. Snap cards now size to their own (already-capped) content, preventing double clipping and ensuring controls are always accessible. [[1]](diffhunk://#diff-32cada0314c8edde9948a2fce4c07931cde1623214c05482426f570e11b892d7L51-L70) [[2]](diffhunk://#diff-32cada0314c8edde9948a2fce4c07931cde1623214c05482426f570e11b892d7R71-R85) [[3]](diffhunk://#diff-32cada0314c8edde9948a2fce4c07931cde1623214c05482426f570e11b892d7R102-R169) [[4]](diffhunk://#diff-32cada0314c8edde9948a2fce4c07931cde1623214c05482426f570e11b892d7R102-R169) [[5]](diffhunk://#diff-7709d4c51ab558695cf1e85b6f5b0135abe7bcbb16ad3a7c8451425b208e3563R93-R101) [[6]](diffhunk://#diff-7709d4c51ab558695cf1e85b6f5b0135abe7bcbb16ad3a7c8451425b208e3563L101-R115)

- Added a temporary highlight ring to the targeted `SnapCard` for visual feedback when routing from the overview.

### Dependency and Minor Codebase Updates

- Updated `@snapie/hangouts-core` and `@snapie/hangouts-react` dependencies in `package.json` to use version ranges instead of local file references.

- Minor import fix to include `CHECKER_URL` in `UserProfilePage.jsx`.