### PR TITLE
changelog: 1.78.28-1.78.30

### DIFF
--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,24 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.78.30',
+    date: '2026-08-12',
+    summary:
+      'The same emoji picker now opens everywhere you write, from video descriptions to community posts and stream details, matching the one already used in chat and comments.',
+  },
+  {
+    version: '1.78.29',
+    date: '2026-08-12',
+    summary:
+      'Links inside video descriptions, posts and comments are now checked more strictly, so only genuine web links can open.',
+  },
+  {
+    version: '1.78.28',
+    date: '2026-08-12',
+    summary:
+      'Housekeeping: 3Speak\'s foundations got a big update, with security improvements throughout and a clear-out of unused code.',
+  },
+  {
     version: '1.78.27',
     date: '2026-08-11',
     summary:

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.78.27';
+export const APP_VERSION = '1.78.30';


### PR DESCRIPTION
Covers the React 19 / Vite 8 dependency batch: the emoji picker now consistent across every composer, stricter link checking on rendered post content, and the wider dependency cleanup. APP_VERSION 1.78.27 -> 1.78.30.