### PR TITLE
Feat/august lunatics

### DIFF
--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,18 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.78.33',
+    date: '2026-08-14',
+    summary:
+      'Announcing an OpenPod room now brings people straight into the conversation with a "Join the live session" link (/openpods), while solo streams keep their player so followers can watch right from their feed.',
+  },
+  {
+    version: '1.78.32',
+    date: '2026-08-14',
+    summary:
+      'Your 3Speak posts now describe themselves in a shared format that other Hive apps can read, so your videos, shorts and audio show up the way you meant them to wherever people follow you. It uses the open Hive standard from openattribute.app.',
+  },
+  {
     version: '1.78.31',
     date: '2026-08-13',
     summary:

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.78.31',
+    date: '2026-08-13',
+    summary:
+      'Text stays selectable while a video plays, so you can copy from the description, comments and reaction threads without losing your selection.',
+  },
+  {
     version: '1.78.30',
     date: '2026-08-12',
     summary:

--- a/src/components/AudioUploadModal/AudioUploadModal.jsx
+++ b/src/components/AudioUploadModal/AudioUploadModal.jsx
@@ -14,6 +14,7 @@ import { uploadThumbnail } from '../../utils/uploadThumbnail';
 import { broadcastWithAioha, broadcastViaThreespeak, getCurrentProvider, Providers } from '../../hive-api/aioha';
 import { hasThreespeakPostingAuth, addThreespeakToPostingAuth } from '../../utils/postingAuthority';
 import { checkPostingRc } from '../../utils/rcCheck';
+import { oaEnvelope, threespeakAudio, OA_ARTICLE, OA_MICROPOST, OA_COMMENT } from '../../utils/openAttribute';
 import RcInsufficientModal from '../embed-studio/RcInsufficientModal';
 import CommunityModal from '../modal/Community_modal';
 import Beneficiary_modal from '../modal/Beneficiary_modal';
@@ -693,7 +694,18 @@ function AudioUploadModal({ isOpen, onClose, initialTrack }) {
     const desc = (postDescription || '').trim() || (track.title || '').trim();
     const cover = postThumb ? `![${(track.title || 'cover').replace(/[[\]]/g, '')}](${postThumb})\n\n` : '';
     const body = `${cover}${playUrl}\n\n${desc}`.trim();
-    const metaObj = { app: HIVE_APP_NAME, tags, audio: audioMetaFor(track) };
+    // A standalone track is a top-level titled post, so an Article carrying one
+    // audio attribute. `threespeak.audio` mirrors the bare `audio` key above it:
+    // the bare one is what our own readers already parse, the namespaced one is
+    // the version other frontends can look up.
+    const audioMeta = audioMetaFor(track);
+    const metaObj = {
+      app: HIVE_APP_NAME,
+      tags,
+      audio: audioMeta,
+      ...oaEnvelope(OA_ARTICLE),
+      ...threespeakAudio({ ...audioMeta, duration: track.durationSec }),
+    };
     if (postThumb) metaObj.image = [postThumb];
 
     const ops = [[
@@ -729,7 +741,9 @@ function AudioUploadModal({ isOpen, onClose, initialTrack }) {
     const hivePermlink = generatePermlink(mainTitle) || `audio-album-${Date.now().toString(36)}`;
     const cover = postThumb ? `![cover](${postThumb})\n\n` : '';
     const body = `${cover}${(postDescription || '').trim()}`.trim() || (mainTitle || 'Audio album');
-    const metaObj = { app: HIVE_APP_NAME, tags };
+    // The album's own post carries no audio — the tracks hang off it as replies
+    // — so it gets the envelope and no audio attribute.
+    const metaObj = { app: HIVE_APP_NAME, tags, ...oaEnvelope(OA_ARTICLE) };
     if (postThumb) metaObj.image = [postThumb];
     const ops = [[
       'comment',
@@ -769,7 +783,18 @@ function AudioUploadModal({ isOpen, onClose, initialTrack }) {
     const tThumb = track.thumb || postThumb || '';
     const cover = tThumb ? `![${(track.title || 'cover').replace(/[[\]]/g, '')}](${tThumb})\n\n` : '';
     const body = `${cover}${playUrl}\n\n${desc}`.trim();
-    const metaObj = { app: HIVE_APP_NAME, tags, audio: audioMetaFor(track) };
+    // Both modes post the track as a reply, but to different parents, and the
+    // object follows the parent: an album track replies to our own album post,
+    // so it is a Comment; a snap replies to the peak.snaps container, which
+    // makes it a MicroPost and keeps it readable in other apps' snap feeds.
+    const audioMeta = audioMetaFor(track);
+    const metaObj = {
+      app: HIVE_APP_NAME,
+      tags,
+      audio: audioMeta,
+      ...oaEnvelope(mode === 'album' ? OA_COMMENT : OA_MICROPOST),
+      ...threespeakAudio({ ...audioMeta, duration: track.durationSec }),
+    };
     if (tThumb) metaObj.image = [tThumb];
 
     const ops = [[

--- a/src/components/ReactVideoModal/ReactVideoModal.jsx
+++ b/src/components/ReactVideoModal/ReactVideoModal.jsx
@@ -6,6 +6,7 @@ import { EMBED_UPLOAD_URL, EMBED_API_URL, EMBED_API_KEY, SHORTS_MAX_DURATION_SEC
 import { commentWithAioha, broadcastViaThreespeak, getCurrentProvider, Providers } from '../../hive-api/aioha';
 import { hasThreespeakPostingAuth, addThreespeakToPostingAuth } from '../../utils/postingAuthority';
 import { useAppStore } from '../../lib/store';
+import { oaEnvelope, threespeakVideo, probeVideoOrientation, OA_COMMENT } from '../../utils/openAttribute';
 import './ReactVideoModal.scss';
 
 /**
@@ -289,6 +290,11 @@ function ReactVideoTab({ author, permlink, currentTime, formatTime, onPosted, on
       }
       const newPermlink = `re-${permlink}-${Date.now()}`;
 
+      // OpenAttribute: a reaction is a reply carrying its own video, so it is a
+      // Comment that still gets the video attribute. Orientation comes off the
+      // recorded blob when the reaction was filmed here rather than uploaded.
+      const oaOrientation = await probeVideoOrientation(videoFile || recordedBlob);
+
       const metadata = {
         app: '3speak/new-version',
         format: 'markdown',
@@ -298,6 +304,12 @@ function ReactVideoTab({ author, permlink, currentTime, formatTime, onPosted, on
           platform: '3speak',
           url: embedUrl,
         },
+        ...oaEnvelope(OA_COMMENT),
+        ...threespeakVideo({
+          surface: isShort ? 'shorts' : 'watch',
+          orientation: oaOrientation,
+          duration: videoDuration,
+        }),
       };
 
       // Broadcast the reaction. Every aioha login posts via @threespeak (the
@@ -366,7 +378,7 @@ function ReactVideoTab({ author, permlink, currentTime, formatTime, onPosted, on
     } finally {
       setUploading(false);
     }
-  }, [videoFile, user, videoDuration, currentTime, description, isShort, author, permlink, onPosted, videoPreviewUrl, recordedUrl]);
+  }, [videoFile, user, videoDuration, currentTime, description, isShort, author, permlink, onPosted, videoPreviewUrl, recordedUrl, recordedBlob]);
 
   const hasVideo = !!(videoFile || recordedBlob);
   const canSubmit = hasVideo && !uploading;

--- a/src/components/ReactionPlayer/ReactionPlayer.jsx
+++ b/src/components/ReactionPlayer/ReactionPlayer.jsx
@@ -1,3 +1,4 @@
+import MarkdownView from '../common/MarkdownView';
 import { Fragment, useRef, useState, useEffect, useCallback } from 'react';
 import { getHiveClient } from '../../utils/hiveNode';
 import { MdChevronLeft, MdChevronRight, MdClose, MdAspectRatio, MdVideocam, MdComment, MdKeyboardArrowDown, MdKeyboardArrowUp, MdTranslate, MdFlag } from 'react-icons/md';
@@ -88,7 +89,7 @@ function CommentNode({ comment, depth, collapsible = true }) {
         <span className="rct-thread-author">@{comment.author}</span>
         {collapsible && <span className="comment-collapse-chevron" onClick={() => setCollapsed(true)}><MdKeyboardArrowUp size={18} /></span>}
       </div>
-      <div className="rct-thread-body markdown-view" dangerouslySetInnerHTML={{ __html: bodyHtml }} />
+      <MarkdownView className="rct-thread-body" html={bodyHtml} />
       {translatedText && (
         <div className="comment-translation">
           <div className="comment-translation-header">

--- a/src/components/common/MarkdownView.jsx
+++ b/src/components/common/MarkdownView.jsx
@@ -1,0 +1,30 @@
+import { memo } from 'react';
+
+/**
+ * Rendered-markdown block (`dangerouslySetInnerHTML`), memoised on the HTML string.
+ *
+ * Why this exists: the watch page re-renders on every playhead tick while a video
+ * plays (the "at 0:00" comment timestamp follows it, among other things). Each of
+ * those renders made React re-apply `dangerouslySetInnerHTML` on the description,
+ * every comment and the reaction thread — and re-applying it tears the existing
+ * child nodes out and re-parses fresh ones even when the HTML string is byte
+ * identical. New nodes mean any text the reader had selected inside them is
+ * dropped, so selecting anything in those areas was impossible during playback
+ * (measured: a single tick replaced the children of 19 comment bodies, the
+ * reaction thread and the description; the title and related-videos rails, which
+ * are not rendered this way, were unaffected).
+ *
+ * Memoising on `html` alone means a tick that changes nothing about the text
+ * never reaches the DOM, so the selection survives.
+ */
+function MarkdownView({ html, className = '', ...rest }) {
+  return (
+    <div
+      className={className ? `markdown-view ${className}` : 'markdown-view'}
+      dangerouslySetInnerHTML={{ __html: html || '' }}
+      {...rest}
+    />
+  );
+}
+
+export default memo(MarkdownView);

--- a/src/components/playVideo/BlogContent.jsx
+++ b/src/components/playVideo/BlogContent.jsx
@@ -1,3 +1,4 @@
+import MarkdownView from '../common/MarkdownView';
 import React, { useEffect, useState, useRef } from "react";
 import { createRoot } from "react-dom/client";
 import { getUersContent } from "../../utils/hiveUtils";
@@ -206,10 +207,7 @@ const BlogContent = ({ author, permlink, description, alwaysExpanded = false }) 
             </div>
           </div>
         ) : (
-          <div
-            className="markdown-view"
-            dangerouslySetInnerHTML={{ __html: renderedContent }}
-          />
+          <MarkdownView html={renderedContent} />
         )}
         {needsExpansion && !isExpanded && <div className="fade-overlay" />}
       </div>

--- a/src/components/playVideo/CommentSection.jsx
+++ b/src/components/playVideo/CommentSection.jsx
@@ -1,3 +1,4 @@
+import MarkdownView from '../common/MarkdownView';
 import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { getHiveClient } from '../../utils/hiveNode';
 import './CommentSection.scss';
@@ -704,7 +705,7 @@ function Comment({
             )}
             <span className="comment-collapse-chevron" onClick={() => setCollapsed(true)}><MdKeyboardArrowUp size={18} /></span>
           </div>
-          <div className="markdown-view" dangerouslySetInnerHTML={{ __html: processedBody(comment?.body || '', comment?.permlink) }} />
+          <MarkdownView html={processedBody(comment?.body || '', comment?.permlink)} />
           {translatedText && (
             <div className="comment-translation">
               <div className="comment-translation-header">

--- a/src/context/EmbedUploadContext.jsx
+++ b/src/context/EmbedUploadContext.jsx
@@ -15,6 +15,7 @@ import { useAppStore } from '../lib/store';
 import { usePremiumStatus } from '../hooks/usePremiumStatus';
 import { setChannelTrailer } from '../utils/channelTrailer';
 import { enforceLockedBeneficiaries, getLockedBeneficiaries, chargesEncoder, LOCKED_FUND_ACCOUNT, LOCKED_ENCODER_ACCOUNT } from '../utils/beneficiaries';
+import { oaEnvelope, threespeakVideo, probeVideoOrientation, OA_ARTICLE, OA_MICROPOST, OA_COMMENT } from '../utils/openAttribute';
 import axios from 'axios';
 
 // Hosts that support TUS resume (tusd-backed). The legacy embed.3speak.tv origin
@@ -1195,6 +1196,11 @@ export function EmbedUploadProvider({ children }) {
         if (p) embedAssetPermlink = p;
       } catch { /* fall back to user / hive permlink */ }
 
+      // OpenAttribute: read the source aspect off the file we are publishing.
+      // Resolves null (and the attribute is then omitted) when there is no local
+      // file — a remix that reuses an existing embed never had one.
+      const oaOrientation = await probeVideoOrientation(videoFile);
+
       const jsonMetadata = {
         app: '3speak/embed',
         format: 'markdown',
@@ -1232,6 +1238,19 @@ export function EmbedUploadProvider({ children }) {
             ...(thumbnailUrl ? { sourceMap: [{ url: thumbnailUrl, type: 'thumbnail' }] } : {}),
           },
         },
+        // OpenAttribute. A short is a MicroPost: without this it depends on the
+        // reading app having peak.snaps in its own container list, and any app
+        // that does not falls through to plain `Comment`. A regular upload is an
+        // Article, which is what the spec's rules would infer anyway — the value
+        // there is that the reader stops guessing and gets the attribute below.
+        ...oaEnvelope(fromStories ? OA_MICROPOST : OA_ARTICLE),
+        // `surface` is where this was published to be watched, not how long it
+        // is: a 16-second landscape clip is still a `watch` video.
+        ...threespeakVideo({
+          surface: fromStories ? 'shorts' : 'watch',
+          orientation: oaOrientation,
+          duration: videoDuration,
+        }),
       };
 
       // Build comment_options. When the author is declining payout, skip
@@ -1438,7 +1457,9 @@ export function EmbedUploadProvider({ children }) {
           permlink: replyPermlink,
           title: '',
           body: replyBody,
-          json_metadata: JSON.stringify({ app: '3speak/embed', tags: ['3speak'] }),
+          // A notification pointing at the remix, not the remix itself, so it
+          // carries no video attribute — only the envelope saying what it is.
+          json_metadata: JSON.stringify({ app: '3speak/embed', tags: ['3speak'], ...oaEnvelope(OA_COMMENT) }),
         }];
 
         const remixOps = [mainPostOp, commentOptionsOp, replyOp];

--- a/src/utils/openAttribute.js
+++ b/src/utils/openAttribute.js
@@ -1,0 +1,136 @@
+/**
+ * OpenAttribute (openattribute.app) helpers.
+ *
+ * A shared vocabulary for Hive `json_metadata`, so other frontends can read our
+ * posts without reverse-engineering them. Two pieces ride along with the
+ * metadata we already publish:
+ *
+ *   oa                 the envelope — `{ v, object }` — saying what kind of post
+ *                      this is, so a reader never has to infer it
+ *   threespeak.video   our registered attribute for video posts
+ *   threespeak.audio   ...and for audio posts
+ *
+ * Both attributes were registered on chain from the `threespeak` account on
+ * 2026-08-13 at v1.0.0, which is why the keys read `<account>.<leaf>`.
+ *
+ * TWO RULES THAT ARE EASY TO GET WRONG:
+ *
+ * 1. Attributes sit BESIDE the envelope at the top level of json_metadata, never
+ *    nested inside `oa`. A reader takes attributes from the top level, so a
+ *    nested one is invisible at the other end with no error on either side.
+ *
+ * 2. `object` stays on one of the five core types. Any other value is an
+ *    extension type that readers report as `Unknown`, which would be worse than
+ *    saying nothing: our shorts are currently inferred as MicroPost for free
+ *    because they reply to a container account, and an `x-` name would throw
+ *    that away.
+ */
+
+export const OA_VERSION = 1;
+
+// The core object types we publish. `Container` and `Unknown` exist in the spec
+// but nothing we broadcast is either.
+export const OA_ARTICLE = 'Article';
+export const OA_MICROPOST = 'MicroPost';
+export const OA_COMMENT = 'Comment';
+
+/**
+ * The envelope. Spread into a json_metadata object:
+ *   { ...jsonMetadata, ...oaEnvelope(OA_ARTICLE) }
+ */
+export function oaEnvelope(object) {
+  return { oa: { v: OA_VERSION, object } };
+}
+
+/** Source aspect from pixel dimensions. Returns null when we cannot tell. */
+export function orientationOf(width, height) {
+  const w = Number(width) || 0;
+  const h = Number(height) || 0;
+  if (!w || !h) return null;
+  if (w === h) return 'square';
+  return w > h ? 'landscape' : 'vertical';
+}
+
+/**
+ * Read a video file's orientation off a detached <video> element.
+ *
+ * Judge orientation from the ELEMENT's videoWidth/videoHeight, never from what
+ * a capture was asked for: Firefox pre-rotates recorded camera video, so the
+ * requested constraints and the actual frame disagree.
+ *
+ * Resolves null rather than rejecting — an unknown orientation just means we
+ * omit the attribute, which must never block a publish. The timeout is there so
+ * a file the decoder chokes on cannot hang the upload flow.
+ */
+export function probeVideoOrientation(file) {
+  return new Promise((resolve) => {
+    if (!file || typeof document === 'undefined') { resolve(null); return; }
+
+    const v = document.createElement('video');
+    v.preload = 'metadata';
+
+    let settled = false;
+    const done = (value) => {
+      if (settled) return;
+      settled = true;
+      try { URL.revokeObjectURL(v.src); } catch { /* nothing to revoke */ }
+      resolve(value);
+    };
+
+    v.onloadedmetadata = () => done(orientationOf(v.videoWidth, v.videoHeight));
+    v.onerror = () => done(null);
+    setTimeout(() => done(null), 5000);
+
+    try { v.src = URL.createObjectURL(file); } catch { done(null); }
+  });
+}
+
+/**
+ * `threespeak.video` — registered v1.0.0, required: surface + orientation.
+ *
+ * surface is where the video was published to be watched, not how long it is:
+ * `watch` is a page with title and comments, `shorts` is the vertical swipe
+ * feed, `live` is a stream. A 16-second landscape clip is still `watch`.
+ *
+ * Returns {} when surface or orientation is unknown. We would rather publish no
+ * claim than one that breaks the schema we registered.
+ */
+export function threespeakVideo({ surface, orientation, duration, startsAt } = {}) {
+  if (!surface || !orientation) return {};
+
+  const attr = { surface, orientation };
+
+  // Only on a stream announced ahead of time. One starting at publish time has
+  // none, because the post's own timestamp already says when it began.
+  if (startsAt) attr.startsAt = startsAt;
+
+  // Never on `live`: a stream has no length when its post is written, and we do
+  // not edit the post afterwards.
+  const secs = Number(duration);
+  if (surface !== 'live' && Number.isFinite(secs) && secs > 0) {
+    attr.duration = secs;
+  }
+
+  return { 'threespeak.video': attr };
+}
+
+/**
+ * `threespeak.audio` — registered v1.0.0, required: type.
+ *
+ * Mirrors the bare `audio` key we already write, so one reader parses both. The
+ * `type` default matches the composer's own default, which leaves the field
+ * unset until the author picks something.
+ */
+export function threespeakAudio({ type, genre, bpm, duration } = {}) {
+  const attr = { type: type || 'voice_message' };
+
+  if (genre) attr.genre = String(genre).trim();
+
+  const beats = Number(bpm);
+  if (Number.isFinite(beats) && beats > 0) attr.bpm = beats;
+
+  const secs = Number(duration);
+  if (Number.isFinite(secs) && secs > 0) attr.duration = secs;
+
+  return { 'threespeak.audio': attr };
+}

--- a/src/utils/openpodAnnounce.js
+++ b/src/utils/openpodAnnounce.js
@@ -7,6 +7,7 @@ import {
   buildOpenPodPermlink,
   buildOpenPodSnapMetadata,
 } from './openpodUtils';
+import { oaEnvelope, threespeakVideo, OA_ARTICLE, OA_MICROPOST } from './openAttribute';
 
 // --- Shared announce config (community / payout / beneficiaries) ----------
 // Edited in TWO places — the create-room dialog AND the studio's post tab —
@@ -63,11 +64,47 @@ export function getAnnounceConfig() {
 }
 
 // A short snap announcement, threaded under the latest @peak.snaps container.
-async function postSnap(room, watchUrl) {
+async function postSnap(room, watchUrl, orientation, host) {
   const snapPost = await fetchLatestSnapsPost();
   const body = buildOpenPodSnapBody(room.title, watchUrl, room.backgroundImage);
   const permlink = buildOpenPodPermlink();
-  const metadata = buildOpenPodSnapMetadata(room.name);
+  const thumbnailUrl = room.backgroundImage || '';
+
+  // A standalone stream is a broadcast, so the snap carries it: same `video`
+  // block as the full post, which is what makes peakd/ecency render the player
+  // instead of showing a bare link.
+  //
+  // A conference room is deliberately NOT carried. It is something you join,
+  // and embedding a player invites people to sit and watch it silently from the
+  // audience — the opposite of what a room is for. A room snap stays a link
+  // into the conversation, so it gets the envelope and no video.
+  const isStandalone = room.mode === 'standalone';
+  const embedUrl = `https://play.3speak.tv/embed?v=${host}/${room.name}`;
+
+  const metadata = {
+    ...buildOpenPodSnapMetadata(room.name),
+    ...oaEnvelope(OA_MICROPOST),
+    ...(isStandalone ? {
+      links: [embedUrl],
+      video: {
+        platform: '3speak',
+        url: embedUrl,
+        reusable: false,
+        live: true,
+        ...(thumbnailUrl ? { thumbnail: thumbnailUrl } : {}),
+        info: {
+          platform: '3speak',
+          author: host,
+          permlink: room.name,
+          title: room.title || '',
+          duration: 0,
+          live: true,
+          ...(thumbnailUrl ? { sourceMap: [{ url: thumbnailUrl, type: 'thumbnail' }] } : {}),
+        },
+      },
+      ...threespeakVideo({ surface: 'live', orientation }),
+    } : {}),
+  };
   await commentWithAioha(snapPost.author, snapPost.permlink, permlink, '', body, metadata);
 }
 
@@ -76,7 +113,7 @@ async function postSnap(room, watchUrl) {
 // post, the watch link (?v=host/roomName), and the embed the player resolves
 // to the live stream. Same object structure as an embed-studio video post
 // (see EmbedUploadContext) so any 3Speak-aware frontend renders it identically.
-async function postFullPost({ room, user, isPremium }) {
+async function postFullPost({ room, user, isPremium, orientation }) {
   const cfg = getAnnounceConfig();
   const communityTag = typeof cfg.community === 'string' && cfg.community ? cfg.community : 'hive-181335';
 
@@ -89,13 +126,25 @@ async function postFullPost({ room, user, isPremium }) {
   const embedUrl = `https://play.3speak.tv/embed?v=${host}/${roomName}`;
   const watchUrl = `https://3speak.tv/watch?v=${host}/${roomName}`;
 
-  // Standalone streams get ONE link — "Watch on 3speak.tv" (the ?v=host/room
-  // watch page). No separate "Join the live session" link.
+  // A standalone stream is a broadcast: the body leads with the embed so every
+  // frontend renders the player, and it gets ONE link, "Watch on 3speak.tv"
+  // (the ?v=host/room watch page). No separate "Join the live session" link.
+  //
+  // A conference room is something you join. Embedding it would seat people in
+  // a silent audience, which is the opposite of what a room is for, so a room
+  // announcement carries no player anywhere — not in the body, not in `video`,
+  // not in the attribute — and links into the room instead. This matches what
+  // the UI already does: Card3 sends a conference to /openpods/<room> under a
+  // "LIVE CHAT" badge, while a standalone gets "LIVE" and the watch page.
+  const isStandalone = room.mode === 'standalone';
+  const joinUrl = `https://3speak.tv/openpods/${roomName}`;
   const descPart = (room.description || '').trim();
-  const body =
-    `${embedUrl}\n\n` +
-    (descPart ? `${descPart}\n\n` : '') +
-    `---\n▶ [Watch on 3speak.tv](${watchUrl})`;
+  const body = isStandalone
+    ? `${embedUrl}\n\n` +
+      (descPart ? `${descPart}\n\n` : '') +
+      `---\n▶ [Watch on 3speak.tv](${watchUrl})`
+    : (descPart ? `${descPart}\n\n` : '') +
+      `---\n🎙️ [Join the live session](${joinUrl})`;
 
   const permlink = roomName;
 
@@ -104,24 +153,35 @@ async function postFullPost({ room, user, isPremium }) {
     format: 'markdown',
     tags,
     ...(thumbnailUrl ? { image: [thumbnailUrl] } : {}),
-    links: [embedUrl],
-    video: {
-      platform: '3speak',
-      url: embedUrl,
-      reusable: false,
-      live: true,
-      ...(thumbnailUrl ? { thumbnail: thumbnailUrl } : {}),
-      info: {
-        platform: '3speak',
-        author: host,
-        permlink: roomName,
-        title: room.title || '',
-        duration: 0,
-        live: true,
-        ...(thumbnailUrl ? { sourceMap: [{ url: thumbnailUrl, type: 'thumbnail' }] } : {}),
-      },
-    },
     openpodRoom: roomName,
+    // OpenAttribute. On a standalone stream `surface: live` is permanent: it
+    // says how this post was published, not whether the stream is still
+    // running. Nothing edits it afterwards, so it carries no duration — the
+    // end, and any VOD that replaces the stream, live in our own database
+    // rather than on chain.
+    ...oaEnvelope(OA_ARTICLE),
+    ...(isStandalone ? {
+      links: [embedUrl],
+      video: {
+        platform: '3speak',
+        url: embedUrl,
+        reusable: false,
+        live: true,
+        ...(thumbnailUrl ? { thumbnail: thumbnailUrl } : {}),
+        info: {
+          platform: '3speak',
+          author: host,
+          permlink: roomName,
+          title: room.title || '',
+          duration: 0,
+          live: true,
+          ...(thumbnailUrl ? { sourceMap: [{ url: thumbnailUrl, type: 'thumbnail' }] } : {}),
+        },
+      },
+      ...threespeakVideo({ surface: 'live', orientation }),
+    } : {
+      links: [joinUrl],
+    }),
   };
 
   // Build beneficiaries — @threespeakfund 10% is locked for non-Pro hosts, but
@@ -161,7 +221,7 @@ async function postFullPost({ room, user, isPremium }) {
  * top-level post — per the host's choice. Community/payout/beneficiaries come
  * from the shared announce config (getAnnounceConfig).
  */
-export async function postOpenPodAnnouncement({ room, options, user, isPremium }) {
+export async function postOpenPodAnnouncement({ room, options, user, isPremium, orientation }) {
   if (!user) return;
   if (options && options.notifyOnHive === false) return;
 
@@ -171,10 +231,10 @@ export async function postOpenPodAnnouncement({ room, options, user, isPremium }
 
   try {
     if (announceType === 'post') {
-      await postFullPost({ room, user, isPremium });
+      await postFullPost({ room, user, isPremium, orientation });
       toast.success('Live session announced on Hive!');
     } else {
-      await postSnap(room, watchUrl);
+      await postSnap(room, watchUrl, orientation, host);
     }
   } catch (err) {
     // Non-blocking — the pod is live regardless of whether the post landed.
@@ -221,5 +281,8 @@ export async function firePendingAnnouncement(roomName, freshPost) {
     if (Array.isArray(freshPost.tags)) room.post = { ...(room.post || {}), tags: freshPost.tags };
   }
 
-  await postOpenPodAnnouncement({ ...payload, room });
+  // The studio reports the composited output's shape at go-live. Older SDK
+  // builds send nothing, in which case the announcement simply carries no video
+  // attribute rather than a guessed orientation.
+  await postOpenPodAnnouncement({ ...payload, room, orientation: freshPost?.orientation });
 }

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.78.31';
+export const APP_VERSION = '1.78.33';

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.78.30';
+export const APP_VERSION = '1.78.31';


### PR DESCRIPTION
This pull request introduces support for the OpenAttribute (openattribute.app) standard in 3Speak’s post metadata, making video and audio posts more interoperable with other Hive apps. It adds helpers for producing OpenAttribute envelopes and attributes, updates all relevant publishing flows to include these, and improves the React rendering of markdown content to preserve text selection during playback.

**OpenAttribute support and metadata improvements:**

* Added `src/utils/openAttribute.js` with helpers to generate OpenAttribute envelopes and registered `threespeak.video` and `threespeak.audio` attributes, including utilities for video orientation and attribute schema compliance.
* Updated video and audio publishing flows (`AudioUploadModal.jsx`, `ReactVideoModal.jsx`, `EmbedUploadContext.jsx`) to include OpenAttribute envelopes and the appropriate `threespeak.video`/`threespeak.audio` attributes in `json_metadata`, ensuring posts are correctly described for other Hive apps. [[1]](diffhunk://#diff-50e40fed72f53186a893f6e86848decb6a2797216b8fe56e4b99f211b4f33485R17) [[2]](diffhunk://#diff-50e40fed72f53186a893f6e86848decb6a2797216b8fe56e4b99f211b4f33485L696-R708) [[3]](diffhunk://#diff-50e40fed72f53186a893f6e86848decb6a2797216b8fe56e4b99f211b4f33485L732-R746) [[4]](diffhunk://#diff-50e40fed72f53186a893f6e86848decb6a2797216b8fe56e4b99f211b4f33485L772-R797) [[5]](diffhunk://#diff-ffd455555063706173ea6988d83e6bb9b20a9b8d1b1d24440ffc693e5eec68bcR9) [[6]](diffhunk://#diff-ffd455555063706173ea6988d83e6bb9b20a9b8d1b1d24440ffc693e5eec68bcR293-R297) [[7]](diffhunk://#diff-ffd455555063706173ea6988d83e6bb9b20a9b8d1b1d24440ffc693e5eec68bcR307-R312) [[8]](diffhunk://#diff-68e8c5f60a59262c932bc2fc9c3d7883d415c71402fe0def050d1a1cd38dbce3R18) [[9]](diffhunk://#diff-68e8c5f60a59262c932bc2fc9c3d7883d415c71402fe0def050d1a1cd38dbce3R1199-R1203) [[10]](diffhunk://#diff-68e8c5f60a59262c932bc2fc9c3d7883d415c71402fe0def050d1a1cd38dbce3R1241-R1253) [[11]](diffhunk://#diff-68e8c5f60a59262c932bc2fc9c3d7883d415c71402fe0def050d1a1cd38dbce3L1441-R1462)

**Markdown rendering and UX improvements:**

* Introduced a memoized `MarkdownView` component to prevent unnecessary DOM updates during playback, preserving text selection in descriptions and comments.
* Replaced direct `dangerouslySetInnerHTML` usage with the new `MarkdownView` in comment threads, blog content, and comment sections for a smoother user experience. [[1]](diffhunk://#diff-355e251a5e8e3b4d3e208a86b5e8bb7ebb83367e9c4d973eea91d89cf23f1b04R1) [[2]](diffhunk://#diff-355e251a5e8e3b4d3e208a86b5e8bb7ebb83367e9c4d973eea91d89cf23f1b04L91-R92) [[3]](diffhunk://#diff-355ce09984889bb7e4311a364f5f437622b3a83bc4e29b65e90dc0a413892993R1) [[4]](diffhunk://#diff-355ce09984889bb7e4311a364f5f437622b3a83bc4e29b65e90dc0a413892993L209-R210) [[5]](diffhunk://#diff-ca8b84439a4b7d1f1a92e6b08853c432b91c1fa1e6ec0d81b1070a8496131fa5R1) [[6]](diffhunk://#diff-ca8b84439a4b7d1f1a92e6b08853c432b91c1fa1e6ec0d81b1070a8496131fa5L707-R708)

**Changelog updates:**

* Added entries for versions 1.78.31–1.78.33, including the OpenAttribute announcement and related user-facing improvements.

These changes ensure that all new 3Speak posts carry standardized, machine-readable metadata, improving cross-app compatibility and the reliability of content rendering.