### PR TITLE
Feat/august freaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
     <link rel="dns-prefetch" href="https://images.hive.blog" />
 
     <!-- Primary Meta Tags -->
-    <title>3Speak - Decentralized Video Platform</title>
-    <meta name="title" content="3Speak - Decentralized Video Platform" />
+    <title>3S | Real People - Real Stories</title>
+    <meta name="title" content="3S | Real People - Real Stories" />
     <meta name="description" content="3Speak is a decentralized video sharing platform built on blockchain technology. Watch, upload, and share videos while earning cryptocurrency rewards." />
     <meta name="keywords" content="3speak, decentralized video, blockchain video, crypto video platform, web3 video, hive blockchain, video sharing, cryptocurrency" />
     <meta name="author" content="3Speak" />
@@ -51,7 +51,7 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://3speak.tv/" />
-    <meta property="og:title" content="3Speak - Decentralized Video Platform" />
+    <meta property="og:title" content="3S | Real People - Real Stories" />
     <meta property="og:description" content="3Speak is a decentralized video sharing platform built on blockchain technology. Watch, upload, and share videos while earning cryptocurrency rewards." />
     <meta property="og:image" content="https://3speak.tv/3speak.jpeg" />
     <meta property="og:image:width" content="1200" />
@@ -62,7 +62,7 @@
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image" />
     <meta property="twitter:url" content="https://3speak.tv/" />
-    <meta property="twitter:title" content="3Speak - Decentralized Video Platform" />
+    <meta property="twitter:title" content="3S | Real People - Real Stories" />
     <meta property="twitter:description" content="3Speak is a decentralized video sharing platform built on blockchain technology. Watch, upload, and share videos while earning cryptocurrency rewards." />
     <meta property="twitter:image" content="https://3speak.tv/3speak.jpeg" />
     <meta name="twitter:site" content="@3speaktv" />

--- a/public/push-sw.js
+++ b/public/push-sw.js
@@ -1,0 +1,59 @@
+/*
+ * Minimal CLASSIC service worker: notifications only, no imports, no Workbox.
+ *
+ * Why this exists alongside src/sw.js: Firefox does not support ES-module
+ * service workers, and the Vite dev server can only serve the app's real worker
+ * as a module (its Workbox imports are ESM). So in dev, Firefox throws during
+ * script evaluation and ends up with no worker at all — which means no push,
+ * and no way to test notifications in that browser.
+ *
+ * A production build bundles src/sw.js into a classic script, so this file is
+ * never reached there: utils/webPush.js tries /sw.js first and only falls
+ * through to this when the real worker cannot be registered.
+ *
+ * Keep the two push handlers here in step with the ones at the top of
+ * src/sw.js. They are duplicated rather than shared because a classic worker
+ * cannot import, and pulling in a bundler for thirty lines would defeat the
+ * point of having a dependency-free fallback.
+ */
+
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));
+
+self.addEventListener('push', (event) => {
+  var data = {};
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch (err) {
+    return;                       // not ours; better nothing than a garbage notification
+  }
+  if (!data.title) return;
+
+  event.waitUntil(
+    self.registration.showNotification(data.title, {
+      body: data.body || '',
+      icon: '/3speak.jpeg',
+      badge: '/3speak.jpeg',
+      tag: data.tag || undefined,
+      data: { url: data.url || '/' },
+    })
+  );
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  var target = (event.notification.data && event.notification.data.url) || '/';
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(function (all) {
+      for (var i = 0; i < all.length; i += 1) {
+        var client = all[i];
+        if (new URL(client.url).origin === self.location.origin) {
+          return client.focus().then(function () {
+            return 'navigate' in client ? client.navigate(target) : null;
+          });
+        }
+      }
+      return self.clients.openWindow(target);
+    })
+  );
+});

--- a/server/index.cjs
+++ b/server/index.cjs
@@ -25,6 +25,15 @@ const PORT = process.env.SERVER_PORT || 4020
 
 const POSTING_WIF = process.env.THREESPEAK_POSTING_WIF
 const HIVE_ACCOUNT = process.env.THREESPEAK_HIVE_ACCOUNT || 'badadib'
+// Share of ad revenue split between the creator and the community they posted in.
+// MUST match AD_CREATOR_POOL_PCT on the checker: this endpoint signs the message the
+// checker verifies, so a disagreement would produce signatures it rejects.
+const AD_CREATOR_POOL_PCT = Number(process.env.AD_CREATOR_POOL_PCT) || 50
+// Must equal AD_DEFAULT_COMMUNITY_PCT on the checker. Both sides build the signed
+// message, so a disagreement here signs one split and stores another.
+const AD_DEFAULT_COMMUNITY_PCT = Number.isInteger(Number(process.env.AD_DEFAULT_COMMUNITY_PCT))
+  ? Number(process.env.AD_DEFAULT_COMMUNITY_PCT)
+  : 25
 // Shared app key (same one the embed TUS upload uses) — authenticates wallet
 // logins (Keychain/HiveAuth/PeakVault/Ledger) on the post-creation path, which
 // can't present a token/cookie. Same trust level the upload pipeline already
@@ -1023,6 +1032,65 @@ app.post('/api/snapie-chat/sign-challenge', signChallengeLimiter, async (req, re
   }
 })
 
+// POST /api/ads/opt-out-signature — sign a creator's ad preference on their behalf.
+//
+// HiveSigner and Butter Auth sessions hold no signing key in the browser, so those
+// creators could never sign the checker's ad-preference message client-side. Without
+// this endpoint the people least able to sign would be the only ones unable to turn
+// ads off on their own videos — which is exactly backwards for a consent control.
+//
+// The client sends ONLY a boolean. The message is built here, from the username the
+// session resolves to, in the canonical form the checker expects. That is the whole
+// safety argument: unlike a generic signing oracle this can never be steered into
+// signing arbitrary bytes (a transaction digest, say), because the caller supplies
+// none of them. Compare the snapie-chat endpoint, which has to validate a UUID shape
+// for the same reason.
+app.post('/api/ads/opt-out-signature', signChallengeLimiter, async (req, res) => {
+  try {
+    if (!POSTING_WIF) return res.status(500).json({ error: 'Server is not configured' })
+    const hiveUsername = await resolveDelegatedSignUser(req, res)
+    if (!hiveUsername) return res.status(401).json({ error: 'Unauthorized' })
+
+    // Must be a real boolean: `undefined` would quietly become "off" and turn ads
+    // off for someone who never asked.
+    if (typeof req.body?.adsEnabled !== 'boolean') {
+      return res.status(400).json({ error: 'adsEnabled must be true or false' })
+    }
+    const adsEnabled = req.body.adsEnabled
+
+    // The community's cut of the creator pool. Signed along with everything else so
+    // a signature cannot be lifted from one split and reused on another — this is
+    // the field that decides where money goes. Absent means 0.
+    const shareRaw = req.body.communitySharePct
+    const communitySharePct = shareRaw === undefined || shareRaw === null
+      ? AD_DEFAULT_COMMUNITY_PCT
+      : Number(shareRaw)
+    if (!Number.isInteger(communitySharePct) || communitySharePct < 0 || communitySharePct > AD_CREATOR_POOL_PCT) {
+      return res.status(400).json({ error: `communitySharePct must be a whole number between 0 and ${AD_CREATOR_POOL_PCT}` })
+    }
+
+    // We sign as @threespeak, so the grant has to actually exist — otherwise the
+    // checker would reject the signature anyway and the user would see a cryptic
+    // failure instead of a reason.
+    if (!(await hasThreespeakPostingGrant(hiveUsername))) {
+      return res.status(403).json({
+        error: `Turning ads off from here needs @${HIVE_ACCOUNT} posting authority on your account. Log in with Keychain, HiveAuth, PeakVault or Ledger to set it directly instead.`,
+      })
+    }
+
+    const timestamp = Date.now()
+    // Keep in lockstep with prefsMessage() in 3speakchecks/routes/advertise.js.
+    const message = ['3speak-ads', 'creator-prefs', hiveUsername, adsEnabled ? 'on' : 'off',
+      String(communitySharePct), String(timestamp)].join('|')
+    const signature = PrivateKey.fromString(POSTING_WIF).sign(cryptoUtils.sha256(Buffer.from(message, 'utf8'))).toString()
+
+    return res.json({ success: true, signature, timestamp, username: hiveUsername, communitySharePct })
+  } catch (err) {
+    console.error('Ads opt-out signature error:', err.message)
+    res.status(500).json({ error: 'Signing failed' })
+  }
+})
+
 // Image upload — sign the standard images.hive.blog "ImageSigningChallenge" with
 // @threespeak's posting key and upload on the user's behalf. Lets every login
 // (incl. HiveSigner, which can't sign client-side) attach covers/thumbnails with
@@ -1057,7 +1125,17 @@ app.post('/api/upload-image', imageUploadLimiter, express.raw({ type: () => true
     const data = await hostResp.json().catch(() => ({}))
     if (!hostResp.ok || !data.url) {
       console.error('Image host rejected:', hostResp.status, JSON.stringify(data).slice(0, 200))
-      return res.status(502).json({ error: 'Image host rejected the upload' })
+      // Tell the caller WHICH failure this is. A 429 from images.hive.blog is the
+      // shared @threespeak upload quota running out — it is not the user's file, not
+      // retryable in the next second, and not something a generic "upload failed"
+      // helps anyone diagnose. It has bitten thumbnails too.
+      const quota = hostResp.status === 429 || /qouta|quota/i.test(JSON.stringify(data))
+      return res.status(quota ? 503 : 502).json({
+        error: quota
+          ? "3Speak's image upload quota is exhausted for now — this is on our side, not your file. Try again later."
+          : 'Image host rejected the upload',
+        upstreamStatus: hostResp.status,
+      })
     }
     return res.json({ success: true, url: data.url })
   } catch (e) {

--- a/server/og-server.cjs
+++ b/server/og-server.cjs
@@ -37,6 +37,11 @@ const CHECKER_URL = process.env.CHECKER_URL || 'https://checker.3speak.tv';
 // Cap the transcript we inline so a long video can't bloat the bot response.
 const MAX_TRANSCRIPT_CHARS = 20000;
 
+// Comments inlined for crawlers. Real viewer wording is the point (people search
+// the phrases other people type), so the bar is only about excluding padding.
+const MAX_COMMENTS = 15;
+const MIN_COMMENT_CHARS = 10;
+
 const BOT_USER_AGENTS = [
   'facebookexternalhit',
   'Facebot',
@@ -335,9 +340,39 @@ function srtToText(srt) {
   return joined;
 }
 
+// Subtitle files live on IPFS, and the hot CDN 500s ("block was not found
+// locally") for anything it hasn't pinned yet — as of 2026-08 that is EVERY
+// subtitle file, which is why the transcript section silently never rendered
+// despite this code existing. The checker's /subtitle-proxy fetches the CID
+// server-side, falling through the gateways to the ingest node's own IPFS API,
+// so it answers when the CDN doesn't.
+async function fetchSrt(cid, signal) {
+  try {
+    const direct = await fetch(`${BUNNY_IPFS_CDN}/ipfs/${cid}`, { signal });
+    if (direct.ok) return await direct.text();
+  } catch (_) { /* fall through to the proxy */ }
+  try {
+    const proxied = await fetch(`${CHECKER_URL}/subtitle-proxy/${cid}`, { signal });
+    if (proxied.ok) return await proxied.text();
+  } catch (_) { /* no transcript for this one */ }
+  return null;
+}
+
+/**
+ * The video's transcript, plus the languages it has captions in.
+ *
+ * English is preferred, then whatever the video actually has — a Spanish talk
+ * should be indexed by its Spanish words rather than not at all. Only ONE
+ * language is inlined on purpose: a page carrying the same speech five times
+ * over reads as duplicated, near-spam text and muddies the page's own language
+ * signal, which is the opposite of what this is for. The other languages are
+ * declared as `subtitleLanguage` instead, which is the field meant to carry them.
+ */
 async function fetchTranscript(author, permlink) {
   const ctrl = new AbortController();
-  const timer = setTimeout(() => ctrl.abort(), 2500);
+  // Two network hops now (list, then the file, possibly via the proxy), so the
+  // old 2.5s budget for the whole chain was tight even when the CDN answered.
+  const timer = setTimeout(() => ctrl.abort(), 6000);
   try {
     const listRes = await fetch(`${TRANSLATE_API_URL}/subtitles/${author}/${permlink}`, {
       signal: ctrl.signal,
@@ -346,16 +381,95 @@ async function fetchTranscript(author, permlink) {
     const list = await listRes.json();
     if (!Array.isArray(list) || list.length === 0) return null;
 
-    const entry = list.find((l) => l && l.lang === 'en') || list[0];
-    if (!entry || !entry.cid) return null;
+    const languages = list.map((l) => l && l.lang).filter(Boolean);
+    const preferred = list.find((l) => l && l.lang === 'en') || list[0];
+    // One unfetchable file shouldn't cost the page its transcript when the video
+    // has seven other translations sitting right there.
+    const ordered = [preferred, ...list.filter((l) => l !== preferred)];
 
-    const srtRes = await fetch(`${BUNNY_IPFS_CDN}/ipfs/${entry.cid}`, { signal: ctrl.signal });
-    if (!srtRes.ok) return null;
-    const text = srtToText(await srtRes.text());
-    if (!text) return null;
-    return { text, lang: entry.lang || 'en' };
+    for (const entry of ordered) {
+      if (!entry || !entry.cid) continue;
+      const srt = await fetchSrt(entry.cid, ctrl.signal);
+      if (!srt) continue;
+      const text = srtToText(srt);
+      if (text) return { text, lang: entry.lang || 'en', languages };
+    }
+    return null;
   } catch (_) {
     return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Strip a Hive comment body down to plain prose.
+ *
+ * URLs and markdown links go entirely, label kept — deliberately, and not just
+ * for tidiness: with no anchors in the output there is no PageRank to hand a
+ * comment spammer, which is the whole reason inlining user text is normally a
+ * risk. Images, code fences and markup go the same way, then whitespace is
+ * collapsed so the length test measures words rather than formatting.
+ */
+function commentToText(body) {
+  if (!body || typeof body !== 'string') return '';
+  return body
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/https?:\/\/\S+/g, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/[*_>#`~|-]{1,}/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// Emoji and punctuation shouldn't count toward the length floor: "🔥🔥🔥🔥🔥" is
+// not a ten-character comment in any sense that matters.
+function meaningfulLength(text) {
+  return text.replace(/[^\p{L}\p{N}]/gu, '').length;
+}
+
+/**
+ * Top-level replies worth showing a crawler: substantive ones first, capped.
+ *
+ * Only direct replies (get_content_replies returns exactly those), so a long
+ * argument in a sub-thread doesn't drown the page. Ordered by payout, which is
+ * Hive's own quality signal and a far better ranking than recency.
+ */
+async function fetchComments(author, permlink) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 3500);
+  try {
+    const res = await fetch(HIVE_API, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'condenser_api.get_content_replies',
+        params: [author, permlink],
+        id: 1,
+      }),
+      signal: ctrl.signal,
+    });
+    if (!res.ok) return [];
+    const data = await res.json();
+    const replies = (data && data.result) || [];
+    if (!Array.isArray(replies)) return [];
+
+    const payout = (c) => parseFloat(c.pending_payout_value) + parseFloat(c.total_payout_value) || 0;
+    return replies
+      .map((c) => ({
+        author: c.author,
+        text: commentToText(c.body),
+        created: toIsoDate(c.created),
+        score: payout(c) * 1000 + (c.net_votes || 0),
+      }))
+      .filter((c) => c.author && meaningfulLength(c.text) >= MIN_COMMENT_CHARS)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, MAX_COMMENTS);
+  } catch (_) {
+    return [];
   } finally {
     clearTimeout(timer);
   }
@@ -382,6 +496,10 @@ function buildOgHtml({
   uploadDate,
   embedUrl,
   transcript,
+  transcriptLang,
+  subtitleLanguages,
+  comments,
+  commentCount,
 }) {
   const safeTitle = escapeHtml(title);
   const safeDesc = escapeHtml(description);
@@ -417,13 +535,37 @@ function buildOgHtml({
   const isoDuration = secondsToISO8601(duration);
   if (isoDuration) ld.duration = isoDuration;
   if (transcript) ld.transcript = transcript;
+  // Which languages this video has captions in. Declared rather than inlined:
+  // the words go in once (see fetchTranscript), the availability goes here.
+  if (Array.isArray(subtitleLanguages) && subtitleLanguages.length) {
+    ld.subtitleLanguage = subtitleLanguages;
+  }
+  if (typeof commentCount === 'number' && commentCount >= 0) ld.commentCount = commentCount;
+  if (Array.isArray(comments) && comments.length) {
+    ld.comment = comments.map((c) => ({
+      '@type': 'Comment',
+      author: { '@type': 'Person', name: `@${c.author}` },
+      text: c.text,
+      ...(c.created ? { dateCreated: c.created } : {}),
+    }));
+  }
   const jsonLd = `<script type="application/ld+json">${JSON.stringify(ld).replace(
     /</g,
     '\\u003c',
   )}</script>`;
 
+  // `lang` on the section matters when the spoken language isn't the page's:
+  // it stops a Spanish transcript being read as bad English.
   const transcriptSection = transcript
-    ? `\n  <section>\n    <h2>Transcript</h2>\n    <p>${escapeHtml(transcript)}</p>\n  </section>`
+    ? `\n  <section${transcriptLang ? ` lang="${escapeHtml(transcriptLang)}"` : ''}>\n    <h2>Transcript</h2>\n    <p>${escapeHtml(transcript)}</p>\n  </section>`
+    : '';
+
+  // Rendered without a single anchor: commentToText already removed the links,
+  // so there is nothing here for a spammer to gain.
+  const commentsSection = Array.isArray(comments) && comments.length
+    ? `\n  <section>\n    <h2>Comments</h2>\n${comments
+        .map((c) => `    <article><p><b>@${escapeHtml(c.author)}</b>: ${escapeHtml(c.text)}</p></article>`)
+        .join('\n')}\n  </section>`
     : '';
 
   return `<!DOCTYPE html>
@@ -456,7 +598,7 @@ function buildOgHtml({
 <body>
   <h1>${safeTitle}</h1>
   <p><a href="${safeUrl}">${safeTitle}</a> by @${safeAuthor} on <a href="${escapeHtml(BASE_URL)}">3Speak</a></p>
-  <p>${safeDesc}</p>${transcriptSection}
+  <p>${safeDesc}</p>${transcriptSection}${commentsSection}
 </body>
 </html>`;
 }
@@ -466,7 +608,7 @@ function buildOgHtml({
 // than a broken response. Mirrors index.html's primary OG/Twitter tags.
 function buildGenericHtml(siteUrl) {
   const url = escapeHtml(siteUrl);
-  const title = '3Speak - Decentralized Video Platform';
+  const title = '3Speak | Real People - Real Stories';
   const desc =
     '3Speak is a decentralized video sharing platform built on blockchain technology. Watch, upload, and share videos while earning cryptocurrency rewards.';
   return `<!DOCTYPE html>
@@ -598,9 +740,20 @@ const server = http.createServer(async (req, res) => {
     // Transcripts only exist for Hive-backed videos; fetch by the resolved Hive
     // author/permlink (not the embed asset id), and skip on noindex pages.
     let transcript = null;
+    let transcriptLang = null;
+    let subtitleLanguages = null;
+    let comments = [];
     if (post && index) {
-      const t = await fetchTranscript(post.author, post.permlink);
+      // Both hang off the same Hive post; fetch them together rather than
+      // adding the comment round-trip on top of the transcript's.
+      const [t, c] = await Promise.all([
+        fetchTranscript(post.author, post.permlink),
+        fetchComments(post.author, post.permlink),
+      ]);
       transcript = (t && t.text) || null;
+      transcriptLang = (t && t.lang) || null;
+      subtitleLanguages = (t && t.languages) || null;
+      comments = c;
     }
 
     const html = buildOgHtml({
@@ -614,6 +767,10 @@ const server = http.createServer(async (req, res) => {
       uploadDate,
       embedUrl: `${origin}/embed?v=${video.author}/${video.permlink}`,
       transcript,
+      transcriptLang,
+      subtitleLanguages,
+      comments,
+      commentCount: post && typeof post.children === 'number' ? post.children : undefined,
     });
 
     return sendHtml(req, res, 200, html);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -78,6 +78,7 @@ const FirstUploads = lazy(() => import("./page/FirstUploads"));
 const FollowFeed = lazy(() => import("./page/FollowFeed"));
 const HiveImageUploader = lazy(() => import("./page/HiveImageUploader"));
 const Leaderboard = lazy(() => import("./page/Leaderboard"));
+const Advertise = lazy(() => import("./page/Advertise"));
 const Legal = lazy(() => import("./page/Legal"));
 const LoginNew = lazy(() => import("./page/Login/LoginNew"));
 const ManteAuthCallback = lazy(() => import("./page/Login/ManteAuthCallback"));
@@ -622,6 +623,7 @@ function App() {
             />
             <Route path="/t/:tag" element={<TagFeed />} />
             <Route path="/leaderboard" element={<Leaderboard />} />
+            <Route path="/advertise" element={<Advertise />} />
             <Route path="/profile" element={<ProfilePage />} />
             {/* Spotlight — creator link page. Canonical: 3speak.tv/links/username (no @).
                 Legacy /@handle/links still resolves (nginx 301s it to /links/ in prod). */}

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.78.48',
+    date: '2026-08-22',
+    summary:
+      'Browser notifications are here. Turn them on from the bell or in Settings → Notifications, and 3Speak can reach you even when it\'s closed: new videos, shorts and audio from creators you follow, plus replies, mentions and new followers. You choose which ones.',
+  },
+  {
     version: '1.78.47',
     date: '2026-08-22',
     summary:

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.78.43',
+    date: '2026-08-20',
+    summary:
+      'The Leaderboard (/leaderboard) now only shows the note about when watch-time tracking started on the boards it actually applies to, so the 7 and 30 day boards read clean.',
+  },
+  {
     version: '1.78.42',
     date: '2026-08-19',
     summary:

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.78.42',
+    date: '2026-08-19',
+    summary:
+      'Links in video descriptions, comments and community posts now open in a new tab, so clicking one never costs you an upload in progress or your place in a video.',
+  },
+  {
     version: '1.78.41',
     date: '2026-08-19',
     summary:

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,18 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.78.46',
+    date: '2026-08-20',
+    summary:
+      'Every channel now has a podcast feed at 3speak.tv/rss/username.xml, covering their videos and audio uploads. Subscribe in any podcast app or RSS reader, or use the new feed button on a profile.',
+  },
+  {
+    version: '1.78.45',
+    date: '2026-08-20',
+    summary:
+      'Videos with subtitles now have a Transcript tab beside the video, next to Reactions. Read along, click any line to jump there, switch language, or copy the whole thing.',
+  },
+  {
     version: '1.78.44',
     date: '2026-08-20',
     summary:

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.78.44',
+    date: '2026-08-20',
+    summary:
+      'Videos posted outside a community no longer show a community name on the watch page.',
+  },
+  {
     version: '1.78.43',
     date: '2026-08-20',
     summary:

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,30 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.78.41',
+    date: '2026-08-19',
+    summary:
+      'Profile polish: 3Speak badges now match the Hive badges beside them for a calmer header, and a channel trailer\'s description takes the full width when there is no community post next to it.',
+  },
+  {
+    version: '1.78.40',
+    date: '2026-08-19',
+    summary:
+      'Empty tabs on your own profile now point you straight at what to do next: Videos, Shorts, Audio and Playlists each offer the matching upload or create button.',
+  },
+  {
+    version: '1.78.39',
+    date: '2026-08-19',
+    summary:
+      'The Overview tab on a profile now shows what is inside each playlist: one row of videos per playlist, right above the playlist covers. Hit View all to open the whole playlist.',
+  },
+  {
+    version: '1.78.38',
+    date: '2026-08-19',
+    summary:
+      'Profiles now show a creator\'s links page next to their Overview tab (/p/username), in 3Speak\'s own colours. Fold it away with the arrow in its corner and it stays folded until you bring it back. On phones there\'s a Links button under Message.',
+  },
+  {
     version: '1.78.37',
     date: '2026-08-17',
     summary:

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.78.47',
+    date: '2026-08-22',
+    summary:
+      'Browser tabs and shared links now lead with 3S, so a 3Speak tab is easy to spot. Community pages show the community\'s name instead of its id.',
+  },
+  {
     version: '1.78.46',
     date: '2026-08-20',
     summary:

--- a/src/components/Communities/CommunitiesRender.jsx
+++ b/src/components/Communities/CommunitiesRender.jsx
@@ -49,7 +49,9 @@ function CommunitiesRender() {
   };
 
   useEffect(() => {
-    document.title = '3Speak - Tokenised video communities';
+    // The tab title comes from RouteTitle like every other page. Setting
+    // document.title here used to override it, which is why this page alone kept
+    // an older brand line and the 'Communities' entry in the route table was dead.
     generate();
   }, []);
   const handleCardClick = (communityName) => {

--- a/src/components/Communities/CommunityPage.jsx
+++ b/src/components/Communities/CommunityPage.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { getHiveClient } from '../../utils/hiveNode';
 import { useParams } from "react-router-dom";
+import { Helmet } from "react-helmet-async";
 import { toast } from 'sonner';
 import { Clock, TrendingUp, Users, PenLine, FileText, Coins, CalendarDays, Check, Plus } from 'lucide-react';
 import "./CommunityPage.scss";
@@ -26,6 +27,12 @@ const fmtNum = (n) => (typeof n === 'number' ? n.toLocaleString('en-US') : '—'
 function CommunityPage() {
   const { communityName: id } = useParams();
   const [dataMain, setDataMain] = useState(null);
+
+  // The tab title is the community's DISPLAY name, not the route param — that is
+  // the raw Hive id (hive-181335), which tells a reader nothing. RouteTitle lists
+  // this route as self-titled, so nothing competes for the tag. Until the bridge
+  // call returns we say "Community" rather than showing the id we are avoiding.
+  const communityTitle = dataMain?.title || 'Community';
   const [trend, setTrend] = useState(false); // false = new (default), true = trending
   const hideWatched = useAppStore(s => s.hideWatched);
   const feedUser = useAppStore(s => s.user);
@@ -190,6 +197,9 @@ function CommunityPage() {
 
   return (
     <div className="community-page-wrap">
+      <Helmet>
+        <title>{`3S | ${communityTitle}`}</title>
+      </Helmet>
       <ProfileHeader
         username={id}
         name={dataMain?.title || id}

--- a/src/components/LeaderboardBadges/LeaderboardBadges.scss
+++ b/src/components/LeaderboardBadges/LeaderboardBadges.scss
@@ -33,43 +33,28 @@
     }
   }
 
-  // Badges render over the profile BANNER, whose brightness we don't control, so
-  // every pill is fully opaque and carries its own text colour. A translucent
-  // tint here let the dark banner bleed through and made the text unreadable.
-  // Colours are fixed rather than theme-dependent: an opaque pill keeps the same
-  // contrast against light and dark alike.
-  // 3Speak Pro — a status, not a ranking, so it gets the brand red rather than
-  // another medal tier. Opaque like the rest so it stays legible over any
-  // banner. Not a link: the Pro page lives on the owner's own wallet, so it
-  // would be a dead end on someone else's profile.
-  .lb-badge-pro {
-    background: #e31337;
-    border-color: #b30f2b;
-    color: #fff;
-    cursor: default;
-  }
-
-  .lb-badge-top1 {
-    background: #ffd75e;
-    border-color: #d9ae2b;
-    color: #4a3600;
-  }
-
-  .lb-badge-top3 {
-    background: #dbe2e8;
-    border-color: #b3bfc9;
-    color: #2f3a44;
-  }
-
-  .lb-badge-top10 {
-    background: #f0c39a;
-    border-color: #cf9a67;
-    color: #5c3313;
-  }
-
+  // One neutral pill for every badge. The medal tiers (gold / silver / bronze)
+  // plus the brand-red Pro chip read as four different systems in a single row,
+  // right under a row of Hive badges that is already neutral.
+  //
+  // Colours are .hive-badge's, to the value: the two rows sit together in the
+  // same badge block, so anything but an exact match reads as a mistake.
+  // They still render over the profile BANNER, whose brightness we don't
+  // control, so the pill keeps its opaque surface — a translucent tint let the
+  // banner bleed through and killed the contrast. Only the colour-coding went.
+  .lb-badge-pro,
+  .lb-badge-top1,
+  .lb-badge-top3,
+  .lb-badge-top10,
   .lb-badge-top50 {
-    background: #e7ebee;
-    border-color: #c3ccd4;
-    color: #3b454e;
+    background: rgba(15, 23, 42, 0.92);
+    border-color: rgba(148, 163, 184, 0.28);
+    color: #e2e8f0;
+
+    &:hover { border-color: rgba(148, 163, 184, 0.5); }
   }
+
+  // Not a link: the Pro page lives on the owner's own wallet, so it would be a
+  // dead end on someone else's profile.
+  .lb-badge-pro { cursor: default; }
 }

--- a/src/components/ProfileHeader/ProfileHeader.scss
+++ b/src/components/ProfileHeader/ProfileHeader.scss
@@ -345,6 +345,24 @@
                 color: #fff;
               }
             }
+
+            // A third action (ProfileLinksButton, narrow screens only) belongs
+            // directly UNDER Message rather than wrapped onto a line of its
+            // own: two columns, and the extra button claims column 2's second
+            // row, so it sits under Message and matches its width. :has keeps
+            // every profile without a links page on the plain flex row.
+            @media screen and (max-width: 1024px) {
+              &:has(.profile-links-btn) {
+                display: grid;
+                grid-template-columns: auto auto;
+                align-items: center;
+              }
+
+              .profile-links-btn {
+                grid-column: 2;
+                justify-self: stretch;
+              }
+            }
           }
 
           // @account, directly under a display name.

--- a/src/components/RouteTitle.jsx
+++ b/src/components/RouteTitle.jsx
@@ -13,11 +13,18 @@ import { Helmet } from 'react-helmet-async';
  * (react-helmet-async lets the last-rendered value win, and we'd rather not
  * depend on mount order.)
  */
-const SELF_TITLED = ['/watch', '/shorts'];
+const SELF_TITLED = ['/watch', '/shorts', '/community/:communityName'];
 
 // First match wins. `title` may be a string or a fn of the matched params.
+// `full: true` means the string IS the whole tab title — it does not get the
+// "3S | <page>" prefix. Used by the home page, which carries the brand line
+// itself rather than being labelled like a sub-page.
+//
+// The prefix is "3S" rather than "3Speak": it matches the logo, so a tab is
+// recognisable from the mark alone, and putting it first means the platform
+// survives the truncation a narrow tab applies to the end of the string.
 const ROUTES = [
-  { path: '/', end: true, title: 'Home' },
+  { path: '/', end: true, title: '3S | Real People - Real Stories', full: true },
   { path: '/home-feed', title: 'Home Feed' },
   { path: '/follow-feed', title: 'Follow Feed' },
   { path: '/trend', title: 'Trending' },
@@ -27,7 +34,6 @@ const ROUTES = [
   { path: '/leaderboard', title: 'Leaderboard' },
   { path: '/notifications', title: 'Notifications' },
   { path: '/communities', title: 'Communities' },
-  { path: '/community/:communityName', title: (p) => p.communityName },
   { path: '/audio/:author/:permlink', title: (p) => `Audio by @${p.author}` },
   { path: '/audio', title: 'Audio' },
   { path: '/playlist/:playlistId', title: 'Playlist' },
@@ -50,12 +56,32 @@ const ROUTES = [
   { path: '/auth/login', title: 'Login' },
 ];
 
-export function resolveRouteTitle(pathname) {
+const BRAND_FALLBACK = '3Speak - Decentralized Video Platform';
+
+function matchRoute(pathname) {
   for (const r of ROUTES) {
     const m = matchPath({ path: r.path, end: r.end ?? false }, pathname);
-    if (m) return typeof r.title === 'function' ? r.title(m.params) : r.title;
+    if (m) return { route: r, params: m.params };
   }
   return null;
+}
+
+/** The page's own label, without the brand suffix. */
+export function resolveRouteTitle(pathname) {
+  const hit = matchRoute(pathname);
+  if (!hit) return null;
+  return typeof hit.route.title === 'function' ? hit.route.title(hit.params) : hit.route.title;
+}
+
+/** The exact string that goes in <title>, suffix rules applied. */
+export function resolveDocumentTitle(pathname) {
+  const hit = matchRoute(pathname);
+  const label = hit
+    ? (typeof hit.route.title === 'function' ? hit.route.title(hit.params) : hit.route.title)
+    : null;
+  // Unknown route → the plain brand title rather than a stale one.
+  if (!label) return BRAND_FALLBACK;
+  return hit.route.full ? label : `3S | ${label}`;
 }
 
 export default function RouteTitle() {
@@ -64,11 +90,9 @@ export default function RouteTitle() {
   // Let self-titling pages own the tag entirely.
   if (SELF_TITLED.some((p) => matchPath({ path: p, end: false }, pathname))) return null;
 
-  const title = resolveRouteTitle(pathname);
-  // Unknown route → fall back to the plain brand title rather than a stale one.
   return (
     <Helmet>
-      <title>{title ? `${title} | 3Speak` : '3Speak - Decentralized Video Platform'}</title>
+      <title>{resolveDocumentTitle(pathname)}</title>
     </Helmet>
   );
 }

--- a/src/components/SEOHead.jsx
+++ b/src/components/SEOHead.jsx
@@ -13,9 +13,12 @@ const SEOHead = ({
   modifiedTime = null,
   structuredData = null,
 }) => {
+  // "3S" matches the logo and leads, so the platform is the part that survives a
+  // narrow tab. The brand default passes through untouched rather than being
+  // branded twice.
   const fullTitle = title === '3Speak - Decentralized Video Platform'
     ? title
-    : `${title} | 3Speak`;
+    : `3S | ${title}`;
 
   return (
     <Helmet>

--- a/src/components/SettingsModal/SettingsModal.jsx
+++ b/src/components/SettingsModal/SettingsModal.jsx
@@ -6,6 +6,11 @@ import { useAppStore } from '../../lib/store';
 import { APP_VERSION } from '../../version';
 import { getHiveUrl } from '../../utils/hiveNode';
 import { fetchUserInterests, saveInterestsToHive } from '../../utils/interests';
+import { fetchCreatorAdPrefs, setCreatorAdPrefs } from '../../lib/advertiseData';
+import { adsEnabledFor } from '../../utils/config';
+import {
+  pushSupported, getPushState, enablePush, disablePush, getPushPrefs, setPushPrefs,
+} from '../../utils/webPush';
 import TagsV2Picker from '../tooltip/TagsV2Picker';
 import DataRequestForm from './DataRequestForm';
 import './SettingsModal.scss';
@@ -92,6 +97,154 @@ function InterestsSection() {
 }
 
 // Small inline switch (replaces the big LabeledToggle in this dialog).
+// Ads on the creator's own videos. Ads run network-wide by default, so this is the
+// other half of that bargain and has to be reachable by every login — including
+// HiveSigner and Butter Auth, which cannot sign in the browser (the data layer
+// falls back to a delegated @threespeak signature for those).
+function AdsSection() {
+  const user = useAppStore((s) => s.user);
+  const [adsEnabled, setAdsEnabled] = useState(true);
+  // Placeholder only — the real split (and the platform default for a creator who
+  // has never set one) comes from the server. The row stays hidden until it lands,
+  // so nobody is shown a share that is about to change under them.
+  const [split, setSplit] = useState(null);
+  // The percentage box is a draft until saved: every save costs a wallet signature,
+  // so typing "25" must not fire three of them on the way there.
+  const [draftCommunity, setDraftCommunity] = useState('0');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Closed testing — nothing renders and nothing is fetched for anyone else.
+  const visible = adsEnabledFor(user);
+
+  useEffect(() => {
+    if (!user || !visible) return undefined;
+    let alive = true;
+    setLoading(true);
+    fetchCreatorAdPrefs(user)
+      .then((r) => {
+        if (!alive) return;
+        setAdsEnabled(r.adsEnabled !== false);
+        if (r.split) { setSplit(r.split); setDraftCommunity(String(r.split.communityPct)); }
+      })
+      .catch(() => { /* unreadable preference just shows the default */ })
+      .finally(() => { if (alive) setLoading(false); });
+    return () => { alive = false; };
+  }, [user, visible]);
+
+  // Both fields ride one signed message, so saving either costs a single prompt.
+  async function save(nextEnabled, nextCommunity) {
+    if (saving) return false;
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await setCreatorAdPrefs(user, {
+        adsEnabled: nextEnabled,
+        communitySharePct: nextCommunity,
+      });
+      if (res.split) { setSplit(res.split); setDraftCommunity(String(res.split.communityPct)); }
+      return true;
+    } catch (err) {
+      setError(err.message || 'Could not save the setting.');
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onToggle(next) {
+    const previous = adsEnabled;
+    setAdsEnabled(next);          // optimistic — a toggle that lags feels broken
+    const ok = await save(next, split ? split.communityPct : undefined);
+    if (ok) toast.success(next ? 'Ads are on for your videos' : 'Ads are off for your videos');
+    else setAdsEnabled(previous); // put it back; the setting did not change
+  }
+
+  const parsedDraft = parseInt(draftCommunity, 10);
+  const draftValid = !!split
+    && Number.isInteger(parsedDraft) && parsedDraft >= 0 && parsedDraft <= split.poolPct;
+  const draftChanged = draftValid && parsedDraft !== split.communityPct;
+
+  async function onSaveShare() {
+    if (!draftChanged) return;
+    if (await save(adsEnabled, parsedDraft)) toast.success('Revenue split saved');
+  }
+
+  if (!user || !visible) return null;
+
+  return (
+    <div className="settings-section">
+      <h4 className="settings-section-title">Ads on your videos</h4>
+      <div className="settings-modal-row">
+        <div className="settings-row-text">
+          <span className="settings-row-title">Allow ads</span>
+          <span className="settings-row-desc">
+            A short sponsor spot can play inside your videos. You get a share of what it
+            earns, and so does the community you posted in. Turn this off and your videos
+            carry no ads at all &mdash; they are also removed from what we offer
+            advertisers, so nothing is sold that you have opted out of.
+          </span>
+        </div>
+        <Switch
+          checked={adsEnabled}
+          onChange={onToggle}
+          ariaLabel="Allow ads on your videos"
+        />
+      </div>
+      {adsEnabled && split && (
+        <div className="settings-modal-row settings-ads-split">
+          <div className="settings-row-text">
+            <span className="settings-row-title">Share with the community</span>
+            <span className="settings-row-desc">
+              {split.poolPct}% of what an ad earns is split between you and the community
+              you posted in. Choose how much of it the community gets &mdash; leave it at
+              zero and you keep all {split.poolPct}%.
+            </span>
+            <span className="settings-ads-breakdown">
+              You {draftValid ? split.poolPct - parsedDraft : split.creatorPct}%
+              <span aria-hidden="true"> · </span>
+              Community {draftValid ? parsedDraft : split.communityPct}%
+            </span>
+          </div>
+          <div className="settings-ads-share-control">
+            <label className="settings-visually-hidden" htmlFor="settings-community-share">
+              Community share, percent
+            </label>
+            <div className="settings-ads-input">
+              <input
+                id="settings-community-share"
+                type="number"
+                min="0"
+                max={split.poolPct}
+                step="1"
+                inputMode="numeric"
+                value={draftCommunity}
+                onChange={(e) => setDraftCommunity(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') onSaveShare(); }}
+                aria-invalid={!draftValid}
+              />
+              <span aria-hidden="true">%</span>
+            </div>
+            {draftChanged && (
+              <button type="button" className="settings-ads-save" onClick={onSaveShare} disabled={saving}>
+                Save
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+      {(loading || saving || error || (split && !draftValid)) && (
+        <p className={`settings-ads-status${(error || (split && !draftValid)) ? ' error' : ''}`}>
+          {error
+            || (split && !draftValid ? `Enter a whole number between 0 and ${split.poolPct}.` : null)
+            || (saving ? 'Saving\u2026' : 'Loading your current setting\u2026')}
+        </p>
+      )}
+    </div>
+  );
+}
+
 function Switch({ checked, onChange, ariaLabel }) {
   return (
     <button
@@ -104,6 +257,138 @@ function Switch({ checked, onChange, ariaLabel }) {
     >
       <span className="settings-switch-knob" />
     </button>
+  );
+}
+
+/**
+ * Browser push notifications.
+ *
+ * Two separate things, deliberately shown as such: whether THIS DEVICE is
+ * registered at all (a browser permission, per machine), and WHAT you want to
+ * hear about (a preference, per account, applying to every device). Someone who
+ * turns notifications off on their laptop shouldn't lose their choices on their
+ * phone, so the per-kind switches stay visible and editable either way.
+ */
+const KIND_COPY = {
+  videos: { title: 'New videos', desc: 'When a creator you follow publishes a video.' },
+  shorts: { title: 'New shorts', desc: 'When a creator you follow posts a short.' },
+  audio: { title: 'New audio', desc: 'When a creator you follow uploads a track or episode.' },
+  replies: { title: 'Replies', desc: 'When someone replies to your post or comment.' },
+  mentions: { title: 'Mentions', desc: 'When someone mentions you by name.' },
+  follows: { title: 'New followers', desc: 'When someone follows you.' },
+  votes: { title: 'Upvotes', desc: 'When someone upvotes your post. Off by default — a popular post is a lot of buzzes.' },
+  reblogs: { title: 'Reblogs', desc: 'When someone reblogs your post.' },
+};
+
+// The two groups answer different questions: what other people published, and
+// what happened to you.
+const KIND_GROUPS = [
+  { label: 'From creators you follow', kinds: ['videos', 'shorts', 'audio'] },
+  { label: 'About you', kinds: ['replies', 'mentions', 'follows', 'votes', 'reblogs'] },
+];
+
+function NotificationsSection() {
+  const user = useAppStore((s) => s.user);
+  const [state, setState] = useState({ supported: false, worker: true, permission: 'default', subscribed: false });
+  const [kinds, setKinds] = useState([]);
+  const [prefs, setPrefs] = useState({});
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (pushSupported()) getPushState().then(setState).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (!user) return;
+    getPushPrefs(user).then(({ kinds: k, prefs: p }) => { setKinds(k); setPrefs(p); }).catch(() => {});
+  }, [user]);
+
+  const toggleDevice = async () => {
+    setBusy(true);
+    try {
+      if (state.subscribed) {
+        await disablePush(user);
+        toast.success('This device will no longer be notified');
+      } else {
+        await enablePush(user);
+        toast.success('This device will be notified');
+      }
+      setState(await getPushState());
+    } catch (err) {
+      toast.error(err.message || 'Could not change notifications');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const toggleKind = async (kind, value) => {
+    const next = { ...prefs, [kind]: value };
+    setPrefs(next);                                   // optimistic: a switch that lags feels broken
+    try {
+      setPrefs(await setPushPrefs(user, next));
+    } catch (err) {
+      setPrefs(prefs);                                // put it back rather than lie
+      toast.error(err.message || 'Could not save that');
+    }
+  };
+
+  if (!user) {
+    return (
+      <div className="settings-section">
+        <h4 className="settings-section-title">Notifications</h4>
+        <p className="settings-note">Log in to choose what you get notified about.</p>
+      </div>
+    );
+  }
+
+  const blocked = state.permission === 'denied';
+  const noWorker = state.worker === false;
+
+  return (
+    <div className="settings-section">
+      <h4 className="settings-section-title">Notifications</h4>
+
+      {!pushSupported() ? (
+        <p className="settings-note">This browser can’t show notifications. On iPhone and iPad they only work once 3Speak is added to the Home Screen.</p>
+      ) : (
+        <>
+          <Row
+            title="Notify this device"
+            desc={blocked
+              ? 'Blocked in your browser settings for this site — allow notifications there first.'
+              : noWorker
+                ? 'Not available on this build.'
+                : 'Get a notification even when 3Speak isn’t open. Applies to this browser only.'}
+            checked={state.subscribed}
+            onChange={busy || blocked || noWorker ? () => {} : toggleDevice}
+          />
+
+          <p className="settings-note">
+            What to be notified about. These apply to every device you’ve turned on.
+          </p>
+          {KIND_GROUPS.map(({ label, kinds: group }) => {
+            // Only offer what the server actually supports, so an older backend
+            // can't leave dead switches on the page.
+            const available = group.filter((k) => !kinds.length || kinds.includes(k));
+            if (!available.length) return null;
+            return (
+              <div key={label} className="settings-kind-group">
+                <span className="settings-kind-group-label">{label}</span>
+                {available.map((k) => (
+                  <Row
+                    key={k}
+                    title={KIND_COPY[k].title}
+                    desc={KIND_COPY[k].desc}
+                    checked={prefs[k] !== false}
+                    onChange={(v) => toggleKind(k, v)}
+                  />
+                ))}
+              </div>
+            );
+          })}
+        </>
+      )}
+    </div>
   );
 }
 
@@ -124,6 +409,7 @@ const TABS = [
   { id: 'shorts', label: 'Shorts' },
   { id: 'content', label: 'Content' },
   { id: 'interests', label: 'Interests' },
+  { id: 'notifications', label: 'Notifications' },
   { id: 'about', label: 'About / Contact' },
 ];
 
@@ -309,6 +595,7 @@ export default function SettingsModal({ isOpen, onClose }) {
         )}
 
         {tab === 'content' && (
+          <>
           <div className="settings-section">
             <h4 className="settings-section-title">Content</h4>
             <Row
@@ -330,9 +617,12 @@ export default function SettingsModal({ isOpen, onClose }) {
               onChange={(v) => setPrivateMode(v)}
             />
           </div>
+          <AdsSection />
+          </>
         )}
 
         {tab === 'interests' && <InterestsSection />}
+        {tab === 'notifications' && <NotificationsSection />}
 
         {tab === 'about' && (
           <>

--- a/src/components/SettingsModal/SettingsModal.scss
+++ b/src/components/SettingsModal/SettingsModal.scss
@@ -119,6 +119,28 @@
   color: var(--text-secondary, #9aa);
 }
 
+// Explanatory line inside a section, between the switches.
+.settings-kind-group {
+  margin-bottom: 6px;
+}
+
+.settings-kind-group-label {
+  display: block;
+  margin: 12px 2px 2px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted, var(--text-secondary));
+}
+
+.settings-note {
+  margin: 6px 2px 10px;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+
 .settings-modal-row {
   display: flex;
   align-items: center;
@@ -288,4 +310,97 @@
     color: var(--text-primary, #f1f1f1);
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.18);
   }
+}
+
+/* Status line under the ads toggle — loading, saving, or why a save failed. */
+.settings-ads-status {
+  margin: 6px 0 0;
+  padding: 0 4px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-muted);
+
+  &.error {
+    color: var(--accent-primary);
+  }
+}
+
+/* Community revenue-share editor, under the ads toggle. */
+.settings-ads-split {
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.settings-ads-breakdown {
+  margin-top: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+}
+
+.settings-ads-share-control {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.settings-ads-input {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-muted);
+
+  input {
+    width: 68px;
+    padding: 7px 9px;
+    border: 1px solid var(--input-border);
+    border-radius: 8px;
+    background: var(--input-bg);
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 14px;
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+
+    &:focus-visible {
+      outline: 2px solid var(--accent-primary);
+      outline-offset: 1px;
+    }
+
+    &[aria-invalid="true"] {
+      border-color: var(--accent-primary);
+    }
+  }
+}
+
+.settings-ads-save {
+  padding: 6px 14px;
+  border: none;
+  border-radius: 8px;
+  background: var(--accent-primary);
+  color: var(--text-inverse);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover:not(:disabled) { background: var(--accent-hover); }
+  &:focus-visible { outline: 2px solid var(--accent-primary); outline-offset: 2px; }
+  &:disabled { opacity: 0.55; cursor: not-allowed; }
+}
+
+.settings-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
 }

--- a/src/components/Userprofilepage/ChannelTrailer.scss
+++ b/src/components/Userprofilepage/ChannelTrailer.scss
@@ -63,6 +63,17 @@
   }
 }
 
+// No community note beside the player (the snap column isn't rendered at all),
+// so the description takes the whole rest of the row instead of leaving the
+// other half empty.
+.channel-trailer-row:not(:has(.channel-trailer-snap)) .channel-trailer-meta {
+  width: calc(100% - var(--ct-player-w) - var(--ct-gap));
+
+  @include mix.respond(phone) {
+    width: 100%;
+  }
+}
+
 .channel-trailer-meta {
   display: flex;
   flex-direction: column;
@@ -212,18 +223,20 @@
     span { font-size: 0.82rem; color: var(--text-secondary); line-height: 1.35; }
   }
 
+  // Red outline, never a red fill (app-wide convention for red controls).
   .cte-btn {
     flex: 0 0 auto;
     padding: 0.5rem 0.9rem;
     border-radius: 10px;
+    border: 1px solid var(--accent-primary);
     font-size: 0.86rem;
     font-weight: 600;
     text-decoration: none;
-    color: var(--text-inverse, #fff);
-    background: var(--accent-primary);
-    transition: background 0.15s ease;
+    color: var(--accent-primary);
+    background: transparent;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 
-    &:hover { background: var(--accent-hover); }
+    &:hover { background: var(--accent-light); }
   }
 
   @include mix.respond(phone) {

--- a/src/components/Userprofilepage/ProfileEmptyState.jsx
+++ b/src/components/Userprofilepage/ProfileEmptyState.jsx
@@ -1,0 +1,91 @@
+import { useNavigate } from 'react-router-dom';
+import { IoCloudUploadSharp } from 'react-icons/io5';
+import { MdGraphicEq } from 'react-icons/md';
+import { IoMdAdd } from 'react-icons/io';
+import ShortsIcon from '../icons/ShortsIcon';
+import { getCreatorSettings, isUploadBlocked } from '../../utils/creatorSettings';
+import { useSupportBlock } from '../../lib/supportBlockStore';
+import { useAppStore } from '../../lib/store';
+import './ProfileEmptyState.scss';
+
+/**
+ * What a profile tab shows when it has nothing in it.
+ *
+ * On your own profile that is a call to action: the tab you just opened is the
+ * one place you already care about that kind of content, so it offers the
+ * upload rather than announcing an absence. On someone else's it is one quiet
+ * line — a visitor can't fix an empty tab, so a big block would just be noise.
+ *
+ * Uploads run through the same creator gate the Upload menu uses (a blocked
+ * creator gets the support dialog, not the studio).
+ */
+const KINDS = {
+  video: {
+    Icon: IoCloudUploadSharp,
+    title: 'No videos yet',
+    text: 'Upload your first video and it lands right here.',
+    cta: 'Upload a video',
+    go: (navigate) => navigate('/studio'),
+    visitor: (u) => `@${u} hasn't published any videos yet.`,
+  },
+  shorts: {
+    Icon: ShortsIcon,
+    title: 'No shorts yet',
+    text: 'Shorts are vertical videos, made for a quick scroll.',
+    cta: 'Upload a short',
+    go: (navigate) => navigate('/embed-studio?from=shorts'),
+    visitor: (u) => `@${u} hasn't published any shorts yet.`,
+  },
+  audio: {
+    Icon: MdGraphicEq,
+    title: 'No audio yet',
+    text: 'Music, podcasts and mixes live on your profile too.',
+    cta: 'Upload audio',
+    go: () => window.dispatchEvent(new CustomEvent('open-audio-upload')),
+    visitor: (u) => `@${u} hasn't published any audio yet.`,
+  },
+  playlists: {
+    Icon: IoMdAdd,
+    title: 'No playlists yet',
+    text: 'Group your videos into a playlist people can watch in order.',
+    cta: 'Create your first playlist',
+    // Opens a modal the page owns, so it isn't an upload and isn't gated.
+    gated: false,
+    visitor: (u) => `@${u} has no public playlists.`,
+  },
+};
+
+export default function ProfileEmptyState({ kind = 'video', isOwnProfile = false, username, onAction }) {
+  const navigate = useNavigate();
+  const cfg = KINDS[kind] || KINDS.video;
+
+  if (!isOwnProfile) {
+    return (
+      <div className="profile-empty">
+        <p className="pe-line">{cfg.visitor(username)}</p>
+      </div>
+    );
+  }
+
+  const Icon = cfg.Icon;
+  const onClick = async (e) => {
+    e.preventDefault();
+    if (cfg.gated === false) { onAction?.(); return; }
+    // Same gate as UploadLinks: fails open if the check itself errors.
+    const settings = await getCreatorSettings(useAppStore.getState().user);
+    if (isUploadBlocked(settings)) {
+      useSupportBlock.getState().showSupportBlock('upload');
+      return;
+    }
+    cfg.go(navigate);
+  };
+
+  return (
+    <div className="profile-empty profile-empty--own">
+      <span className="pe-icon"><Icon size={22} /></span>
+      <strong className="pe-title">{cfg.title}</strong>
+      <span className="pe-text">{cfg.text}</span>
+      <button type="button" className="pe-btn" onClick={onClick}>{cfg.cta}</button>
+    </div>
+  );
+}

--- a/src/components/Userprofilepage/ProfileEmptyState.scss
+++ b/src/components/Userprofilepage/ProfileEmptyState.scss
@@ -1,0 +1,74 @@
+@use "../../mixins.scss" as mix;
+
+// Replaces the old 400px "no data" plate (a crossed-out database graphic in red)
+// that every empty profile tab used to show.
+.profile-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 3rem 1.25rem;
+
+  // Visitor view: one line, no card, no icon.
+  .pe-line {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+  }
+
+  &--own {
+    gap: 0.35rem;
+    padding: 2.5rem 1.25rem;
+    border: 1px dashed var(--border-color);
+    border-radius: 14px;
+    background: var(--bg-secondary);
+  }
+
+  .pe-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    margin-bottom: 0.35rem;
+    border-radius: 50%;
+    background: var(--bg-hover);
+    color: var(--text-secondary);
+  }
+
+  .pe-title {
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--text-primary);
+  }
+
+  .pe-text {
+    max-width: 34ch;
+    font-size: 0.85rem;
+    line-height: 1.4;
+    color: var(--text-secondary);
+  }
+
+  // Red outline, never a red fill (app-wide convention for red controls).
+  .pe-btn {
+    margin-top: 0.85rem;
+    padding: 0.5rem 1.2rem;
+    border: 1px solid var(--accent-primary);
+    border-radius: 999px;
+    background: transparent;
+    color: var(--accent-primary);
+    font-size: 0.86rem;
+    font-weight: 700;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+
+    &:hover { background: var(--accent-light); }
+  }
+
+  @include mix.respond(phone) {
+    padding: 2rem 1rem;
+    &--own { padding: 1.75rem 1rem; }
+    .pe-btn { width: 100%; }
+  }
+}

--- a/src/components/Userprofilepage/ProfileLinksButton.jsx
+++ b/src/components/Userprofilepage/ProfileLinksButton.jsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import { FaLink } from 'react-icons/fa6';
+import { fetchSpotlight } from '../../utils/spotlight';
+import './ProfileLinksButton.scss';
+
+/**
+ * "Links" button under the Message button, on narrow screens.
+ *
+ * The framed links page beside the Overview tab (ProfileLinksPanel) only exists
+ * from 1025px up, so below that a visitor had no way to reach the page at all.
+ * This is its exact complement: same breakpoint, other side of it.
+ *
+ * Only rendered when the creator actually has a page — a button through to an
+ * empty one is worse than no button. It lives in the header's `nameActions`,
+ * which only exists on someone else's profile, so the own-profile case is
+ * handled for free (the Links tab is right there anyway).
+ *
+ * Wears `btn btn-hero-message` so it IS the Message button visually, and its
+ * own class only places it in the row below.
+ */
+export default function ProfileLinksButton({ username }) {
+  const [isNarrow, setIsNarrow] = useState(
+    () => typeof window !== 'undefined' && window.matchMedia('(max-width: 1024px)').matches,
+  );
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 1024px)');
+    const on = () => setIsNarrow(mq.matches);
+    mq.addEventListener('change', on);
+    return () => mq.removeEventListener('change', on);
+  }, []);
+
+  const [hasPage, setHasPage] = useState(false);
+  useEffect(() => {
+    if (!isNarrow || !username) return undefined;
+    let alive = true;
+    fetchSpotlight(username)
+      .then((r) => { if (alive) setHasPage(!!(r.exists && r.page?.sections?.length)); })
+      .catch(() => { if (alive) setHasPage(false); });
+    return () => { alive = false; };
+  }, [isNarrow, username]);
+
+  if (!isNarrow || !hasPage) return null;
+
+  // Plain anchor, not a router Link: /links/<user> is standalone HTML served by
+  // nginx, and it carries its own way back to the profile.
+  return (
+    <a className="btn btn-hero-message profile-links-btn" href={`/links/${username}`}>
+      <FaLink /> Links
+    </a>
+  );
+}

--- a/src/components/Userprofilepage/ProfileLinksButton.scss
+++ b/src/components/Userprofilepage/ProfileLinksButton.scss
@@ -1,0 +1,7 @@
+// The button IS the Message button: `.name-actions .btn.btn-hero-message` in
+// ProfileHeader.scss styles it, and the same file places it in the row below
+// (the action row's own specificity is far too high to override from here).
+// All that's left is undoing what an <a> brings along.
+.profile-links-btn {
+  text-decoration: none;
+}

--- a/src/components/Userprofilepage/ProfileLinksPanel.jsx
+++ b/src/components/Userprofilepage/ProfileLinksPanel.jsx
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { FiChevronLeft, FiChevronRight, FiEdit2 } from 'react-icons/fi';
+import { fetchSpotlight } from '../../utils/spotlight';
+import './ProfileLinksPanel.scss';
+
+// Collapse is a preference, not a per-profile state: someone who folds the
+// column away means it for every profile they visit, and it survives reloads.
+const COLLAPSE_KEY = 'links-panel-collapsed';
+const readCollapsed = () => {
+  try { return localStorage.getItem(COLLAPSE_KEY) === '1'; } catch { return false; }
+};
+
+// The framed page paints whatever background, fills and text colours its owner
+// chose, which is right on the standalone page and shouting on a profile.
+// Beside the overview it wears the app's own palette instead — surfaces, text
+// and borders all become 3Speak's, while the creator's layout, icons, imagery
+// and copy stay theirs. The full-colour version is one click away on the
+// standalone page.
+//
+// The frame is same-origin (nginx serves it from this host), so the override
+// goes in as a stylesheet on the framed document rather than as a render flag
+// the API would have to grow. `null` document = not ready or, one day, not
+// same-origin; either way there is nothing to style and nothing to fix.
+function applyHostTheme(frame) {
+  let doc;
+  try { doc = frame?.contentDocument; } catch { return; }   // cross-origin
+  if (!doc?.head) return;
+  const host = getComputedStyle(document.documentElement);
+  const v = (name, fallback) => (host.getPropertyValue(name) || '').trim() || fallback;
+  const css = `
+    body {
+      background: ${v('--bg-secondary', '#16181c')} !important;
+      color: ${v('--text-primary', '#f1f5f9')} !important;
+    }
+    /* Shadows exist to lift text off a photo background there is no longer. */
+    .nm, .hd, .bio, .h { text-shadow: none !important; }
+    .hd, .bio { color: ${v('--text-secondary', '#94a3b8')} !important; }
+    /* The avatar's coloured glow ring goes with the background it was lit for. */
+    .av { box-shadow: none !important; }
+
+    /* Every block surface becomes one app card: same fill, same border, no
+       coloured glow. !important because per-block colours are written as
+       inline styles by the renderer. Radius, spacing and layout are left
+       alone — those are the creator's design, not its palette. */
+    .lnk, .emb, .vcard, .chbtn {
+      background: ${v('--bg-tertiary', '#242424')} !important;
+      color: ${v('--text-primary', '#f1f5f9')} !important;
+      border: 1px solid ${v('--border-color', '#3d3d3d')} !important;
+      box-shadow: none !important;
+    }
+    /* Icon pucks carry their own fill per link; let the card show through. */
+    .ic { background: transparent !important; color: inherit !important; }
+    .emb-img { background: ${v('--bg-hover', 'rgba(255,255,255,0.08)')} !important; }
+  `;
+  let style = doc.getElementById('sp-host-theme');
+  if (!style) {
+    style = doc.createElement('style');
+    style.id = 'sp-host-theme';
+    doc.head.appendChild(style);
+  }
+  style.textContent = css;
+}
+
+/**
+ * The creator's Spotlight links, beside the Overview tab on desktop.
+ *
+ * This is the REAL links page in a frame — the same standalone HTML nginx serves
+ * at /links/<user>, iframed exactly the way the editor's "Live preview" does it.
+ * Rendering the blocks a second time in React would drift from the page it is
+ * supposed to be showing (theme background, avatar, headline, motion, latest-posts
+ * feed are all resolved server-side), so it renders the page itself instead.
+ *
+ * The chain read is only there to answer "is there a page at all?": no links →
+ * no panel, and the overview takes the full width back. The owner gets a short
+ * prompt through to the editor instead, otherwise the feature is invisible to
+ * exactly the person who can fill it.
+ *
+ * Mobile never mounts this — see ProfileOverview's desktop check.
+ *
+ * Collapsed, the column shrinks to a chevron that nudges sideways on a loop, so
+ * a visitor still notices this profile HAS a links page (a folded-away panel
+ * that gave no sign of itself would simply be lost).
+ */
+export default function ProfileLinksPanel({ username, isOwnProfile = false, onOpenTab }) {
+  const [state, setState] = useState({ loading: true, exists: false });
+  const [collapsed, setCollapsed] = useState(readCollapsed);
+  const frameRef = useRef(null);
+
+  const themeFrame = useCallback(() => applyHostTheme(frameRef.current), []);
+
+  // Re-skin when the app switches between light and dark: the framed document
+  // has no idea the host's tokens changed under it.
+  useEffect(() => {
+    const target = document.documentElement;
+    const obs = new MutationObserver(themeFrame);
+    obs.observe(target, { attributes: true, attributeFilter: ['data-theme', 'class'] });
+    return () => obs.disconnect();
+  }, [themeFrame]);
+
+  const setFolded = (next) => {
+    setCollapsed(next);
+    try { localStorage.setItem(COLLAPSE_KEY, next ? '1' : '0'); } catch { /* private mode */ }
+  };
+
+  useEffect(() => {
+    if (!username) return undefined;
+    let alive = true;
+    setState({ loading: true, exists: false });
+    fetchSpotlight(username)
+      .then((r) => { if (alive) setState({ loading: false, exists: r.exists && !!r.page?.sections?.length }); })
+      .catch(() => { if (alive) setState({ loading: false, exists: false }); });
+    return () => { alive = false; };
+  }, [username]);
+
+  // No placeholder while it loads: most creators have no page yet, so a skeleton
+  // would appear only to collapse again a moment later.
+  if (state.loading) return null;
+
+  if (!state.exists) {
+    if (!isOwnProfile) return null;
+    return (
+      <aside className="profile-links-panel profile-links-panel--empty">
+        <div className="plp-inner">
+          <p className="plp-hint">Add your socials, shop or newsletter — they show here and on your public links page.</p>
+          <button type="button" className="plp-btn" onClick={() => onOpenTab?.('links')}>Add links</button>
+        </div>
+      </aside>
+    );
+  }
+
+  if (collapsed) {
+    return (
+      <aside className="profile-links-panel profile-links-panel--collapsed">
+        <button
+          type="button"
+          className="plp-handle"
+          onClick={() => setFolded(false)}
+          title={`Show @${username}'s links`}
+          aria-label={`Show @${username}'s links`}
+        >
+          <FiChevronLeft size={18} />
+        </button>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="profile-links-panel">
+      <div className="plp-inner">
+        {/* Sits in the frame's top-left corner, over the page it folds away. */}
+        <button
+          type="button"
+          className="plp-hide"
+          onClick={() => setFolded(true)}
+          title="Hide links"
+          aria-label="Hide links"
+        >
+          <FiChevronRight size={16} />
+        </button>
+
+        {/* Its twin in the opposite corner, on your own profile only. */}
+        {isOwnProfile ? (
+          <button
+            type="button"
+            className="plp-edit"
+            onClick={() => onOpenTab?.('links')}
+            title="Edit links"
+            aria-label="Edit links"
+          >
+            <FiEdit2 size={14} />
+          </button>
+        ) : null}
+
+        {/* Same-origin, so SAMEORIGIN framing is fine; every link the page renders
+            already carries target="_blank", so a click never navigates in here. */}
+        <iframe
+          ref={frameRef}
+          className="plp-frame"
+          src={`/links/${username}`}
+          title={`@${username} links`}
+          loading="lazy"
+          onLoad={themeFrame}
+        />
+
+        <div className="plp-foot">
+          {/* A plain anchor, not a router Link: /links/<user> is served as
+              standalone HTML by nginx (the React route is only a fallback). */}
+          <a className="plp-open" href={`/links/${username}`} target="_blank" rel="noreferrer">
+            Open links page →
+          </a>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/Userprofilepage/ProfileLinksPanel.scss
+++ b/src/components/Userprofilepage/ProfileLinksPanel.scss
@@ -1,0 +1,174 @@
+@use "../../mixins.scss" as mix;
+
+// The links column beside the Overview tab. Desktop only — ProfileOverview does
+// not mount it below 1025px, and this guard keeps it out of the flow if it ever
+// renders there anyway.
+.profile-links-panel {
+  // 20% is the ceiling the column may take of the row, never more. No shrink:
+  // the content column is `flex: 1 1 0`, so it gives up the space instead.
+  flex: 0 0 20%;
+  max-width: 20%;
+  min-width: 0;
+  align-self: flex-start;
+
+  // Fixed in place while the overview scrolls past it. Sticky (not `fixed`) so
+  // it stays inside its own column and needs no hardcoded left offset; the nav
+  // sets --nav-height/--nav-top-offset from JS.
+  position: sticky;
+  top: calc(var(--nav-height, 60px) + 16px);
+
+  @media screen and (max-width: 1024px) {
+    display: none;
+  }
+
+  // ── collapsed ─────────────────────────────────────────────────────────────
+  // Just the handle. Width is the handle plus breathing room, so the overview
+  // takes back everything the panel was holding.
+  &--collapsed {
+    flex: 0 0 auto;
+    width: 44px;
+    max-width: 44px;
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  // Nudges sideways on a loop: a folded panel that sat perfectly still would
+  // never tell anyone this profile has a links page at all.
+  .plp-handle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    padding: 0;
+    border: 1px solid var(--border-color);
+    border-radius: 50%;
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+    cursor: pointer;
+    animation: plp-nudge 3.2s ease-in-out infinite;
+
+    &:hover {
+      color: var(--text-primary);
+      border-color: var(--accent-primary);
+      animation-play-state: paused;
+    }
+  }
+
+  .plp-inner {
+    position: relative;   // anchors the collapse button to the frame's corner
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+
+  // No heading above the frame — the page inside carries its own identity
+  // (avatar, name, headline), so a "Links" title only repeated it.
+  .plp-foot {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0 0.25rem;
+  }
+
+  // The two corner controls: collapse on the left, edit (own profile only) on
+  // the right. They sit OVER the framed page, which paints its own background,
+  // so they carry their own dark scrim rather than a theme token.
+  .plp-hide,
+  .plp-edit {
+    position: absolute;
+    top: 8px;
+    z-index: 2;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    padding: 0;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.55);
+    color: #fff;
+    cursor: pointer;
+    backdrop-filter: blur(3px);
+    transition: all 0.2s ease;
+
+    &:hover {
+      background: rgba(0, 0, 0, 0.8);
+      border-color: rgba(255, 255, 255, 0.55);
+    }
+  }
+
+  .plp-hide { left: 8px; }
+  .plp-edit { right: 8px; }
+
+  // The framed page. Height is the whole sticky column, so the links page lays
+  // itself out against a real viewport (its own `100vh`) and scrolls inside the
+  // frame — same idea as the editor's live-preview device.
+  .plp-frame {
+    display: block;
+    width: 100%;
+    height: calc(100vh - var(--nav-height, 60px) - 90px);
+    min-height: 320px;
+    border: 1px solid var(--border-color, rgba(150, 150, 150, 0.25));
+    border-radius: 14px;
+    // Same surface the framed document is re-skinned to (see applyHostTheme),
+    // so there's no flash of the creator's own background before it lands.
+    background: var(--bg-secondary, #16181c);
+    color-scheme: normal;
+  }
+
+  .plp-open {
+    min-width: 0;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-decoration: none;
+
+    &:hover { color: var(--text-primary); text-decoration: underline; }
+  }
+
+  // ── owner-only prompt when there is no page yet ──
+  &--empty .plp-inner {
+    padding: 14px;
+    border-radius: 14px;
+    border: 1px dashed var(--border-color, rgba(150, 150, 150, 0.35));
+    gap: 0.5rem;
+  }
+
+  .plp-hint {
+    margin: 0;
+    font-size: 0.82rem;
+    line-height: 1.45;
+    color: var(--text-secondary);
+  }
+
+  .plp-btn {
+    align-self: flex-start;
+    padding: 0.4rem 0.9rem;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    background: transparent;
+    color: var(--text-primary);
+    font-size: 0.82rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover { background: var(--bg-hover); border-color: var(--text-secondary); }
+  }
+}
+
+// A double-nudge every few seconds, not a constant wobble: it has to catch the
+// eye, and it also has to sit still long enough to be an easy click target.
+@keyframes plp-nudge {
+  0%, 55%, 78%, 100% { transform: translateX(0); }
+  65% { transform: translateX(-6px); }
+  88% { transform: translateX(-4px); }
+}
+
+// Motion is the whole point of the handle, but not at the cost of someone who
+// asked the OS for less of it.
+@media (prefers-reduced-motion: reduce) {
+  .profile-links-panel .plp-handle { animation: none; }
+}

--- a/src/components/Userprofilepage/ProfileOverview.jsx
+++ b/src/components/Userprofilepage/ProfileOverview.jsx
@@ -4,6 +4,8 @@ import PlaylistCard from '../Cards/PlaylistCard';
 import UserAudioList from './UserAudioList';
 import ChannelTrailer from './ChannelTrailer';
 import CommunitySnaps from './CommunitySnaps';
+import ProfileLinksPanel from './ProfileLinksPanel';
+import ProfilePlaylistRails from './ProfilePlaylistRails';
 import './ProfileOverview.scss';
 
 /**
@@ -15,6 +17,9 @@ import './ProfileOverview.scss';
  * which said nothing about whether they also make shorts, audio or playlists.
  *
  * Sections with nothing in them are omitted rather than shown empty.
+ *
+ * On desktop the creator's Spotlight links sit in a sticky column to the right
+ * of all this (ProfileLinksPanel); phones and tablets keep the single column.
  */
 
 const DESKTOP_COUNT = 6;
@@ -69,6 +74,18 @@ export default function ProfileOverview({
     return () => mq.removeEventListener('change', on);
   }, []);
 
+  // The links column only exists on desktop — mobile keeps the layout it had.
+  // Gated in JS rather than CSS so a phone never pays for the extra Hive read.
+  const [isDesktop, setIsDesktop] = useState(
+    () => typeof window !== 'undefined' && window.matchMedia('(min-width: 1025px)').matches,
+  );
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 1025px)');
+    const on = () => setIsDesktop(mq.matches);
+    mq.addEventListener('change', on);
+    return () => mq.removeEventListener('change', on);
+  }, []);
+
   const videoSlice = videos.slice(0, RAIL_COUNT);
   const shortSlice = shorts.slice(0, RAIL_COUNT);
   const playlistSlice = playlists.slice(0, perRow);
@@ -79,49 +96,64 @@ export default function ProfileOverview({
 
   return (
     <div className="profile-overview">
-      <ChannelTrailer username={username} isOwnProfile={isOwnProfile} onOpenCommunityTab={openCommunityTab} />
+      <div className="pov-main">
+        <ChannelTrailer username={username} isOwnProfile={isOwnProfile} onOpenCommunityTab={openCommunityTab} />
 
-      <Section title="Videos" count={videoSlice.length} onViewMore={() => onOpenTab('video')}>
-        <Card3
-          videos={videoSlice}
+        <Section title="Videos" count={videoSlice.length} onViewMore={() => onOpenTab('video')}>
+          <Card3
+            videos={videoSlice}
+            getContentForVideo={getContentForVideo}
+            isWatched={isWatched}
+            getViewCount={getViewCount}
+          />
+        </Section>
+
+        <Section title="Shorts" count={shortSlice.length} onViewMore={() => onOpenTab('shorts')}>
+          <Card3
+            videos={shortSlice}
+            shortsGrid
+            linkPrefix="/shorts"
+            getViewCount={getViewCount}
+          />
+        </Section>
+
+        {/* Audio, community posts and playlists own their own data, so they're
+            rendered limited rather than sliced here, and hide when empty. */}
+        <section className="pov-section pov-section--audio">
+          <div className="pov-head">
+            <h3>Audio</h3>
+            <button type="button" className="pov-more" onClick={() => onOpenTab('audio')}>View more</button>
+          </div>
+          <UserAudioList user={username} limit={perRow} />
+        </section>
+
+        {snapCount > 0 && (
+          <section className="pov-section">
+            <div className="pov-head">
+              <h3>Community</h3>
+              <button type="button" className="pov-more" onClick={() => onOpenTab('community')}>View more</button>
+            </div>
+            <CommunitySnaps user={username} limit={perRow} hideEmpty onOpenTab={openCommunityTab} />
+          </section>
+        )}
+
+        {/* What's actually IN the playlists: one rail per playlist, above the
+            row of covers. Loads only when scrolled to (ProfilePlaylistRails). */}
+        <ProfilePlaylistRails
+          playlists={playlists}
           getContentForVideo={getContentForVideo}
           isWatched={isWatched}
           getViewCount={getViewCount}
         />
-      </Section>
 
-      <Section title="Shorts" count={shortSlice.length} onViewMore={() => onOpenTab('shorts')}>
-        <Card3
-          videos={shortSlice}
-          shortsGrid
-          linkPrefix="/shorts"
-          getViewCount={getViewCount}
-        />
-      </Section>
+        <Section title="Playlists" count={playlistSlice.length} onViewMore={() => onOpenTab('playlists')}>
+          <PlaylistCard playlists={playlistSlice} />
+        </Section>
+      </div>
 
-      {/* Audio, community posts and playlists own their own data, so they're
-          rendered limited rather than sliced here, and hide when empty. */}
-      <section className="pov-section pov-section--audio">
-        <div className="pov-head">
-          <h3>Audio</h3>
-          <button type="button" className="pov-more" onClick={() => onOpenTab('audio')}>View more</button>
-        </div>
-        <UserAudioList user={username} limit={perRow} />
-      </section>
-
-      {snapCount > 0 && (
-        <section className="pov-section">
-          <div className="pov-head">
-            <h3>Community</h3>
-            <button type="button" className="pov-more" onClick={() => onOpenTab('community')}>View more</button>
-          </div>
-          <CommunitySnaps user={username} limit={perRow} hideEmpty onOpenTab={openCommunityTab} />
-        </section>
-      )}
-
-      <Section title="Playlists" count={playlistSlice.length} onViewMore={() => onOpenTab('playlists')}>
-        <PlaylistCard playlists={playlistSlice} />
-      </Section>
+      {isDesktop ? (
+        <ProfileLinksPanel username={username} isOwnProfile={isOwnProfile} onOpenTab={onOpenTab} />
+      ) : null}
     </div>
   );
 }

--- a/src/components/Userprofilepage/ProfileOverview.scss
+++ b/src/components/Userprofilepage/ProfileOverview.scss
@@ -1,6 +1,24 @@
 @use "../../mixins.scss" as mix;
 
 .profile-overview {
+  // ── desktop: content column + sticky links column ─────────────────────────
+  // Below 1025px this stays exactly what it was: one column, no aside (the
+  // panel is not even mounted — see ProfileOverview's isDesktop check).
+  @media screen and (min-width: 1025px) {
+    display: flex;
+    align-items: flex-start;   // required, or the aside stretches and `sticky` has no room to travel
+    gap: 1.5rem;
+  }
+
+  // `flex: 1 1 0` — basis 0, NOT auto. With `auto` the base size is the rails'
+  // max-content width (huge), so the shrink was shared with the links column and
+  // crushed it to a few characters wide. min-width:0 lets the rails shrink at all
+  // (a flex item's default min-width is its content).
+  .pov-main {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
   .pov-section {
     margin-bottom: 2rem;
 
@@ -29,6 +47,13 @@
     }
   }
 
+  // `.pov-more` is a <button> in every section but the playlist rails, whose
+  // "View all" is a real link to the playlist page.
+  a.pov-more {
+    display: inline-block;
+    text-decoration: none;
+  }
+
   .pov-more {
     flex-shrink: 0;
     padding: 0.3rem 0.8rem;
@@ -50,7 +75,7 @@
 
   // An empty audio list renders its own "nothing here" block; in a preview row
   // that reads as a broken section, so the whole section hides instead.
-  .pov-section--audio:has(.empty-wrap) {
+  .pov-section--audio:has(.profile-empty) {
     display: none;
   }
 

--- a/src/components/Userprofilepage/ProfilePlaylistRails.jsx
+++ b/src/components/Userprofilepage/ProfilePlaylistRails.jsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+import { getHiveUrl } from '../../utils/hiveNode';
+import Card3 from '../Cards/Card3';
+
+/**
+ * The playlists' actual contents at the foot of the Overview tab: one rail of
+ * video tiles per playlist, under the row of playlist covers.
+ *
+ * What's left out, and why:
+ *  - private playlists and Watch Later — a profile shows what a creator chose
+ *    to publish, and Watch Later is a personal queue. (Someone else's profile
+ *    never carries them anyway; your OWN page fetches all of yours, so the
+ *    filter has to live here.)
+ *  - audio items, and any playlist left with nothing but audio: these are video
+ *    tiles, and an album of tracks belongs in the Audio tab.
+ *
+ * Cost control: item data comes from one Hive `get_content` per item, so a rail
+ * only fetches once it scrolls near the viewport, at most ITEM_CAP items, for
+ * at most MAX_PLAYLISTS playlists. The rails sit at the very bottom of a long
+ * tab, so for most visits that is no requests at all.
+ */
+
+const MAX_PLAYLISTS = 5;
+const ITEM_CAP = 10;
+const WATCH_LATER_NAME = 'Watch Later';
+
+// The marker the checker's audioHiveSync uses too: an audio post links to its
+// own player. Detected from the body we already fetched — no second call.
+const AUDIO_MARKER = /audio\.3speak\.tv\/play\?a=/;
+
+const num = (v) => Number.parseFloat(v) || 0;
+
+async function fetchPlaylistVideos(items) {
+  const ordered = [...items].sort((a, b) => (a.position ?? 0) - (b.position ?? 0)).slice(0, ITEM_CAP);
+  const resolved = await Promise.all(ordered.map(async (item) => {
+    try {
+      const { data } = await axios.post(getHiveUrl(), {
+        jsonrpc: '2.0',
+        method: 'condenser_api.get_content',
+        params: [item.author, item.permlink],
+        id: 1,
+      });
+      const post = data?.result;
+      if (!post?.author) return null;                                   // deleted / never existed
+      if (typeof post.body === 'string' && AUDIO_MARKER.test(post.body)) return null;
+
+      let meta = {};
+      try {
+        meta = typeof post.json_metadata === 'string' ? JSON.parse(post.json_metadata) : post.json_metadata || {};
+      } catch { /* malformed metadata — the tile still renders */ }
+
+      // Card3 reads payout / votes / comments from `stats` when the profile's
+      // own content batch has nothing for this post, which is every item by
+      // another creator.
+      return {
+        author: post.author,
+        permlink: post.permlink,
+        title: post.title,
+        created_at: post.created,
+        images: { thumbnail: meta.image?.[0] || null },
+        duration: meta.video?.info?.duration || 0,
+        stats: {
+          total_hive_reward: num(post.pending_payout_value) + num(post.total_payout_value) + num(post.curator_payout_value),
+          num_votes: post.net_votes ?? post.active_votes?.length ?? null,
+          num_comments: post.children ?? null,
+        },
+      };
+    } catch {
+      return null;
+    }
+  }));
+  return resolved.filter(Boolean);
+}
+
+function PlaylistRail({ playlist, getContentForVideo, isWatched, getViewCount }) {
+  const ref = useRef(null);
+  const [near, setNear] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return undefined;
+    if (typeof IntersectionObserver === 'undefined') { setNear(true); return undefined; }
+    const io = new IntersectionObserver((entries) => {
+      if (entries.some((e) => e.isIntersecting)) { setNear(true); io.disconnect(); }
+    }, { rootMargin: '400px' });
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  const { data: videos = [] } = useQuery({
+    queryKey: ['profile-playlist-rail', playlist.id],
+    queryFn: () => fetchPlaylistVideos(playlist.items),
+    enabled: near && !!playlist.items?.length,
+    staleTime: 10 * 60 * 1000,
+    retry: false,
+  });
+
+  // The wrapper always renders (it's what the observer watches) but stays empty
+  // until there is something to show — so an all-audio playlist never flashes a
+  // heading that then disappears.
+  return (
+    <div ref={ref} className="pov-playlist-rail">
+      {videos.length > 0 && (
+        <section className="pov-section">
+          <div className="pov-head">
+            <h3>{playlist.name}</h3>
+            <Link className="pov-more" to={`/playlist/${playlist.id}`}>View all</Link>
+          </div>
+          <Card3
+            videos={videos}
+            getContentForVideo={getContentForVideo}
+            isWatched={isWatched}
+            getViewCount={getViewCount}
+          />
+        </section>
+      )}
+    </div>
+  );
+}
+
+export default function ProfilePlaylistRails({ playlists = [], getContentForVideo, isWatched, getViewCount }) {
+  const shown = playlists
+    .filter((p) => p?.access === 'public' && p.name !== WATCH_LATER_NAME && p.items?.length)
+    .slice(0, MAX_PLAYLISTS);
+
+  if (!shown.length) return null;
+
+  return shown.map((playlist) => (
+    <PlaylistRail
+      key={playlist.id}
+      playlist={playlist}
+      getContentForVideo={getContentForVideo}
+      isWatched={isWatched}
+      getViewCount={getViewCount}
+    />
+  ));
+}

--- a/src/components/Userprofilepage/UserAudioList.jsx
+++ b/src/components/Userprofilepage/UserAudioList.jsx
@@ -3,11 +3,11 @@ import axios from 'axios';
 import { CHECKER_URL } from '../../utils/config';
 import AudioTile from '../AudioTile/AudioTile';
 import BarLoader from '../Loader/BarLoader';
-import icon from '../../../public/images/stack.png';
+import ProfileEmptyState from './ProfileEmptyState';
 import './UserAudioList.scss';
 
 // `limit` renders only the newest N (the Overview tab shows a preview row).
-function UserAudioList({ user, limit = 0 }) {
+function UserAudioList({ user, limit = 0, isOwnProfile = false }) {
   const { data: audio = [], isLoading } = useQuery({
     queryKey: ['user-audio', user],
     queryFn: async () => {
@@ -19,12 +19,7 @@ function UserAudioList({ user, limit = 0 }) {
 
   if (isLoading) return <BarLoader />;
   if (audio.length === 0) {
-    return (
-      <div className="empty-wrap">
-        <img src={icon} alt="" />
-        <span>No Audio Tracks Available</span>
-      </div>
-    );
+    return <ProfileEmptyState kind="audio" isOwnProfile={isOwnProfile} username={user} />;
   }
 
   const shown = limit > 0 ? audio.slice(0, limit) : audio;

--- a/src/components/Userprofilepage/UserProfilePage.jsx
+++ b/src/components/Userprofilepage/UserProfilePage.jsx
@@ -6,7 +6,6 @@ import { getFollowers, getRelationshipBetweenAccounts, isAccountValid } from '..
 import { isCreatorHidden as isModeratedCreatorHidden } from '../../utils/hiddenCreators';
 import { followWithAioha, isLoggedIn } from '../../hive-api/aioha';
 import { useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import icon from "../../../public/images/stack.png"
 import "./UserProfilePage.scss"
 import BarLoader from '../Loader/BarLoader';
 import { Quantum } from 'ldrs/react'
@@ -46,6 +45,8 @@ import HiveBadges from '../HiveBadges/HiveBadges';
 import ProfileHeader from '../ProfileHeader/ProfileHeader';
 import ProfileStats from '../ProfileHeader/ProfileStats';
 import ProfileOverview from './ProfileOverview';
+import ProfileLinksButton from './ProfileLinksButton';
+import ProfileEmptyState from './ProfileEmptyState';
 
 
 
@@ -543,6 +544,10 @@ const {
             >
               <MdChatBubbleOutline /> Message
             </button>
+            {/* Narrow screens only: below 1025px the framed links page beside
+                Overview isn't rendered, so this is the way through to it. It
+                sits directly under Message (see ProfileLinksButton.scss). */}
+            <ProfileLinksButton username={user} />
           </>
         ) : null}
         badges={
@@ -665,10 +670,7 @@ const {
     isLoading ? (
       <BarLoader />
     ) : videos?.length === 0 ? (
-      <div className='empty-wrap'>
-        <img src={icon} alt="" />
-        <span>No Video Data Available</span>
-      </div>
+      <ProfileEmptyState kind="video" isOwnProfile={isOwnProfile} username={user} />
     ) : (
       <Card3 videos={videos} loading={isFetchingNextPage} getContentForVideo={getContentForVideo} isWatched={isWatched} getViewCount={getViewCount} />
     )
@@ -676,15 +678,12 @@ const {
     isShortsLoading ? (
       <BarLoader />
     ) : shortsVideos.length === 0 ? (
-      <div className='empty-wrap'>
-        <img src={icon} alt="" />
-        <span>No Shorts Available</span>
-      </div>
+      <ProfileEmptyState kind="shorts" isOwnProfile={isOwnProfile} username={user} />
     ) : (
       <Card3 videos={shortsVideos} loading={isFetchingNextShortsPage} linkPrefix="/shorts" linkQuery={`&user=${user}`} getViewCount={getViewCount} shortsGrid />
     )
   ) : show === "audio" ? (
-    <UserAudioList user={user} />
+    <UserAudioList user={user} isOwnProfile={isOwnProfile} />
   ) : show === "supporters" ? (
     <Card3 videos={gatedVideos} getViewCount={getViewCount} />
   ) : show === "streams" ? (
@@ -705,15 +704,12 @@ const {
       {playlistsLoading ? (
         <BarLoader />
       ) : playlists.length === 0 ? (
-        <div className='empty-wrap'>
-          <img src={icon} alt="" />
-          <span>No Public Playlists Available</span>
-          {isOwnProfile && (
-            <button className="create-playlist-btn-empty" onClick={() => setShowCreateModal(true)}>
-              <IoMdAdd /> Create Your First Playlist
-            </button>
-          )}
-        </div>
+        <ProfileEmptyState
+          kind="playlists"
+          isOwnProfile={isOwnProfile}
+          username={user}
+          onAction={() => setShowCreateModal(true)}
+        />
       ) : (
         <PlaylistCard playlists={playlists} loading={playlistsLoading} error={playlistsError?.message} />
       )}

--- a/src/components/Userprofilepage/UserProfilePage.jsx
+++ b/src/components/Userprofilepage/UserProfilePage.jsx
@@ -15,6 +15,7 @@ import axios from 'axios';
 import { MY_VIDEOS_URL, CHECKER_URL } from '../../utils/config';
 import Card3 from '../Cards/Card3';
 import { IoMdShare, IoMdAdd } from 'react-icons/io';
+import { MdRssFeed } from 'react-icons/md';
 import { MdAdd, MdClose, MdPlayArrow, MdFlag, MdChatBubbleOutline } from 'react-icons/md';
 import ReportModal, { isReported } from '../modal/ReportModal';
 import { RiUserFollowLine, RiUserUnfollowLine } from 'react-icons/ri';
@@ -580,6 +581,25 @@ const {
                     : <><IoBanOutline /> Hide</>}
               </button>
             )}
+            {/* Podcast / RSS feed for the channel. React 19 hoists the <link>
+                into <head>, which is what makes browsers and feed readers
+                auto-discover it; the button is for people who already know
+                what to do with a feed URL. */}
+            <link
+              rel="alternate"
+              type="application/rss+xml"
+              title={`${user} on 3Speak`}
+              href={`${window.location.origin}/rss/${user}.xml`}
+            />
+            <a
+              className="btn btn-secondary"
+              href={`/rss/${user}.xml`}
+              target="_blank"
+              rel="noreferrer"
+              title={`Podcast feed for @${user} — subscribe in any podcast app or RSS reader`}
+            >
+              <MdRssFeed />
+            </a>
             <button
               className="btn btn-secondary"
               onClick={async () => {

--- a/src/components/nav/NotificationBell.jsx
+++ b/src/components/nav/NotificationBell.jsx
@@ -1,7 +1,12 @@
 import { useEffect, useRef, useState, useMemo } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { IoIosNotifications } from 'react-icons/io';
+import { MdNotificationsActive, MdNotificationsOff } from 'react-icons/md';
+import { toast } from 'sonner';
 import { useAppStore } from '../../lib/store';
+import {
+  pushSupported, getPushState, enablePush, disablePush, syncPushSubscription,
+} from '../../utils/webPush';
 import { useHiveNotifications } from '../../hooks/useHiveNotifications';
 import {
   getNotificationRoute,
@@ -27,6 +32,51 @@ const MAX_STACKED_AVATARS = 4;
 function NotificationBell() {
   const { user, authenticated } = useAppStore();
   const [open, setOpen] = useState(false);
+
+  // Browser push, opted into from here — this dropdown IS the notifications UI,
+  // so it's where someone looks for "also tell me when I'm not on the site".
+  const [push, setPush] = useState({ supported: false, permission: 'default', subscribed: false });
+  const [pushBusy, setPushBusy] = useState(false);
+  // On mount, not just when the dropdown opens. getPushState() registers the
+  // service worker if the page hasn't got a live one, and the bell is on every
+  // page — so a tab left over from a build whose worker failed to evaluate
+  // heals itself on the next page load instead of staying permanently unable to
+  // subscribe. Registering a worker needs no permission and prompts nothing.
+  useEffect(() => {
+    if (!pushSupported()) return;
+    getPushState().then((st) => {
+      setPush(st);
+      // Server rows get pruned when a push service reports an endpoint gone, so
+      // a browser can hold a live subscription the server has forgotten. Re-assert
+      // it here rather than leaving the toggle stuck on "On" with nothing arriving.
+      if (st.subscribed && user) syncPushSubscription(user);
+    }).catch(() => {});
+  }, [user]);
+
+  // ...and again whenever the dropdown opens, so the switch reflects a change
+  // made in Settings (or another tab) without a reload.
+  useEffect(() => {
+    if (!open || !pushSupported()) return;
+    getPushState().then(setPush).catch(() => {});
+  }, [open]);
+
+  const togglePush = async () => {
+    setPushBusy(true);
+    try {
+      if (push.subscribed) {
+        await disablePush(user);
+        toast.success('Notifications turned off for this device');
+      } else {
+        await enablePush(user);
+        toast.success('You will be notified when creators you follow post');
+      }
+      setPush(await getPushState());
+    } catch (err) {
+      toast.error(err.message || 'Could not change notification settings');
+    } finally {
+      setPushBusy(false);
+    }
+  };
   const [hoveredId, setHoveredId] = useState(null);
   const ref = useRef(null);
   const navigate = useNavigate();
@@ -145,13 +195,33 @@ function NotificationBell() {
         <div className="notif-dropdown" role="menu">
           <div className="notif-dropdown-header">
             <span className="notif-dropdown-title">Notifications</span>
-            <Link
-              to="/notifications"
-              className="notif-dropdown-seeall"
-              onClick={() => setOpen(false)}
-            >
-              See all
-            </Link>
+            <div className="notif-dropdown-actions">
+              {pushSupported() && authenticated && (
+                <button
+                  type="button"
+                  className={`notif-push-toggle${push.subscribed ? ' on' : ''}`}
+                  onClick={togglePush}
+                  disabled={pushBusy || push.permission === 'denied' || push.worker === false}
+                  title={push.permission === 'denied'
+                    ? 'Notifications are blocked for this site in your browser settings'
+                    : push.worker === false
+                      ? 'This build has no service worker, so notifications cannot be registered here'
+                      : push.subscribed
+                        ? 'Stop notifying this device'
+                        : 'Get notified when creators you follow post'}
+                >
+                  {push.subscribed ? <MdNotificationsActive size={15} /> : <MdNotificationsOff size={15} />}
+                  <span>{push.subscribed ? 'On' : 'Notify me'}</span>
+                </button>
+              )}
+              <Link
+                to="/notifications"
+                className="notif-dropdown-seeall"
+                onClick={() => setOpen(false)}
+              >
+                See all
+              </Link>
+            </div>
           </div>
 
           {loading && notifications.length === 0 && (

--- a/src/components/nav/NotificationBell.scss
+++ b/src/components/nav/NotificationBell.scss
@@ -126,6 +126,45 @@
   &:hover { text-decoration: underline; }
 }
 
+// Header right side: the push opt-in sits next to "See all", because this
+// dropdown is where someone looks for "also tell me when I'm not on the site".
+.notif-dropdown-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.notif-push-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 9px;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover:not(:disabled) {
+    color: var(--text-primary);
+    border-color: var(--text-secondary);
+    background: var(--bg-hover);
+  }
+
+  // Subscribed: red OUTLINE, never a fill (app-wide convention).
+  &.on {
+    border-color: var(--accent-primary);
+    color: var(--accent-primary);
+  }
+
+  // Blocked at the browser level — the button can't fix that, so it says so
+  // via its title instead of pretending it can.
+  &:disabled { opacity: 0.55; cursor: not-allowed; }
+}
+
 .notif-dropdown-empty {
   padding: 24px 14px;
   text-align: center;

--- a/src/components/nav/ProfileNav.jsx
+++ b/src/components/nav/ProfileNav.jsx
@@ -3,7 +3,7 @@ import "./ProfileNav.scss"
 import '../../page/Login/KeyChainLogin.scss';
 import { useAppStore } from '../../lib/store';
 import { useGetMyQuery } from '../../hooks/getUserDetails';
-import { MdKeyboardArrowDown, MdOutlineKeyboardArrowUp, MdSettings, MdTrendingUp } from "react-icons/md";
+import { MdKeyboardArrowDown, MdOutlineKeyboardArrowUp, MdSettings, MdTrendingUp, MdCampaign } from "react-icons/md";
 import { ImPower } from "react-icons/im";
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { FaDiscord, FaLanguage } from 'react-icons/fa';
@@ -18,6 +18,7 @@ import logoDark from '../../assets/image/3S_logodark.png';
 import { SiTelegram } from "react-icons/si";
 import { getVotePower } from '../../utils/hiveUtils';
 import { getHiveUrl, ensureHealthyNode } from '../../utils/hiveNode';
+import { adsEnabledFor } from '../../utils/config';
 import LabeledToggle from '../LabeledToggle/LabeledToggle';
 import SettingsModal from '../SettingsModal/SettingsModal';
 import { useAvatarUrl } from '../../utils/avatarCache';
@@ -114,6 +115,13 @@ function ProfileNav({ isVisible, onclose, toggleAddAccount, openLoginModal }) {
           {/* <Link className="wrap">
             <FaLanguage className="icon" /> <span>Language Settings</span>
           </Link> */}
+          {/* Closed testing. Same gate as the /advertise page itself, so the menu can
+              never offer a link to a page that would answer with a 404. */}
+          {adsEnabledFor(user) && (
+            <Link to="/advertise" className="wrap" onClick={onclose}>
+              <MdCampaign className="icon" /> <span>Advertise</span>
+            </Link>
+          )}
           <a className="wrap" onClick={() => { setSettingsOpen(true); onclose(); }}>
             <MdSettings className="icon" /> <span>Settings</span>
           </a>

--- a/src/components/playVideo/PlayVideo.jsx
+++ b/src/components/playVideo/PlayVideo.jsx
@@ -72,7 +72,7 @@ import SummaryModal from '../SummaryModal/SummaryModal';
 
 dayjs.extend(relativeTime);
 
-const PlayVideo = ({ videoDetails, author, permlink, mediaUnavailable = false, mediaBlocked = false, onRetryPlayback = null, mediaLoading = false, playlistData, onClosePlaylist, videoControls, mobileReactionPanel, cinemaReactionPanel, videoRef, wrapperRef, onVideoEdited, overrideBody, scheduled = false, scheduledOn = null, onEditScheduled, v2 = false, isLive = false, streamRoom = null, liveChatSlot = null, onLiveChatSent = null, vodAssetPending = false, onStreamRoomMeta = null, belowPlayerSlot = null }) => {
+const PlayVideo = ({ videoDetails, author, permlink, mediaUnavailable = false, mediaBlocked = false, onRetryPlayback = null, mediaLoading = false, playlistData, onClosePlaylist, videoControls, mobileReactionPanel, cinemaReactionPanel, videoRef, wrapperRef, onVideoEdited, overrideBody, scheduled = false, scheduledOn = null, onEditScheduled, v2 = false, isLive = false, streamRoom = null, liveChatSlot = null, onLiveChatSent = null, vodAssetPending = false, onStreamRoomMeta = null, belowPlayerSlot = null, sponsorLabel = null }) => {
   const { user, authenticated } = useAppStore();
   const interests = useAppStore((s) => s.interests);
   const setInterests = useAppStore((s) => s.setInterests);
@@ -806,6 +806,12 @@ const PlayVideo = ({ videoDetails, author, permlink, mediaUnavailable = false, m
                   vodAssetPending={vodAssetPending}
                   onRoomMeta={onStreamRoomMeta}
                 />
+              )}
+              {sponsorLabel && (
+                // Disclosure while a sponsor spot is playing. Rendered inside the
+                // player frame rather than as a page-level element: a filter list
+                // cannot hide it without hiding the video with it.
+                <div className="watch-sponsor-note">{sponsorLabel}</div>
               )}
               <video
                 ref={videoRef}

--- a/src/components/playVideo/PlayVideo.scss
+++ b/src/components/playVideo/PlayVideo.scss
@@ -1673,3 +1673,28 @@
   from { opacity: 0; }
   to   { opacity: 1; }
 }
+
+/* Sponsored disclosure, shown only while a stitched ad is playing. Inside the
+   player frame on purpose: a filter list cannot hide it without hiding the video. */
+.watch-sponsor-note {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 4;
+  padding: 4px 10px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.66);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  line-height: 1.4;
+  pointer-events: none;
+
+  @media (max-width: 600px) {
+    top: 8px;
+    left: 8px;
+    font-size: 11px;
+    padding: 3px 8px;
+  }
+}

--- a/src/components/playVideo/Transcript.jsx
+++ b/src/components/playVideo/Transcript.jsx
@@ -1,0 +1,179 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { MdContentCopy, MdKeyboardArrowDown, MdKeyboardArrowUp } from 'react-icons/md';
+import {
+  listSubtitleLanguages,
+  loadSubtitleCues,
+  SUBTITLE_LANG_KEY,
+} from '../../hooks/useSubtitles';
+import './Transcript.scss';
+
+/**
+ * The video's spoken words, under the description.
+ *
+ * Two audiences. A viewer gets a way to read a talk they can't listen to, to
+ * find the one bit they came for, and to jump straight to it. A search engine
+ * gets the only real text a video page has: titles and descriptions are a
+ * sentence each, while a transcript is the whole thing, which is what makes a
+ * watch page findable by a phrase someone actually said.
+ *
+ * The crawler half is served by the prerender sidecar, not by this component:
+ * Googlebot and bingbot are routed to og-server.cjs for /watch and never
+ * execute the SPA, so the text they index is the server-rendered copy. This one
+ * is purely for the person watching.
+ *
+ * `embedded` drops the panel's own heading and show/hide button, for when it
+ * sits inside the watch tabs and the tab bar is already the chrome.
+ *
+ * The cues come from the same fetch + cache the on-video captions use, but the
+ * language here is chosen independently: reading along is not the same choice
+ * as turning captions on, and neither should switch the other.
+ */
+
+const AUTOSCROLL_PAUSE_MS = 6000;
+
+const stamp = (seconds) => {
+  const s = Math.max(0, Math.floor(Number(seconds) || 0));
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  const pad = (n) => String(n).padStart(2, '0');
+  return h > 0 ? `${h}:${pad(m)}:${pad(sec)}` : `${m}:${pad(sec)}`;
+};
+
+export default function Transcript({ author, permlink, currentTime = 0, onSeek, embedded = false }) {
+  const [languages, setLanguages] = useState([]);
+  const [lang, setLang] = useState(null);
+  const [cues, setCues] = useState([]);
+  const [expanded, setExpanded] = useState(embedded);
+  const [copied, setCopied] = useState(false);
+
+  const listRef = useRef(null);
+  const lastUserScrollRef = useRef(0);
+
+  // Which languages exist for this video.
+  useEffect(() => {
+    let alive = true;
+    setLanguages([]); setLang(null); setCues([]);
+    listSubtitleLanguages(author, permlink).then((list) => {
+      if (!alive || !list.length) return;
+      setLanguages(list);
+      // Prefer the viewer's caption language, then English, then whatever exists.
+      let stored = null;
+      try { stored = localStorage.getItem(SUBTITLE_LANG_KEY); } catch { /* private mode */ }
+      const pick = list.find((l) => l.lang === stored)
+        || list.find((l) => l.lang === 'en')
+        || list[0];
+      setLang(pick.lang);
+    });
+    return () => { alive = false; };
+  }, [author, permlink]);
+
+  // The lines themselves. A subtitle file lives on IPFS and any single one can
+  // be temporarily unfetchable (the hot CDN 500s for content it hasn't pinned
+  // yet, and the fallback gateway is not always healthy either). A video with
+  // eight translations shouldn't show no transcript because the preferred one
+  // is the unlucky file, so the rest are tried in turn.
+  useEffect(() => {
+    if (!lang || !languages.length) return undefined;
+    let alive = true;
+    (async () => {
+      const preferred = languages.find((l) => l.lang === lang);
+      const ordered = [preferred, ...languages.filter((l) => l.lang !== lang)].filter(Boolean);
+      for (const entry of ordered) {
+        try {
+          const parsed = await loadSubtitleCues(author, permlink, entry);
+          if (!alive) return;
+          if (parsed.length) {
+            setCues(parsed);
+            // Say which language is actually on screen.
+            if (entry.lang !== lang) setLang(entry.lang);
+            return;
+          }
+        } catch { /* unfetchable right now — try the next language */ }
+      }
+      if (alive) setCues([]);
+    })();
+    return () => { alive = false; };
+  }, [lang, languages, author, permlink]);
+
+  const activeIndex = useMemo(() => {
+    if (!cues.length) return -1;
+    // Cues are in order, so the last one that has started is the current one.
+    let lo = 0; let hi = cues.length - 1; let found = -1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (cues[mid].start <= currentTime) { found = mid; lo = mid + 1; } else { hi = mid - 1; }
+    }
+    if (found < 0) return -1;
+    return currentTime <= cues[found].end + 0.5 ? found : -1;
+  }, [cues, currentTime]);
+
+  // Follow along, unless the reader is scrolling the panel themselves.
+  useEffect(() => {
+    if (!expanded || activeIndex < 0) return;
+    if (Date.now() - lastUserScrollRef.current < AUTOSCROLL_PAUSE_MS) return;
+    const el = listRef.current?.querySelector(`[data-cue="${activeIndex}"]`);
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [activeIndex, expanded]);
+
+  const copy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(cues.map((c) => c.text).join('\n'));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    } catch { /* clipboard blocked — nothing useful to say */ }
+  }, [cues]);
+
+  if (!cues.length) return null;
+
+  return (
+    <section className={`transcript${expanded ? ' expanded' : ''}${embedded ? ' embedded' : ''}`}>
+      <div className="transcript-head">
+        {embedded ? null : <h3>Transcript</h3>}
+        <div className="transcript-actions">
+          {languages.length > 1 && (
+            <select
+              className="transcript-lang"
+              value={lang || ''}
+              onChange={(e) => setLang(e.target.value)}
+              aria-label="Transcript language"
+            >
+              {languages.map((l) => <option key={l.lang} value={l.lang}>{l.label || l.lang}</option>)}
+            </select>
+          )}
+          <button type="button" className="transcript-copy" onClick={copy} title="Copy transcript">
+            <MdContentCopy size={15} /> {copied ? 'Copied' : 'Copy'}
+          </button>
+        </div>
+      </div>
+
+      <div
+        className="transcript-body"
+        ref={listRef}
+        onScroll={() => { lastUserScrollRef.current = Date.now(); }}
+      >
+        {cues.map((cue, i) => (
+          <button
+            key={`${cue.start}-${i}`}
+            type="button"
+            data-cue={i}
+            className={`transcript-line${i === activeIndex ? ' active' : ''}`}
+            onClick={() => onSeek?.(cue.start)}
+            title={`Jump to ${stamp(cue.start)}`}
+          >
+            <span className="transcript-time">{stamp(cue.start)}</span>
+            <span className="transcript-text">{cue.text}</span>
+          </button>
+        ))}
+      </div>
+
+      {embedded ? null : (
+        <button type="button" className="transcript-toggle" onClick={() => setExpanded((v) => !v)}>
+          {expanded
+            ? <><MdKeyboardArrowUp size={18} /> Hide transcript</>
+            : <><MdKeyboardArrowDown size={18} /> Show transcript{cues.length ? ` (${cues.length} lines)` : ''}</>}
+        </button>
+      )}
+    </section>
+  );
+}

--- a/src/components/playVideo/Transcript.scss
+++ b/src/components/playVideo/Transcript.scss
@@ -1,0 +1,141 @@
+@use "../../mixins.scss" as mix;
+
+// Closed by default and fully collapsed, but never unmounted: the text has to
+// stay in the DOM for crawlers (see Transcript.jsx). A closed accordion is
+// indexed normally; text painted in the background colour is not, it is treated
+// as hidden text and works against the page.
+.transcript {
+  margin: 1.5rem 0 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  background: var(--bg-secondary);
+  overflow: hidden;
+
+  // Nothing but the header shows until it's opened.
+  &:not(.expanded) {
+    .transcript-head { border-bottom: 0; }
+    .transcript-body { padding-top: 0; padding-bottom: 0; }
+  }
+
+  .transcript-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.7rem 0.9rem;
+    border-bottom: 1px solid var(--border-color);
+
+    h3 {
+      margin: 0;
+      font-size: 0.95rem;
+      font-weight: 700;
+      color: var(--text-primary);
+    }
+  }
+
+  .transcript-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .transcript-lang,
+  .transcript-copy {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 0.28rem 0.7rem;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 0.78rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover {
+      color: var(--text-primary);
+      border-color: var(--text-secondary);
+      background: var(--bg-hover);
+    }
+  }
+
+  .transcript-body {
+    // Closed: present, measurable, invisible. Open: a scrollable column.
+    max-height: 0;
+    overflow-y: auto;
+    padding: 0.4rem 0.35rem;
+    transition: max-height 0.25s ease;
+    scrollbar-width: thin;
+
+    &::-webkit-scrollbar { width: 6px; }
+    &::-webkit-scrollbar-thumb {
+      background: var(--border-color);
+      border-radius: 999px;
+    }
+  }
+
+  &.expanded .transcript-body {
+    max-height: min(70vh, 44rem);
+  }
+
+  // Each line is a seek control, so it reads as text but behaves as a button.
+  .transcript-line {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    width: 100%;
+    padding: 0.22rem 0.55rem;
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 0.86rem;
+    line-height: 1.45;
+    text-align: left;
+    cursor: pointer;
+
+    &:hover { background: var(--bg-hover); color: var(--text-primary); }
+
+    &.active {
+      background: var(--accent-light);
+      color: var(--text-primary);
+      .transcript-time { color: var(--accent-primary); }
+    }
+  }
+
+  .transcript-time {
+    flex: 0 0 auto;
+    min-width: 3.1rem;
+    font-variant-numeric: tabular-nums;
+    font-size: 0.76rem;
+    font-weight: 600;
+    color: var(--text-muted);
+  }
+
+  .transcript-text { flex: 1 1 auto; }
+
+  .transcript-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    width: 100%;
+    padding: 0.5rem;
+    border: 0;
+    border-top: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 0.82rem;
+    font-weight: 600;
+    cursor: pointer;
+
+    &:hover { color: var(--text-primary); background: var(--bg-hover); }
+  }
+
+  @include mix.respond(phone) {
+    .transcript-line { font-size: 0.82rem; }
+    .transcript-time { min-width: 2.8rem; }
+  }
+}

--- a/src/components/playVideo/WatchTabs.jsx
+++ b/src/components/playVideo/WatchTabs.jsx
@@ -1,0 +1,93 @@
+import { useEffect, useMemo, useState } from 'react';
+import Transcript from './Transcript';
+import { listSubtitleLanguages } from '../../hooks/useSubtitles';
+import './WatchTabs.scss';
+
+/**
+ * The top of the watch page's right column: reactions and the transcript,
+ * one at a time, above the recommendations.
+ *
+ * The transcript used to sit under the comments, where nobody scrolled to it.
+ * It belongs beside the video, next to the other "more about this video" panel,
+ * and sharing the column with reactions costs neither of them any room.
+ *
+ * DESKTOP ONLY for the transcript. On a phone the right column stacks under
+ * everything else and a wall of subtitle lines between the video and the
+ * recommendations is in the way rather than useful — so on mobile this renders
+ * the reaction panel exactly as it did before, with no tab bar at all. Same
+ * when a video has no subtitles: one thing to show means no tabs to pick from.
+ */
+export default function WatchTabs({ reactionPanel, author, permlink, currentTime = 0, onSeek }) {
+  const [isDesktop, setIsDesktop] = useState(
+    () => typeof window !== 'undefined' && window.matchMedia('(min-width: 768px)').matches,
+  );
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 768px)');
+    const on = () => setIsDesktop(mq.matches);
+    mq.addEventListener('change', on);
+    return () => mq.removeEventListener('change', on);
+  }, []);
+
+  // One cheap list call decides whether there's a transcript to offer; the
+  // panel itself only mounts once its tab is chosen.
+  const [hasSubtitles, setHasSubtitles] = useState(false);
+  useEffect(() => {
+    if (!isDesktop) { setHasSubtitles(false); return undefined; }
+    let alive = true;
+    setHasSubtitles(false);
+    listSubtitleLanguages(author, permlink)
+      .then((list) => { if (alive) setHasSubtitles(list.length > 0); })
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [author, permlink, isDesktop]);
+
+  const tabs = useMemo(() => {
+    const out = [];
+    if (reactionPanel) out.push('reactions');
+    if (isDesktop && hasSubtitles) out.push('transcript');
+    return out;
+  }, [reactionPanel, isDesktop, hasSubtitles]);
+
+  const [active, setActive] = useState(null);
+  // Keep the selection valid as tabs appear and disappear (resizing across the
+  // breakpoint, subtitles arriving late, reactions being closed).
+  useEffect(() => {
+    setActive((cur) => (cur && tabs.includes(cur) ? cur : tabs[0] || null));
+  }, [tabs]);
+
+  if (!tabs.length) return null;
+  // Nothing to choose between: render exactly what was there before.
+  if (tabs.length === 1 && tabs[0] === 'reactions') return reactionPanel;
+
+  return (
+    <div className="watch-tabs">
+      <div className="watch-tabs-bar" role="tablist">
+        {tabs.map((t) => (
+          <button
+            key={t}
+            type="button"
+            role="tab"
+            aria-selected={active === t}
+            className={`watch-tab${active === t ? ' active' : ''}`}
+            onClick={() => setActive(t)}
+          >
+            {t === 'reactions' ? 'Reactions' : 'Transcript'}
+          </button>
+        ))}
+      </div>
+
+      <div className="watch-tabs-panel" role="tabpanel">
+        {active === 'reactions' && reactionPanel}
+        {active === 'transcript' && (
+          <Transcript
+            author={author}
+            permlink={permlink}
+            currentTime={currentTime}
+            onSeek={onSeek}
+            embedded
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/playVideo/WatchTabs.scss
+++ b/src/components/playVideo/WatchTabs.scss
@@ -1,0 +1,65 @@
+@use "../../mixins.scss" as mix;
+
+// Reactions and the transcript share the top of the watch page's right column.
+.watch-tabs {
+  width: 100%;
+  min-width: 0;
+  margin-bottom: 14px;
+
+  .watch-tabs-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    border-bottom: 1px solid var(--border-color);
+  }
+
+  .watch-tab {
+    padding: 0.5rem 0.9rem;
+    border: 0;
+    border-bottom: 2px solid transparent;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: color 0.15s ease, border-color 0.15s ease;
+
+    &:hover { color: var(--text-primary); }
+
+    &.active {
+      color: var(--text-primary);
+      border-bottom-color: var(--accent-primary);
+    }
+
+    @include mix.respond(phone) {
+      padding: 0.45rem 0.7rem;
+      font-size: 0.85rem;
+    }
+  }
+
+  .watch-tabs-panel {
+    padding-top: 10px;
+    min-width: 0;
+  }
+
+  // The transcript's own frame is redundant here — the tab bar is the chrome.
+  .transcript.embedded {
+    margin: 0;
+    border: 0;
+    background: transparent;
+
+    .transcript-head {
+      justify-content: flex-end;
+      padding: 0 0 0.5rem;
+      border-bottom: 0;
+    }
+
+    // Matches the reaction panel's own footprint, so switching tabs doesn't
+    // shove the recommendations up and down the column.
+    .transcript-body {
+      max-height: min(52vh, 30rem);
+      padding-left: 0;
+      padding-right: 0;
+    }
+  }
+}

--- a/src/context/EmbedUploadContext.jsx
+++ b/src/context/EmbedUploadContext.jsx
@@ -240,13 +240,17 @@ export function EmbedUploadProvider({ children }) {
   // must be, because the upload begins the moment this step opens and the gated
   // toggle lives on that very screen. Absent on an instance that predates it,
   // in which case gating still has to be settled before the first byte.
-  const finalizeTokenRef = useRef(null);
-  const deferredPermlinkRef = useRef(null);
-  // What we actually asked for when the token was minted, so a toggle flipped
-  // afterwards against a non-deferring backend is caught instead of silently
-  // lost.
-  const tokenGatedRef = useRef(false);
+  //
+  // The deferral is deliberately NOT held in a ref. It used to be, and because
+  // one slot was shared by all three upload paths, an attempt started while an
+  // earlier one was still running would overwrite it — publish then commissioned
+  // the encode against the abandoned permlink and got a 409, while the upload
+  // that actually landed sat pinned at awaiting_encode and never encoded. It now
+  // travels as a value, returned by each uploader with the URL it produced.
   const earlyUploadPromiseRef = useRef(null);
+  // The deferral belonging to the background upload specifically, so publish can
+  // still find it when the upload finished before the user pressed the button.
+  const earlyDeferralRef = useRef(null);
   const earlyUploadStartedRef = useRef(false);
   const earlyUploadedFileRef = useRef(null); // which file the background upload used
   // The embed server chosen for this upload. Sticky for the whole lifecycle so
@@ -369,11 +373,9 @@ export function EmbedUploadProvider({ children }) {
     } catch { /* ignore */ }
     earlyEmbedUrlRef.current = '';
     earlyUploadPromiseRef.current = null;
+    earlyDeferralRef.current = null;
     earlyUploadStartedRef.current = false;
     earlyUploadedFileRef.current = null;
-    finalizeTokenRef.current = null;
-    deferredPermlinkRef.current = null;
-    tokenGatedRef.current = false;
     chosenEmbedBaseRef.current = '';
     setSelectedEndpoint('');
     setVideoUploadStatus('idle');
@@ -393,14 +395,12 @@ export function EmbedUploadProvider({ children }) {
    * video quietly going out in the clear.
    */
   const captureDeferral = useCallback((data) => {
-    tokenGatedRef.current = data?.gated === true;
-    if (data?.defer_encode === true && data?.finalize_token) {
-      finalizeTokenRef.current = data.finalize_token;
-      deferredPermlinkRef.current = data.permlink || '';
-    } else {
-      finalizeTokenRef.current = null;
-      deferredPermlinkRef.current = null;
-    }
+    const deferred = data?.defer_encode === true && !!data?.finalize_token;
+    return {
+      finalizeToken: deferred ? data.finalize_token : null,
+      permlink: deferred ? (data.permlink || '') : '',
+      gated: data?.gated === true,
+    };
   }, []);
 
   const runTusUpload = useCallback(async (generatedPermlink, uploadEndpoint = EMBED_UPLOAD_URL) => {
@@ -430,6 +430,8 @@ export function EmbedUploadProvider({ children }) {
     const tokenBase = uploadEndpoint.replace(/\/uploads\/?$/, '').replace(/\/+$/, '');
     let tusToken = null;
     let tokenEmbedUrl = '';
+    // Assigned on both the success and the mint-failure path below.
+    let deferral;
     try {
       const tokenRes = await axios.post(
         `${tokenBase}/uploads/token`,
@@ -443,12 +445,12 @@ export function EmbedUploadProvider({ children }) {
         },
         { headers: { 'X-API-Key': EMBED_API_KEY, 'Content-Type': 'application/json' } },
       );
-      captureDeferral(tokenRes.data);
+      deferral = captureDeferral(tokenRes.data);
       tusToken = tokenRes.data?.token || null;
       tokenEmbedUrl = tokenRes.data?.embed_url || '';
     } catch (tokenErr) {
       console.warn('Upload token mint failed — falling back to API-key upload (no deferral)', tokenErr);
-      captureDeferral(null);
+      deferral = captureDeferral(null);
     }
 
     const MB = 1024 * 1024;
@@ -572,7 +574,7 @@ export function EmbedUploadProvider({ children }) {
     }
     upload.start();
     await done;
-    return capturedEmbedUrl;
+    return { embedUrl: capturedEmbedUrl, deferral };
   }, [videoFile, user, fromStories, videoDuration, gated, gatedAllowlist, captureDeferral]);
 
   // Preflight-free multipart POST helper for the chunked protocol. No custom
@@ -736,18 +738,36 @@ export function EmbedUploadProvider({ children }) {
     let totalChunks = 0;
     let received = new Set();
     let embedFromServer = '';
+    let deferral = null;
 
     // Resume a live session for this exact file (survives a reload / retry).
     let stored = null;
     try { stored = localStorage.getItem(fpKey); } catch { /* ignore */ }
+    // Sessions written by builds before the deferral was persisted are a bare
+    // sessionId string; anything newer is {sessionId, deferral}.
+    let storedId = null;
+    let storedDeferral = null;
     if (stored) {
       try {
-        const st = await postForm(`${base}/upload/chunk/status`, { sessionId: stored }, null, { timeoutMs: 15000 });
+        const parsed = JSON.parse(stored);
+        storedId = parsed?.sessionId || null;
+        storedDeferral = parsed?.deferral || null;
+      } catch { storedId = stored; }
+    }
+    if (storedId) {
+      try {
+        const st = await postForm(`${base}/upload/chunk/status`, { sessionId: storedId }, null, { timeoutMs: 15000 });
         if (st && Number.isFinite(st.totalChunks)) {
-          sessionId = stored;
+          sessionId = storedId;
           totalChunks = st.totalChunks;
           chunkSize = st.chunkSize;
           received = new Set(st.received || []);
+          // A resumed session mints no token, so the deferral has to come back
+          // out of storage — otherwise publish would reach for whatever the last
+          // unrelated mint happened to leave in the refs. If it is missing, the
+          // server still parked this upload and we can no longer commission it:
+          // mark it so publish refuses instead of posting to Hive regardless.
+          deferral = storedDeferral || { finalizeToken: null, permlink: '', gated: false, lost: true };
         }
       } catch { /* expired/unknown — create a fresh session below */ }
     }
@@ -766,7 +786,7 @@ export function EmbedUploadProvider({ children }) {
       // token with the flag silently dropped, and uploading against it would
       // publish a supporters-only video in the clear. IPFS content cannot be
       // withdrawn, so failing loudly here is the only safe response.
-      captureDeferral(tokenRes.data);
+      deferral = captureDeferral(tokenRes.data);
       if (gated && tokenRes.data?.gated !== true) {
         throw new Error(
           'This upload server does not support supporters-only videos yet. ' +
@@ -833,7 +853,7 @@ export function EmbedUploadProvider({ children }) {
       chunkSize = created.chunkSize;
       embedFromServer = created.embed_url || embedFromServer;
       received = new Set(created.received || []);
-      try { localStorage.setItem(fpKey, sessionId); } catch { /* ignore */ }
+      try { localStorage.setItem(fpKey, JSON.stringify({ sessionId, deferral })); } catch { /* ignore */ }
     }
 
     // Progress = bytes the SERVER has confirmed + bytes currently in flight. The
@@ -942,7 +962,17 @@ export function EmbedUploadProvider({ children }) {
 
     const fin = await postForm(`${base}/upload/chunk/finish`, { sessionId }, null, { timeoutMs: 60000 });
     try { localStorage.removeItem(fpKey); } catch { /* ignore */ }
-    return fin.embed_url || embedFromServer || '';
+    // finish reports the permlink that actually received the bytes — the only
+    // authority on the subject. A finalize token is bound to one permlink server
+    // side, so if the two disagree the token belongs to some other upload and
+    // sending it would 403; treat that as a lost deferral rather than
+    // commissioning the wrong video.
+    const finPermlink = fin?.permlink || '';
+    if (deferral?.finalizeToken && finPermlink && deferral.permlink !== finPermlink) {
+      console.warn(`Chunked finish landed on ${finPermlink} but the deferral holds ${deferral.permlink} — discarding mismatched finalize token`);
+      deferral = { finalizeToken: null, permlink: finPermlink, gated: deferral.gated, lost: true };
+    }
+    return { embedUrl: fin.embed_url || embedFromServer || '', deferral };
   }, [user, fromStories, gated, gatedAllowlist, videoFile, videoDuration, postForm]);
 
   // TIER 3, last resort: ONE multipart POST carrying the whole file.
@@ -990,7 +1020,7 @@ export function EmbedUploadProvider({ children }) {
     // token with the flag silently dropped, and uploading against it would
     // publish a supporters-only video in the clear. IPFS content cannot be
     // withdrawn, so failing loudly here is the only safe response.
-    captureDeferral(tokenRes.data);
+    const deferral = captureDeferral(tokenRes.data);
     if (gated && tokenRes.data?.gated !== true) {
       throw new Error(
         'This upload server does not support supporters-only videos yet. ' +
@@ -1024,14 +1054,16 @@ export function EmbedUploadProvider({ children }) {
     );
 
     if (!res || !res.embed_url) throw new Error('Single-request upload did not return an embed URL');
-    return res.embed_url;
+    return { embedUrl: res.embed_url, deferral };
   }, [user, fromStories, gated, gatedAllowlist, videoFile, videoDuration, postForm]);
 
   // Upload with automatic fallback. Primary path is TUS on the least-busy host;
   // if the user forced the reliable path (checkbox) or PATCH was already detected
   // blocked this session, go straight to the chunked fallback. If TUS trips the
   // PATCH-blocked watchdog mid-attempt, switch to chunked and remember it for the
-  // rest of the session. Returns the embed URL.
+  // rest of the session. Returns { embedUrl, deferral } — the deferral belongs to
+  // whichever path actually produced the bytes, so publish can never commission
+  // the encode against an attempt that was abandoned along the way.
   const runUploadWithFallback = useCallback(async (generatedPermlink) => {
     const reliableBase = (EMBED_API_URL || '').replace(/\/+$/, '');
 
@@ -1102,28 +1134,32 @@ export function EmbedUploadProvider({ children }) {
       try {
         // Stale-client guard: if a newer build is deployed, force-reload onto it
         // BEFORE any upload starts, so nobody uploads on cached/retired code.
-        if (await reloadIfStale()) return '';   // page is reloading — bail out
+        if (await reloadIfStale()) return { embedUrl: '', deferral: null };   // page is reloading — bail out
         // TUS on the least-busy host, auto-falling back to chunked if PATCH is blocked.
-        const url = await runUploadWithFallback('');
+        const { embedUrl: url, deferral } = await runUploadWithFallback('');
         if (!url) throw new Error('No embed URL returned');
         earlyEmbedUrlRef.current = url;
+        // Pin the deferral to THIS upload. Whatever else starts and mints a
+        // token later cannot move the target the encode gets commissioned at.
+        earlyDeferralRef.current = deferral;
         setEmbedUrl(url);
         setUploadProgress(100);
         setVideoUploadStatus('done');
         setStatusText('');
-        return url;
+        return { embedUrl: url, deferral };
       } catch (err) {
         console.error('Background video upload failed:', err);
         // Allow the publish step to retry the upload inline.
         earlyUploadStartedRef.current = false;
         earlyUploadPromiseRef.current = null;
+        earlyDeferralRef.current = null;
         setVideoUploadStatus('error');
         // Say WHY, in the bar the user is actually looking at. Without this the
         // last thing on screen stays "retrying…" forever, which is
         // indistinguishable from the hang these guards exist to prevent.
         setStatusText(err?.message || 'Upload failed — please retry');
         toast.error(err?.message || 'Upload failed — please retry');
-        return '';
+        return { embedUrl: '', deferral: null };
       }
     })();
     earlyUploadPromiseRef.current = p;
@@ -1179,10 +1215,19 @@ export function EmbedUploadProvider({ children }) {
     // If the background upload (started on the "Add details" step) is running or
     // done, reuse it instead of uploading again. Wait for an in-flight one.
     let earlyUrl = earlyEmbedUrlRef.current;
+    // Travels with the bytes from here on, never out of shared state: by the
+    // time publish runs a second attempt may have started, and commissioning
+    // against its permlink strands the upload that actually landed at
+    // awaiting_encode forever.
+    let deferral = earlyDeferralRef.current;
     if (!prefilled && !earlyUrl && earlyUploadPromiseRef.current) {
       setUploading(true);
       setStatusText('Finishing video upload…');
-      try { earlyUrl = await earlyUploadPromiseRef.current; } catch { earlyUrl = ''; }
+      try {
+        const early = await earlyUploadPromiseRef.current;
+        earlyUrl = early?.embedUrl || '';
+        deferral = early?.deferral || null;
+      } catch { earlyUrl = ''; deferral = null; }
     }
     const alreadyUploaded = !prefilled && !!earlyUrl;
 
@@ -1232,7 +1277,9 @@ export function EmbedUploadProvider({ children }) {
       } else {
         // No background upload available (it failed, or the user reached publish
         // before "Add details" started one) → upload inline now, with fallback.
-        capturedEmbedUrl = await runUploadWithFallback(generatedPermlink);
+        const uploaded = await runUploadWithFallback(generatedPermlink);
+        capturedEmbedUrl = uploaded?.embedUrl || '';
+        deferral = uploaded?.deferral || null;
       }
 
       // Fallback: if no X-Embed-URL header, warn but don't use the raw TUS URL
@@ -1254,20 +1301,32 @@ export function EmbedUploadProvider({ children }) {
       // which is the whole reason for deferring — the encoder is what encrypts,
       // and an unencrypted rendition is public the moment its CID is pinned, so
       // the decision cannot be revisited afterwards.
-      if (finalizeTokenRef.current && deferredPermlinkRef.current) {
+      if (deferral?.lost) {
+        // The bytes landed, but the finalize token that goes with them is gone
+        // (a session resumed from an older build, or a token bound to a
+        // different permlink). Commissioning is impossible, and posting to Hive
+        // anyway would publish a video that stays parked and never encodes.
+        throw new Error(
+          'This upload could not be finalised because its upload session was '
+          + 'interrupted. Nothing was published. Please re-select the video and '
+          + 'upload it again.'
+        );
+      }
+
+      if (deferral?.finalizeToken && deferral?.permlink) {
         const finalizeBase = (chosenEmbedBaseRef.current || EMBED_API_URL || '').replace(/\/+$/, '');
         addMessage(gated ? 'Starting encrypted encode…' : 'Starting encode…');
         await axios.post(
-          `${finalizeBase}/video/${deferredPermlinkRef.current}/encode`,
+          `${finalizeBase}/video/${deferral.permlink}/encode`,
           { gated: !!gated, ...(gated && gatedAllowlist.length ? { allowlist: gatedAllowlist } : {}) },
           {
             headers: {
-              Authorization: `Bearer ${finalizeTokenRef.current}`,
+              Authorization: `Bearer ${deferral.finalizeToken}`,
               'Content-Type': 'application/json',
             },
           },
         );
-      } else if (gated && !tokenGatedRef.current) {
+      } else if (gated && !deferral?.gated) {
         // Not deferred, and the toggle went on after the token was minted. The
         // upload is already committed as public; encoding it now would publish
         // it in the clear, and IPFS content cannot be withdrawn. Stop before the

--- a/src/hooks/useSubtitles.js
+++ b/src/hooks/useSubtitles.js
@@ -46,6 +46,40 @@ function loadStyle() {
 const subtitleCache = {};
 
 /**
+ * The language list for a video, or [] when it has no subtitles.
+ * Shared with the transcript panel, which needs the same list but must NOT
+ * drive the on-video overlay (that follows the viewer's own CC choice).
+ */
+export async function listSubtitleLanguages(author, permlink) {
+  if (!author || !permlink || author === 'unknown') return [];
+  try {
+    const res = await fetch(`${TRANSLATE_API_URL}/subtitles/${author}/${permlink}`);
+    if (!res.ok) return [];
+    const data = await res.json();
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Parsed cues for one language entry ({ lang, cid }), memoised per video+lang.
+ * Both the overlay and the transcript read through this, so a viewer who turns
+ * captions on after reading the transcript pays no second fetch.
+ */
+export async function loadSubtitleCues(author, permlink, langEntry) {
+  if (!langEntry?.cid) return [];
+  const cacheKey = `${author}/${permlink}/${langEntry.lang}`;
+  if (subtitleCache[cacheKey]) return subtitleCache[cacheKey];
+  const srtText = await fetchSrtWithFallback(langEntry.cid);
+  const parsed = parseSrt(srtText);
+  subtitleCache[cacheKey] = parsed;
+  return parsed;
+}
+
+export { SUBTITLE_LANG_KEY };
+
+/**
  * Hook for managing subtitle state on a video.
  * @param {string} author - Video author
  * @param {string} permlink - Video permlink

--- a/src/hooks/useWatchDuration.js
+++ b/src/hooks/useWatchDuration.js
@@ -37,13 +37,14 @@ import { resolveVideoMeta } from '../lib/videoMetaCache';
  * @param {string}  args.author       URL author
  * @param {string}  args.permlink     URL permlink
  * @param {object}  args.playerState  usePlayer() state ({ paused, currentTime, duration })
+ * @param {function} [args.mapPosition] player time → content time, for stitched ads
  * @param {boolean} args.enabled      gate (e.g. false for scheduled/unpublished posts)
  */
 // A video at least this long still counts while the tab is in the background —
 // people listen to long-form with the tab elsewhere on purpose.
 const BACKGROUND_OK_SECONDS = 20 * 60;
 
-export default function useWatchDuration({ api, author, permlink, playerState, enabled = true }) {
+export default function useWatchDuration({ api, author, permlink, playerState, enabled = true, mapPosition = null, premium = false }) {
   const sessionRef = useRef({ sid: null, token: null, beatMs: 5000, lastBeatAt: 0 });
   const startingRef = useRef(false);
   const key = author && author !== 'unknown' && permlink ? `${author}/${permlink}` : null;
@@ -58,8 +59,15 @@ export default function useWatchDuration({ api, author, permlink, playerState, e
 
   // Latest playback position + rate, kept in refs so the stable beat() reads the
   // current values (position → timeline-coverage/heatmap; rate → avg-speed stat).
+  //
+  // `mapPosition` exists because of server-side ad insertion: with a spot stitched
+  // in, the player's currentTime runs ahead of the video by the ad's length. Passing
+  // that through would credit every ad second as watch time on the creator's video
+  // — and the retention data the ad forecast is built from would be poisoned by the
+  // ads it sells. Defaults to the identity, so callers with no ads are unaffected.
   const posRef = useRef(0);
-  posRef.current = Number(playerState?.currentTime) || 0;
+  const rawPos = Number(playerState?.currentTime) || 0;
+  posRef.current = typeof mapPosition === 'function' ? (Number(mapPosition(rawPos)) || 0) : rawPos;
   const rateRef = useRef(1);
   rateRef.current = Number(playerState?.playbackRate) || 1;
 
@@ -125,7 +133,8 @@ export default function useWatchDuration({ api, author, permlink, playerState, e
           const res = await fetch(`${getPlayerUrl()}/api/watch/start`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ owner, permlink: vPermlink, type, duration, position: posRef.current, source: '3speak', private: !!useAppStore.getState().privateMode }),
+            // `premium` marks the row as ad-free so the ad inventory forecast excludes it.
+              body: JSON.stringify({ owner, permlink: vPermlink, type, duration, position: posRef.current, source: '3speak', premium: !!premium, private: !!useAppStore.getState().privateMode }),
           });
           if (!res.ok) continue;                       // 404 for the wrong collection → try the next
           const data = await res.json().catch(() => null);

--- a/src/hooks/useWatchDuration.js
+++ b/src/hooks/useWatchDuration.js
@@ -9,10 +9,23 @@ import { resolveVideoMeta } from '../lib/videoMetaCache';
  *
  *   POST /api/watch/start → opens a server-side session (HMAC token bound to
  *     sid.owner.permlink.ip), returns a beat interval.
- *   POST /api/watch/beat  → sent (throttled) while the video is really playing,
- *     plus a final beat on pause / tab-hide / unmount. The server credits only
- *     the wall-clock gap it measures between beats, so watch time can't be
- *     forged with a single request.
+ *   POST /api/watch/beat  → sent (throttled) while the video is really playing
+ *     AND this tab is the one in front, plus a final beat on pause / tab-hide /
+ *     unmount. The server credits only the wall-clock gap it measures between
+ *     beats, so watch time can't be forged with a single request.
+ *
+ * Tab visibility is part of "really playing" on purpose: a short video left
+ * running in a background tab used to accrue watch time exactly like one
+ * someone was watching. The hide itself still flushes a beat, so the seconds up
+ * to that moment count; the beats simply stop until the tab comes back. The
+ * server caps any single beat at MAX_BEAT_CREDIT_MS (8s), so returning to a
+ * long-hidden tab credits at most that much of the time away, not the whole gap.
+ *
+ * LONG-FORM IS THE EXCEPTION. Past BACKGROUND_OK_SECONDS the background tab is
+ * the point: podcasts, interviews, DJ sets and long talks get listened to with
+ * the tab parked, and that is real watch time, not a video nobody is with. So
+ * anything that long keeps beating while hidden. Below the threshold, a
+ * forgotten tab is far more likely than deliberate listening.
  *
  * Records watched seconds + % of duration (with the viewer IP + video) into the
  * backend's `view-durations` collection. This is the "non-polluting" path — it
@@ -26,10 +39,22 @@ import { resolveVideoMeta } from '../lib/videoMetaCache';
  * @param {object}  args.playerState  usePlayer() state ({ paused, currentTime, duration })
  * @param {boolean} args.enabled      gate (e.g. false for scheduled/unpublished posts)
  */
+// A video at least this long still counts while the tab is in the background —
+// people listen to long-form with the tab elsewhere on purpose.
+const BACKGROUND_OK_SECONDS = 20 * 60;
+
 export default function useWatchDuration({ api, author, permlink, playerState, enabled = true }) {
   const sessionRef = useRef({ sid: null, token: null, beatMs: 5000, lastBeatAt: 0 });
   const startingRef = useRef(false);
   const key = author && author !== 'unknown' && permlink ? `${author}/${permlink}` : null;
+
+  // Whether this tab is the one in front. Kept in a ref so the beat effect reads
+  // it without re-subscribing on every visibility flip.
+  const visibleRef = useRef(typeof document === 'undefined' || document.visibilityState !== 'hidden');
+
+  // Set once the session opens, from the same duration the session was opened
+  // with. Unknown duration counts as short, so the gate stays the safe default.
+  const countsInBackgroundRef = useRef(false);
 
   // Latest playback position + rate, kept in refs so the stable beat() reads the
   // current values (position → timeline-coverage/heatmap; rate → avg-speed stat).
@@ -42,6 +67,7 @@ export default function useWatchDuration({ api, author, permlink, playerState, e
   useEffect(() => {
     sessionRef.current = { sid: null, token: null, beatMs: 5000, lastBeatAt: 0 };
     startingRef.current = false;
+    countsInBackgroundRef.current = false;
   }, [key]);
 
   const beat = () => {
@@ -91,6 +117,7 @@ export default function useWatchDuration({ api, author, permlink, playerState, e
       const duration = (Number.isFinite(storedDuration) && storedDuration > 0)
         ? storedDuration
         : (Number(playerState?.duration) || undefined);
+      countsInBackgroundRef.current = Number.isFinite(duration) && duration >= BACKGROUND_OK_SECONDS;
       // A video lives in exactly one collection — try embed (also matches
       // hive_permlink) then legacy; whichever owns it opens the session.
       for (const type of ['embed', 'legacy']) {
@@ -120,13 +147,32 @@ export default function useWatchDuration({ api, author, permlink, playerState, e
   }, [enabled, key, playerState?.paused]);
 
   // Beat while playing — driven (throttled) by the SDK's currentTime updates,
-  // which only advance while the video is genuinely playing.
+  // which only advance while the video is genuinely playing. A hidden tab keeps
+  // those updates coming (playback doesn't stop), so visibility is checked here
+  // rather than inferred from the player.
   useEffect(() => {
     const s = sessionRef.current;
     if (!enabled || !s.sid || playerState?.paused) return;
+    if (!visibleRef.current && !countsInBackgroundRef.current) return;
     if (Date.now() - s.lastBeatAt >= s.beatMs) beat();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, playerState?.currentTime, playerState?.paused]);
+
+  // Long-form in a hidden tab beats on a timer rather than on the SDK's updates.
+  // Those updates can stop when a tab goes to the background (rAF is paused
+  // there), and the whole point of the long-form exception is that this time
+  // still counts. Idle while visible — the update-driven effect above owns that
+  // case — and idle for anything below the threshold, which isn't counted at all.
+  useEffect(() => {
+    if (!enabled || playerState?.paused) return undefined;
+    const id = setInterval(() => {
+      const s = sessionRef.current;
+      if (!s.sid || visibleRef.current || !countsInBackgroundRef.current) return;
+      if (Date.now() - s.lastBeatAt >= s.beatMs) beat();
+    }, 1000);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, playerState?.paused]);
 
   // Final measured beat when playback pauses.
   useEffect(() => {
@@ -134,14 +180,26 @@ export default function useWatchDuration({ api, author, permlink, playerState, e
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [playerState?.paused]);
 
-  // Flush the tail on tab-hide / unmount (sendBeacon survives unload).
+  // Flush the tail when the tab goes away, and stop counting until it's back.
   useEffect(() => {
-    const onHide = () => { if (document.visibilityState === 'hidden') beat(); };
-    document.addEventListener('visibilitychange', onHide);
-    window.addEventListener('pagehide', onHide);
+    const onVisibility = () => {
+      const hidden = document.visibilityState === 'hidden';
+      visibleRef.current = !hidden;
+      // Beat on the way out only: the seconds actually watched up to this moment
+      // still count. Coming back does NOT beat immediately — that would hand the
+      // server a gap to credit for time nobody was watching.
+      if (hidden) beat();
+      // Coming back after a stretch we DIDN'T count: re-anchor so the next beat
+      // has no gap to credit. Long-form kept beating throughout, so leave its
+      // throttle alone.
+      else if (!countsInBackgroundRef.current) sessionRef.current.lastBeatAt = Date.now();
+    };
+    const onPageHide = () => { visibleRef.current = false; beat(); };
+    document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('pagehide', onPageHide);
     return () => {
-      document.removeEventListener('visibilitychange', onHide);
-      window.removeEventListener('pagehide', onHide);
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('pagehide', onPageHide);
       beat();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/lib/adBreak.js
+++ b/src/lib/adBreak.js
@@ -1,0 +1,131 @@
+/**
+ * Client half of server-side ad insertion, for the SDK-based watch page.
+ *
+ * Deliberately a near-copy of preview-player/src/adBreak.js rather than a shared
+ * package: the two live in different services with different build chains, and a
+ * new npm dependency between them costs more than this duplication does. If a
+ * third player ever needs it, that is the moment to extract it.
+ *
+ * The spot is already inside the playlist by the time the player sees it, so
+ * nothing here fetches an ad and there is no request for a blocker to match. What
+ * this does is the bookkeeping the player cannot do alone:
+ *
+ *  1. ASK whether this playback carries a spot, and hand back a source to load.
+ *  2. MAP the player's timeline back to content time. The important one: in a
+ *     stitched stream currentTime includes the ad, so every ad second would
+ *     otherwise be recorded as watch time against the creator's video — poisoning
+ *     the retention data the ad forecast is itself built from.
+ *  3. Say when the playhead is inside the break, so a Sponsored label can show.
+ *
+ * Every failure path returns "no ad". A video must never fail to play because the
+ * ad system had a bad day.
+ */
+import { CHECKER_URL } from '../utils/config';
+
+const AD_BASE = CHECKER_URL;
+
+// The stitcher only learns where the cut fell when a variant playlist is fetched,
+// a beat after the source is set. Retry briefly rather than guess — a wrong offset
+// silently corrupts watch data, which is worse than no label.
+const RESOLVE_TRIES = 6;
+const RESOLVE_DELAY_MS = 700;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Frequency-cap id for a viewer we cannot name. Per page load, in memory only —
+ * never localStorage, never a cookie. It dies with the tab, so one browsing session
+ * is capped without any durable anonymous identifier existing.
+ */
+const CAP_ID = (() => {
+  try {
+    const a = new Uint8Array(12);
+    (globalThis.crypto || {}).getRandomValues?.(a);
+    return Array.from(a, (b) => b.toString(16).padStart(2, '0')).join('');
+  } catch {
+    return null;
+  }
+})();
+
+export function createAdBreak() {
+  let session = null;
+  let window_ = null;
+  let premium = false;
+
+  return {
+    get active() { return !!session; },
+    get info() { return session; },
+    get resolved() { return !!window_; },
+    /** True when the server said this playback is ad-free because the viewer is Pro. */
+    get isPremiumViewer() { return premium; },
+
+    async request({ owner, permlink, viewer, manifestUrl }) {
+      session = null;
+      window_ = null;
+      premium = false;
+      if (!owner || !permlink || !manifestUrl) return null;
+      try {
+        const res = await fetch(`${AD_BASE}/m/session`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ owner, permlink, viewer: viewer || null, manifestUrl, capId: CAP_ID }),
+        });
+        if (!res.ok) return null;
+        const data = await res.json();
+        premium = data?.premium === true;
+        if (!data || !data.ad || !data.ad.manifestUrl) return null;
+        const sid = (data.ad.manifestUrl.match(/\/m\/([0-9a-f]{32})\.m3u8/) || [])[1];
+        if (!sid) return null;
+        session = {
+          sid,
+          manifestUrl: data.ad.manifestUrl,
+          position: data.ad.position,
+          durationSeconds: data.ad.durationSeconds,
+          label: data.ad.label || 'Sponsored',
+          advertiser: data.ad.advertiser || null,
+        };
+        return session;
+      } catch {
+        return null;
+      }
+    },
+
+    /** Learn where the break actually landed. Safe to call repeatedly. */
+    async resolve() {
+      if (!session || window_) return window_;
+      for (let i = 0; i < RESOLVE_TRIES; i += 1) {
+        try {
+          const res = await fetch(`${AD_BASE}/m/${session.sid}/i`);
+          if (res.ok) {
+            const d = await res.json();
+            if (typeof d.adStartAt === 'number' && d.adDurationSeconds) {
+              window_ = { start: d.adStartAt, duration: d.adDurationSeconds };
+              return window_;
+            }
+          }
+        } catch { /* keep trying */ }
+        await sleep(RESOLVE_DELAY_MS);
+      }
+      return null;
+    },
+
+    isInside(playerTime) {
+      if (!window_ || !Number.isFinite(playerTime)) return false;
+      return playerTime >= window_.start && playerTime < window_.start + window_.duration;
+    },
+
+    /**
+     * Player time → content time. Inside the break the content has not advanced at
+     * all, so it pins to the cut point; after it, the ad's length comes off. This
+     * is what keeps ad seconds out of `view-durations`.
+     */
+    contentTime(playerTime) {
+      if (!window_ || !Number.isFinite(playerTime)) return playerTime;
+      const { start, duration } = window_;
+      if (playerTime < start) return playerTime;
+      if (playerTime < start + duration) return start;
+      return playerTime - duration;
+    },
+
+    reset() { session = null; window_ = null; premium = false; },
+  };
+}

--- a/src/lib/advertiseData.js
+++ b/src/lib/advertiseData.js
@@ -1,0 +1,354 @@
+// Advertiser intake data layer — talks to the checker's /advertise/* endpoints
+// (3speakchecks/routes/advertise.js). The inventory numbers are the cleaned
+// forecast written by services/adInventory.js, not raw view counts: sessions too
+// short to be a viewer, traffic from accounts that behave like autoplay bots, and
+// videos whose creator opted out are all removed before anything is offered here.
+//
+// Admin endpoints are deliberately NOT reachable from this file. They are gated by
+// a server-only secret precisely because every VITE_ variable ends up in the
+// browser bundle, so an approval queue driven from the frontend would not be a gate.
+import {
+  signMessageWithAioha,
+  getCurrentProvider,
+  isManteAuthLogin,
+  KeyTypes,
+  Providers,
+} from '../hive-api/aioha';
+import { CHECKER_URL, EMBED_API_KEY, EMBED_API_URL } from '../utils/config';
+import { uploadThumbnail } from '../utils/uploadThumbnail';
+
+// preview-3speak's own backend — same base aioha and the chat client use.
+const THREESPEAK_API = import.meta.env.VITE_THREESPEAK_API || '/api';
+
+const BASE = `${CHECKER_URL}/advertise`;
+
+// The categories the backend accepts (utils/config.js AD_CATEGORIES). Kept in the
+// same order so the select reads sensibly rather than alphabetically.
+export const AD_CATEGORIES = [
+  { id: 'defi', label: 'DeFi' },
+  { id: 'exchange', label: 'Exchange' },
+  { id: 'gaming', label: 'Gaming' },
+  { id: 'nft', label: 'NFT' },
+  { id: 'infrastructure', label: 'Infrastructure' },
+  { id: 'dao', label: 'DAO / community' },
+  { id: 'media', label: 'Media' },
+  { id: 'education', label: 'Education' },
+  { id: 'event', label: 'Event' },
+  { id: 'tooling', label: 'Tooling' },
+  { id: 'other', label: 'Something else' },
+];
+
+async function readJson(res) {
+  let body = null;
+  try { body = await res.json(); } catch { /* non-JSON error page */ }
+  if (!res.ok) {
+    const err = new Error((body && body.error) || `Request failed (${res.status})`);
+    err.status = res.status;
+    err.body = body;
+    throw err;
+  }
+  return body;
+}
+
+/** Live inventory forecast. Throws with status 503 before the job has ever run. */
+export async function fetchInventory() {
+  return readJson(await fetch(`${BASE}/inventory`));
+}
+
+export async function submitApplication(payload) {
+  return readJson(await fetch(`${BASE}/apply`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  }));
+}
+
+export async function fetchApplication(reference) {
+  return readJson(await fetch(`${BASE}/application/${encodeURIComponent(reference)}`));
+}
+
+export async function fetchCreatorAdPrefs(account) {
+  return readJson(await fetch(`${BASE}/creator/prefs/${encodeURIComponent(account)}`));
+}
+
+/* ─── turning ads off ─────────────────────────────────────────────────── */
+
+// Wallets that can sign an arbitrary message in the browser. HiveSigner cannot
+// sign buffers, and Butter Auth / ManteAuth sessions hold no client-side key at
+// all — they publish through @threespeak. Same set the chat login uses.
+const SIGN_CAPABLE_PROVIDERS = new Set([
+  Providers.Keychain,
+  Providers.HiveAuth,
+  Providers.PeakVault,
+  Providers.Ledger,
+]);
+
+function canSignLocally() {
+  if (isManteAuthLogin()) return false;
+  return SIGN_CAPABLE_PROVIDERS.has(getCurrentProvider());
+}
+
+// Must match prefsMessage() in 3speakchecks/routes/advertise.js exactly. The
+// community share is part of it because that field decides where money goes — a
+// signature made for one split must not be reusable on another.
+const prefsMessage = (account, adsEnabled, communitySharePct, timestamp) =>
+  ['3speak-ads', 'creator-prefs', account, adsEnabled ? 'on' : 'off',
+    String(communitySharePct), String(timestamp)].join('|');
+
+/**
+ * Ask our own backend to sign the preference with @threespeak's posting key,
+ * under the authority the creator already granted it.
+ *
+ * This exists so the setting works for every login. A creator on HiveSigner or
+ * Butter Auth has no key in the browser, so demanding a local signature would
+ * leave exactly those people unable to turn ads off on their own videos — the
+ * wrong group to lock out of a consent control. We send only a boolean; the
+ * backend builds and signs the message itself, so it can never be talked into
+ * signing arbitrary bytes.
+ */
+async function signViaThreespeak(adsEnabled, communitySharePct, account) {
+  const provider = getCurrentProvider();
+  const headers = { 'Content-Type': 'application/json' };
+  const body = { adsEnabled, communitySharePct };
+
+  if (provider === Providers.HiveSigner) {
+    const token = localStorage.getItem('hivesignerToken');
+    if (!token) throw new Error('Your HiveSigner session expired — reconnect and try again.');
+    headers.Authorization = `Bearer ${token}`;
+  } else if (!isManteAuthLogin()) {
+    headers['X-API-Key'] = EMBED_API_KEY;
+    body.username = account;
+  }
+
+  const res = await fetch(`${THREESPEAK_API}/ads/opt-out-signature`, {
+    method: 'POST',
+    headers,
+    credentials: 'include',
+    body: JSON.stringify(body),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || !data.signature) {
+    throw new Error(data.error || 'Could not save the setting. Please try again.');
+  }
+  return { signature: data.signature, timestamp: data.timestamp };
+}
+
+async function signLocally(account, adsEnabled, communitySharePct) {
+  const timestamp = Date.now();
+  const res = await signMessageWithAioha(
+    prefsMessage(account, adsEnabled, communitySharePct, timestamp),
+    KeyTypes.Posting,
+    adsEnabled ? 'Save your ad settings' : 'Turn ads off on your videos',
+  );
+  if (!res?.success || !res.result) throw new Error('Signature was rejected.');
+  return { signature: res.result, timestamp };
+}
+
+/**
+ * Save this creator's ad settings: whether their videos carry ads, and how much of
+ * the creator pool goes to the community they posted in. Signs locally when the
+ * wallet can, and falls back to the delegated backend signature otherwise.
+ *
+ * Both fields go in one signed message, so saving is one signature rather than one
+ * per field — which matters when the wallet shows a prompt for each.
+ */
+export async function setCreatorAdPrefs(account, { adsEnabled, communitySharePct }) {
+  // No default here on purpose: the platform default lives on the server, and a
+  // second copy in the browser is a copy that can drift out of step with the
+  // message being signed. Omitting the field lets the server decide; passing 0
+  // means the creator chose zero.
+  const { signature, timestamp } = canSignLocally()
+    ? await signLocally(account, adsEnabled, communitySharePct)
+    : await signViaThreespeak(adsEnabled, communitySharePct, account);
+
+  return readJson(await fetch(`${BASE}/creator/prefs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ account, adsEnabled, communitySharePct, signature, timestamp }),
+  }));
+}
+
+/* ─── formatting ──────────────────────────────────────────────────────── */
+
+const nf = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
+
+/**
+ * Counts, rounded to whole numbers — except below 10, where a decimal is kept.
+ * Rounding 0.2 to "0" reads as a broken page rather than a small number, and the
+ * difference between "none" and "a fifth of one a day" is exactly what a small
+ * slot's figures need to convey.
+ */
+export const formatCount = (n) => {
+  if (!Number.isFinite(n)) return '—';
+  if (n > 0 && n < 10 && !Number.isInteger(n)) return String(Math.round(n * 10) / 10);
+  return nf.format(Math.round(n));
+};
+
+/** "30s in" / "Before the video" — how a slot reads to someone buying it. */
+export function slotLabel(slot) {
+  if (!slot || slot.position === 0) return 'Before the video';
+  if (slot.position < 60) return `${slot.position} seconds in`;
+  const mins = slot.position / 60;
+  const shown = Number.isInteger(mins) ? mins : mins.toFixed(1);
+  return `${shown} ${String(shown) === '1' ? 'minute' : 'minutes'} in`;
+}
+
+// Region names from the browser, falling back to the raw code. Avoids shipping a
+// country-name table for the fifteen codes we actually show.
+const regionNames = typeof Intl !== 'undefined' && Intl.DisplayNames
+  ? new Intl.DisplayNames(undefined, { type: 'region' })
+  : null;
+
+export function countryName(code) {
+  if (!code || code === 'unknown') return 'Unplaced';
+  try { return (regionNames && regionNames.of(code)) || code; } catch { return code; }
+}
+
+/* ─── the spot itself ─────────────────────────────────────────────────── */
+
+/**
+ * Read a video's duration in the browser, before uploading it.
+ *
+ * Worth the extra step: a spot that is too long is rejected by the backend anyway,
+ * and finding that out after waiting for an upload is a much worse way to learn it.
+ */
+export function readVideoDuration(file) {
+  return new Promise((resolve) => {
+    const url = URL.createObjectURL(file);
+    const v = document.createElement('video');
+    v.preload = 'metadata';
+    const done = (d) => { URL.revokeObjectURL(url); resolve(d); };
+    v.onloadedmetadata = () => done(Number.isFinite(v.duration) ? Math.round(v.duration) : 0);
+    v.onerror = () => done(0);          // unreadable → let the backend decide
+    v.src = url;
+  });
+}
+
+/**
+ * Upload a spot and register it for review.
+ *
+ * Goes through the ordinary embed upload pipeline, so the spot is encoded to the
+ * same HLS ladder as every other video on the platform — a creative encoded any
+ * other way would stall the splice on a codec or resolution change.
+ *
+ * `frontend_app: '3speak-ads'` is what keeps it out of the site: the embed backend
+ * only sets `listed_on_3speak` for uploads from '3speak-tv', and nothing here
+ * broadcasts to Hive, so the spot has no post, earns no rewards and appears in no
+ * feed. It exists only to be reviewed and then played inside a break.
+ */
+/**
+ * Upload a still (logo, frame, key art) and register it as an asset.
+ *
+ * Goes through the same image host everything else on 3Speak uses. It is NOT a
+ * playable spot — the stitcher splices HLS and a still is not something HLS can
+ * express — so it is stored for a human to build a spot around, and the server
+ * refuses to serve it. The UI says so rather than letting an advertiser assume.
+ */
+export async function uploadImageAsset({ file, reference }) {
+  // Reuses the thumbnail uploader's fallback chain rather than calling one host
+  // directly: @threespeak signs first, then the 3Speak image server. That matters
+  // right now — the @threespeak path has been returning `quota_exceeded` from
+  // images.hive.blog, and going straight at it meant every ad image upload failed
+  // when the platform already had a working second route.
+  //
+  // `preferStatic` skips the middle, user-signed step on purpose: it would put a
+  // wallet-signing prompt in front of someone uploading a logo, and it cannot run
+  // at all for the logins that have no client-side key.
+  const url = await uploadThumbnail(file, null, { preferStatic: true });
+  if (!url) throw new Error('Image upload failed');
+
+  return readJson(await fetch(`${BASE}/creatives`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ reference, imageUrl: url }),
+  }));
+}
+
+export async function uploadCreative({ file, account, reference, durationSeconds }) {
+  const form = new FormData();
+  form.append('owner', account);
+  form.append('frontend_app', '3speak-ads');
+  form.append('filename', file.name || 'spot.mp4');
+  if (durationSeconds) form.append('duration', String(durationSeconds));
+  form.append('file', file, file.name || 'spot.mp4');
+
+  const up = await fetch(`${EMBED_API_URL}/upload/simple`, {
+    method: 'POST',
+    headers: { 'X-API-Key': EMBED_API_KEY },
+    body: form,
+  });
+  const upJson = await up.json().catch(() => ({}));
+  if (!up.ok || !upJson.permlink) {
+    throw new Error(upJson.error || `Upload failed (${up.status})`);
+  }
+
+  // Claim the upload as an ad creative. Separate call on purpose: the upload
+  // endpoint belongs to the embed service and knows nothing about advertising.
+  return readJson(await fetch(`${BASE}/creatives`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ reference, embedId: upJson.permlink }),
+  }));
+}
+
+export async function fetchCreatives(reference) {
+  return readJson(await fetch(`${BASE}/creatives?reference=${encodeURIComponent(reference)}`));
+}
+
+/** Rate card + where to send payment. */
+export async function fetchPricing() {
+  return readJson(await fetch(`${BASE}/pricing`));
+}
+
+/* ─── campaigns ───────────────────────────────────────────────────────── */
+
+export async function createCampaign({ reference, name, days, slotPosition, markets, startAt, production }) {
+  return readJson(await fetch(`${BASE}/campaigns`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ reference, name, days, slotPosition, markets, startAt, production }),
+  }));
+}
+
+export async function fetchCampaigns(reference) {
+  return readJson(await fetch(`${BASE}/campaigns?reference=${encodeURIComponent(reference)}`));
+}
+
+/**
+ * Ask the server to look for the on-chain payment.
+ *
+ * Nothing about the money is asserted from here — the backend reads the payment
+ * account's own transfer history and matches the memo. The button is a nudge to go
+ * and check, not a claim that anything was paid.
+ */
+export async function claimCampaign(campaignId) {
+  return readJson(await fetch(`${BASE}/campaigns/${encodeURIComponent(campaignId)}/claim`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  }));
+}
+
+export async function attachCreative({ reference, campaignId, embedId }) {
+  return readJson(await fetch(`${BASE}/campaigns/${encodeURIComponent(campaignId)}/creative`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ reference, embedId }),
+  }));
+}
+
+/** Plain-English answer to "why isn't my campaign running". */
+export const BLOCKED_REASON = {
+  unpaid: 'Waiting for your payment',
+  no_creative: 'No spot attached yet',
+  creative_pending: 'Your spot is still encoding',
+  creative_review: 'Waiting for us to review your spot',
+  creative_rejected: 'Your spot was not accepted',
+  creative_not_encoded: 'Your spot is still encoding',
+  not_started: 'Scheduled, not started yet',
+  ended: 'This flight has ended',
+  paused: 'Paused',
+  cancelled: 'Cancelled',
+  complete: 'Finished',
+  not_submitted: 'Not submitted',
+};

--- a/src/lib/hiveRenderer/renderer.js
+++ b/src/lib/hiveRenderer/renderer.js
@@ -349,16 +349,25 @@ function transformIPFSContent(content, ipfsGateway, fallbackGateways) {
 }
 
 /**
- * Open IPFS links in a new tab. That doesn't suppress the browser's download
- * prompt for a Content-Disposition: attachment response, but it keeps the user
- * from losing their place in the page when one fires. (An onclick handler here
- * would be pointless — FORBID_ATTR strips it during sanitization.)
+ * Every link that leaves 3Speak opens in a new tab.
+ *
+ * Reported from the community (2026-08-19): clicking an image wrapped in a link
+ * inside the upload form's description PREVIEW navigated the tab away, taking
+ * the whole in-progress upload with it. The same click costs a viewer their
+ * place in a playing video, and an IPFS link that answers with
+ * Content-Disposition: attachment fires a download prompt on top of that.
+ *
+ * Absolute http(s) hrefs only, and this runs AFTER Hive frontend URLs have been
+ * rewritten to app-internal ones — so /@author/permlink, /p/user and /t/tag
+ * stay in this tab, where the router handles them. An href that already carries
+ * a target is left alone. (An onclick handler here would be pointless —
+ * FORBID_ATTR strips it during sanitization.)
  */
-function preventIPFSDownloads(content) {
-  return content.replace(
-    /<a href="(https?:\/\/[^"]*(?:ipfs|bafy|Qm)[^"]*)"([^>]*)>/gi,
-    '<a href="$1" target="_blank" rel="noopener noreferrer"$2>'
-  );
+function externalLinksToNewTab(content) {
+  return content.replace(/<a href="(https?:\/\/[^"]*)"([^>]*)>/gi, (match, href, attrs) => {
+    if (/\starget\s*=/i.test(attrs)) return match;
+    return `<a href="${href}" target="_blank" rel="noopener noreferrer"${attrs}>`;
+  });
 }
 
 /** Convert Hive frontend URLs (peakd, ecency, …) to internal app links. */
@@ -472,12 +481,14 @@ export function createHiveRenderer(options = {}) {
     // we failed to switch off — either way, show it as a link, not a player.
     html = rawIframesToLinks(html);
 
-    // Direct IPFS links shouldn't yank the user out of the page.
-    html = preventIPFSDownloads(html);
-
     if (convertHiveUrls) {
       html = convertHiveUrlsToInternal(html, hiveFrontends, internalUrlPrefix);
     }
+
+    // Links off-site shouldn't yank the user out of the page. Deliberately
+    // after the Hive-URL rewrite above, so links that just became internal
+    // aren't sent to a new tab.
+    html = externalLinksToNewTab(html);
 
     html = DOMPurify.sanitize(html, DOMPURIFY_CONFIG);
 

--- a/src/lib/videoData.js
+++ b/src/lib/videoData.js
@@ -36,6 +36,9 @@ function parseMeta(jm) {
 }
 
 // Hive profile — replaces GET_PROFILE / USER_DETAILS.
+// Hive community ids are `hive-` + digits; anything else in `category` is a tag.
+const HIVE_COMMUNITY_RE = /^hive-\d+$/;
+
 export async function fetchHiveProfile(username) {
   if (!username) return null;
   let account = null;
@@ -166,7 +169,15 @@ export async function fetchVideoDetails(author, permlink) {
       num_votes: post.active_votes?.length || 0,
       total_hive_reward: payout,
     },
-    community: post.category ? { _id: post.category, title: post.category } : null,
+    // A Hive post's `category` is the community it was published into — but ONLY
+    // when it actually went to one. Posted straight to a personal blog, Hive
+    // sets `category` to the FIRST TAG instead, so trusting it blindly labelled
+    // an ordinary upload as a community and drew a badge (with the avatar of
+    // whichever account happens to share that tag's name) for a community that
+    // doesn't exist. Community ids are always `hive-<digits>`.
+    community: HIVE_COMMUNITY_RE.test(post.category || '')
+      ? { _id: post.category, title: post.category }
+      : null,
     created_at: post.created,
     tags: meta.tags || [],
     parent_permlink: post.parent_permlink,

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -9,7 +9,17 @@ import './polyfills';
 // (import.meta.env.DEV === false), so 3speak.tv's real PWA is untouched.
 if (import.meta.env.DEV && typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   navigator.serviceWorker.getRegistrations()
-    .then((regs) => regs.forEach((r) => r.unregister()))
+    .then((regs) => regs.forEach((r) => {
+      // ...except the notifications worker, which is registered ON PURPOSE in
+      // dev (utils/webPush.js) and parked at its own scope precisely so it is
+      // distinguishable here. Evicting it every page load was silently breaking
+      // push: unregistering a worker invalidates the push subscriptions tied to
+      // it, so a subscription would save fine and then come back 410 Gone from
+      // the push service. It caches nothing, so there is no stale shell to
+      // evict — the reason this block exists does not apply to it.
+      if (r.scope.endsWith('/push-scope/')) return;
+      r.unregister();
+    }))
     .catch(() => {});
   if (typeof caches !== 'undefined' && caches.keys) {
     caches.keys().then((keys) => keys.forEach((k) => caches.delete(k))).catch(() => {});

--- a/src/page/Advertise.jsx
+++ b/src/page/Advertise.jsx
@@ -1,0 +1,831 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { MdCampaign, MdInfoOutline, MdCheckCircle, MdSchedule, MdCancel } from 'react-icons/md';
+import { toast } from 'sonner';
+import { useAppStore } from '../lib/store';
+import { adsEnabledFor } from '../utils/config';
+import NotFound from './NotFound';
+import {
+  AD_CATEGORIES,
+  fetchInventory,
+  submitApplication,
+  fetchApplication,
+  uploadCreative,
+  uploadImageAsset,
+  fetchCreatives,
+  fetchPricing,
+  createCampaign,
+  fetchCampaigns,
+  claimCampaign,
+  attachCreative,
+  BLOCKED_REASON,
+  readVideoDuration,
+  formatCount,
+  slotLabel,
+  countryName,
+} from '../lib/advertiseData';
+import './Advertise.scss';
+
+// The inventory forecast only moves every few hours, so a long stale time keeps
+// the page instant on revisit without ever showing a number the backend disowns.
+const INVENTORY_STALE_MS = 10 * 60 * 1000;
+
+const EMPTY_FORM = {
+  hiveAccount: '',
+  projectName: '',
+  website: '',
+  contact: '',
+  category: '',
+  budgetHbd: '',
+  markets: [],
+  creativeConcept: '',
+};
+
+function StatTile({ value, label, note }) {
+  return (
+    <div className="adv-stat">
+      <span className="adv-stat-value">{value}</span>
+      <span className="adv-stat-label">{label}</span>
+      {note ? <span className="adv-stat-note">{note}</span> : null}
+    </div>
+  );
+}
+
+function InventoryPanel({ data, isLoading, error }) {
+  if (isLoading) return <div className="adv-panel adv-panel-muted">Loading current availability…</div>;
+
+  if (error) {
+    // A 503 means the forecast job has not produced a snapshot yet — that is a
+    // different message from "something broke", and an advertiser deserves the
+    // honest one rather than a spinner that never resolves.
+    // 404 means the whole ad surface is switched off server-side, not that one
+    // number is missing — and in that state the form below does NOT work either,
+    // so saying it does would send someone into a dead end.
+    if (error.status === 404) {
+      return (
+        <div className="adv-panel adv-panel-muted">
+          Advertising is switched off at the moment. Nothing here will submit until it is turned back on.
+        </div>
+      );
+    }
+    return (
+      <div className="adv-panel adv-panel-muted">
+        {error.status === 503
+          ? 'Availability figures are being recalculated. Apply below and we will send you the current numbers with your quote.'
+          : 'Availability figures are temporarily unavailable. The application form below still works.'}
+      </div>
+    );
+  }
+  if (!data) return null;
+
+  const { audience, slots, quality, trial } = data;
+  // Mid-roll first: it is what we actually sell, and leading with the bigger
+  // pre-roll number would be selling a slot we do not recommend.
+  const ordered = [...(slots || [])].sort((a, b) => (a.position === 0 ? 1 : b.position === 0 ? -1 : a.position - b.position));
+  const topCountries = (audience?.countries || []).slice(0, 6);
+
+  return (
+    <div className="adv-inventory">
+      {trial?.active && (
+        // Without this a reader takes platform capacity for what their spot would
+        // reach today. The restriction is real and stating it costs us nothing.
+        <p className="adv-note adv-note-trial">
+          <MdInfoOutline aria-hidden="true" />
+          <span>{trial.note}</span>
+        </p>
+      )}
+      <div className="adv-stats">
+        <StatTile value={formatCount(audience?.sessionsPerDay)} label="Watch sessions a day" note="Trailing 7 days, after filtering" />
+        <StatTile value={formatCount(audience?.videos)} label="Videos in the pool" note={`Last ${data.windowDays} days`} />
+        <StatTile value={formatCount(audience?.watchHours)} label="Watch hours" note={`Last ${data.windowDays} days`} />
+      </div>
+
+      <div className="adv-slots">
+        <h3>Where a spot can run</h3>
+        <div className="adv-table-wrap">
+          <table className="adv-table">
+            <thead>
+              <tr>
+                <th>Placement</th>
+                <th className="num">Plays a day</th>
+                <th className="num">Plays a month</th>
+                <th className="num">Reach</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ordered.map((s) => (
+                <tr key={s.position} className={s.position === 0 ? 'adv-row-muted' : ''}>
+                  <td>
+                    {slotLabel(s)}
+                    {s.position === 0 ? <span className="adv-tag">not recommended</span> : null}
+                  </td>
+                  <td className="num">{formatCount(s.perDay)}</td>
+                  <td className="num">{formatCount(s.perMonth)}</td>
+                  <td className="num">{s.reachPct}%</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p className="adv-fine">
+          A spot before the video reaches more sessions on paper, but almost half of all
+          watching here stops inside fifteen seconds — so most of those plays land on
+          someone who was already leaving. A spot placed further in is counted only when
+          the viewer actually got there.
+        </p>
+      </div>
+
+      {topCountries.length > 0 && (
+        <div className="adv-countries">
+          <h3>Who watches</h3>
+          <ul className="adv-country-list">
+            {topCountries.map((c) => (
+              <li key={c.code}>
+                <span className="adv-country-name">{countryName(c.code)}</span>
+                <span className="adv-country-bar" aria-hidden="true">
+                  <span style={{ width: `${Math.min(100, c.sharePct * 3)}%` }} />
+                </span>
+                <span className="adv-country-share">{c.sharePct}%</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {quality && (
+        <p className="adv-note">
+          <MdInfoOutline aria-hidden="true" />
+          <span>
+            <strong>{quality.removedPct}% of raw traffic is excluded</strong> from these
+            figures — sessions under {quality.minEngagedSeconds} seconds, accounts whose
+            average session is too short to be a person watching, and videos whose creator
+            opted out. What is left is what we are willing to sell.
+          </span>
+        </p>
+      )}
+    </div>
+  );
+}
+
+function StatusBadge({ status }) {
+  const map = {
+    pending: { Icon: MdSchedule, label: 'Under review' },
+    approved: { Icon: MdCheckCircle, label: 'Approved' },
+    rejected: { Icon: MdCancel, label: 'Not accepted' },
+  };
+  const { Icon, label } = map[status] || map.pending;
+  return (
+    <span className={`adv-status adv-status-${status}`}>
+      <Icon aria-hidden="true" /> {label}
+    </span>
+  );
+}
+
+/**
+ * Book a flight, pay for it, and see what ran.
+ *
+ * Payment is a plain Hive transfer with a memo — no wallet integration, no
+ * redirect, nothing to break. The advertiser sends it from wherever they keep their
+ * HBD and presses check; the server reads the payment account's own history and
+ * matches the memo, so nothing about the money is taken on trust from this page.
+ */
+function CampaignPanel({ reference, pricing, creatives, onNeedCreative }) {
+  const [campaigns, setCampaigns] = useState([]);
+  const [days, setDays] = useState(pricing?.minDays || 7);
+  const [slot, setSlot] = useState(null);
+  // "Make the spot for us" — a one-time fee on top of the flight, in the same total
+  // so the advertiser sends one transfer rather than two.
+  const [wantProduction, setWantProduction] = useState(false);
+  const [brief, setBrief] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+
+  const refresh = useCallback(() => {
+    fetchCampaigns(reference)
+      .then((r) => setCampaigns(r.campaigns || []))
+      .catch(() => { /* an unreadable list is not worth an error banner */ });
+  }, [reference]);
+  useEffect(() => { refresh(); }, [refresh]);
+
+  // Mid-roll first, and pre-roll last with its warning: the honest recommendation is
+  // not the one with the biggest number on it.
+  const slots = useMemo(() => {
+    const list = (pricing?.slotPositions || []).slice();
+    return list.sort((a, b) => (a === 0 ? 1 : b === 0 ? -1 : a - b));
+  }, [pricing]);
+  const chosenSlot = slot ?? slots[0] ?? 30;
+  const productionFee = wantProduction ? (pricing?.productionFeeHbd || 0) : 0;
+  const flight = pricing ? Math.round(days * pricing.pricePerDayHbd * 1000) / 1000 : null;
+  const total = flight != null ? Math.round((flight + productionFee) * 1000) / 1000 : null;
+  const briefTooShort = wantProduction && brief.trim().length < 20;
+
+  async function onBook(e) {
+    e.preventDefault();
+    if (busy) return;
+    setBusy(true); setError(null);
+    try {
+      const res = await createCampaign({
+        reference,
+        days: Number(days),
+        slotPosition: Number(chosenSlot),
+        production: wantProduction ? { requested: true, brief: brief.trim() } : undefined,
+      });
+      toast.success('Flight booked — send the payment to start it');
+      refresh();
+      if (!creatives.length) onNeedCreative?.();
+      return res;
+    } catch (err) {
+      setError(err.message || 'Could not book that flight');
+    } finally { setBusy(false); }
+    return null;
+  }
+
+  async function onCheckPayment(id) {
+    setError(null);
+    try {
+      const r = await claimCampaign(id);
+      toast.success(r.message || 'Payment found');
+      refresh();
+    } catch (err) {
+      // A missing payment is the normal case right after booking, not a failure.
+      setError(err.status === 404 ? 'No matching transfer found yet — it can take a moment to appear on chain.' : (err.message || 'Could not check'));
+    }
+  }
+
+  async function onAttach(id, embedId) {
+    try {
+      await attachCreative({ reference, campaignId: id, embedId });
+      toast.success('Spot attached');
+      refresh();
+    } catch (err) { setError(err.message || 'Could not attach that spot'); }
+  }
+
+  const ready = creatives.filter((c) => c.status === 'ready');
+
+  return (
+    <div className="adv-campaigns">
+      <h3>Your flights</h3>
+
+      <form className="adv-book" onSubmit={onBook}>
+        <div className="adv-field">
+          <label htmlFor="adv-days">Days</label>
+          <input
+            id="adv-days" type="number" min={pricing?.minDays || 7} max={pricing?.maxDays || 90}
+            value={days} onChange={(e) => setDays(e.target.value)}
+          />
+        </div>
+        <div className="adv-field">
+          <label htmlFor="adv-slot">Placement</label>
+          <select id="adv-slot" value={chosenSlot} onChange={(e) => setSlot(Number(e.target.value))}>
+            {slots.map((p) => (
+              <option key={p} value={p}>
+                {p === 0 ? 'Before the video (not recommended)' : slotLabel({ position: p })}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="adv-production">
+          <label className="adv-check">
+            <input
+              type="checkbox"
+              checked={wantProduction}
+              onChange={(e) => setWantProduction(e.target.checked)}
+            />
+            <span>
+              Have us make the video for you
+              {pricing?.productionFeeHbd
+                ? <> &mdash; a one-off <strong>{pricing.productionFeeHbd} HBD</strong> on top of the flight</>
+                : null}
+            </span>
+          </label>
+          {wantProduction && (
+            <div className="adv-field adv-field-wide">
+              <label htmlFor="adv-brief">What should the spot say?</label>
+              <textarea
+                id="adv-brief"
+                rows={4}
+                value={brief}
+                onChange={(e) => setBrief(e.target.value)}
+                placeholder="What you are advertising, who it is for, the one thing a viewer should remember, and anything you want us to avoid. Upload a logo or stills above and we will use them."
+              />
+              <span className="adv-hint">
+                {briefTooShort
+                  ? `${20 - brief.trim().length} more characters — we cannot make a spot from a blank brief`
+                  : 'Enough to work from, thanks'}
+              </span>
+            </div>
+          )}
+        </div>
+
+        <div className="adv-book-total">
+          {total != null ? (
+            <span>
+              <strong>{total} HBD</strong> total
+              {productionFee > 0 ? <span className="adv-hint"> ({flight} flight + {productionFee} production)</span> : null}
+            </span>
+          ) : null}
+          <button type="submit" className="adv-primary" disabled={busy || briefTooShort}>
+            {busy ? 'Booking…' : 'Book this flight'}
+          </button>
+        </div>
+      </form>
+      {error ? <p className="adv-upload-error">{error}</p> : null}
+
+      {campaigns.length > 0 && (
+        <ul className="adv-campaign-list">
+          {campaigns.map((c) => (
+            <li key={c.id}>
+              <div className="adv-campaign-head">
+                <span className="adv-campaign-name">{c.name}</span>
+                <span className="adv-creative-status">{c.status.replace(/_/g, ' ')}</span>
+              </div>
+              <div className="adv-creative-meta">
+                {c.days} days · {slotLabel({ position: c.slotPosition })} · {c.priceHbd} HBD
+                {c.forecast != null ? ` · forecast ${formatCount(c.forecast)} play${c.forecast === 1 ? '' : 's'}` : ''}
+              </div>
+
+              {c.production && (
+                <div className="adv-campaign-blocked">
+                  We are making the video · {c.production.status}
+                  {c.productionFeeHbd ? ` · ${c.productionFeeHbd} HBD` : ''}
+                </div>
+              )}
+
+              {c.blockedBy && (
+                <div className="adv-campaign-blocked">
+                  {BLOCKED_REASON[c.blockedBy] || c.blockedBy}
+                </div>
+              )}
+
+              {c.paidHbd < c.priceHbd && (
+                <div className="adv-pay">
+                  <p className="adv-fine">
+                    Send <strong>{(c.priceHbd - c.paidHbd).toFixed(3)} HBD</strong> to{' '}
+                    <strong>@{c.payTo}</strong> with the memo <code>{c.memo}</code>. HIVE works too and
+                    is valued at the on-chain price.
+                  </p>
+                  <button type="button" className="adv-secondary" onClick={() => onCheckPayment(c.id)}>
+                    I have sent it
+                  </button>
+                </div>
+              )}
+
+              {!c.creative && ready.length > 0 && (
+                <div className="adv-pay">
+                  <label className="adv-hint" htmlFor={`attach-${c.id}`}>Attach an approved spot</label>
+                  <select
+                    id={`attach-${c.id}`}
+                    defaultValue=""
+                    onChange={(e) => e.target.value && onAttach(c.id, e.target.value)}
+                  >
+                    <option value="" disabled>Choose one</option>
+                    {ready.map((cr) => (
+                      <option key={cr.embedId} value={cr.permlink || cr.embedId}>
+                        {cr.durationSeconds}s spot
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
+
+              {(c.delivered > 0 || c.status === 'complete') && (
+                <div className="adv-delivery">
+                  <span><strong>{formatCount(c.delivered)}</strong> play{c.delivered === 1 ? '' : 's'} delivered
+                    {c.forecast ? ` of ${formatCount(c.forecast)} forecast` : ''}</span>
+                  {c.refundHbd > 0 && (
+                    <span className="adv-refund">
+                      {c.refundHbd} HBD owed back for under-delivery
+                      {c.refundStatus === 'pending' ? ' — we will send it' : ''}
+                    </span>
+                  )}
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+const CREATIVE_STATUS = {
+  pending: 'Encoding',
+  review: 'Waiting for review',
+  ready: 'Approved',
+  rejected: 'Not accepted',
+};
+
+/**
+ * Upload the spot. Only appears once an application is approved, because an
+ * unapproved advertiser uploading video is just us hosting files for strangers.
+ *
+ * The upload goes through the ordinary pipeline but is never published to Hive —
+ * it has no post, earns nothing, and appears in no feed. It exists so the spot can
+ * be watched and approved before it ever runs in front of anyone.
+ */
+function CreativePanel({ reference, account, maxSeconds, onCreatives }) {
+  const [creatives, setCreatives] = useState([]);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+  const inputRef = useRef(null);
+
+  const refresh = useCallback(() => {
+    fetchCreatives(reference)
+      .then((r) => { setCreatives(r.creatives || []); onCreatives?.(r.creatives || []); })
+      .catch(() => { /* an unreadable list is not worth an error banner */ });
+  }, [reference, onCreatives]);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  async function onFile(e) {
+    const file = e.target.files && e.target.files[0];
+    if (!file) return;
+    setError(null);
+    setBusy(true);
+    try {
+      if ((file.type || '').startsWith('image/')) {
+        // A still is an asset, not a spot. Said plainly here so nobody uploads a
+        // banner and waits for it to start running.
+        await uploadImageAsset({ file, reference });
+        toast.success('Image saved — it cannot run on its own, but we can build a spot around it');
+      } else {
+        // Checked here as well as on the server so a too-long spot fails in a second
+        // rather than after an upload.
+        const durationSeconds = await readVideoDuration(file);
+        if (durationSeconds && maxSeconds && durationSeconds > maxSeconds) {
+          throw new Error(`That spot is ${durationSeconds} seconds. The slot is ${maxSeconds}.`);
+        }
+        await uploadCreative({ file, account, reference, durationSeconds });
+        toast.success('Spot uploaded — we will review it before it runs');
+      }
+      refresh();
+    } catch (err) {
+      setError(err.message || 'Upload failed');
+    } finally {
+      setBusy(false);
+      if (inputRef.current) inputRef.current.value = '';   // let the same file be retried
+    }
+  }
+
+  return (
+    <div className="adv-creatives">
+      <h3>Your spot</h3>
+      <p className="adv-fine">
+        Upload the video you want to run. It is never posted to Hive and never appears
+        in any feed &mdash; it goes through the same encoder as everything else so it
+        plays cleanly inside a break, and then waits for us to watch it.
+        {maxSeconds ? ` Up to ${maxSeconds} seconds.` : null}
+        {' '}You can also upload stills &mdash; a logo, key art, a frame. An image
+        cannot play inside a break on its own, but we can build a spot around it.
+      </p>
+
+      <div className="adv-upload-row">
+        <input
+          ref={inputRef}
+          id="adv-creative-file"
+          type="file"
+          accept="video/*,image/*"
+          onChange={onFile}
+          disabled={busy}
+          className="adv-visually-hidden"
+        />
+        <label htmlFor="adv-creative-file" className={`adv-primary adv-upload-btn${busy ? ' disabled' : ''}`}>
+          {busy ? 'Uploading…' : 'Upload a video or image'}
+        </label>
+      </div>
+      {error ? <p className="adv-upload-error">{error}</p> : null}
+
+      {creatives.length > 0 && (
+        <ul className="adv-creative-list">
+          {creatives.map((c) => (
+            <li key={c.embedId}>
+              <span className={`adv-creative-status adv-creative-${c.status}`}>
+                {CREATIVE_STATUS[c.status] || c.status}
+              </span>
+              <span className="adv-creative-meta">
+                {c.kind === 'image'
+                  ? 'Image · cannot run on its own'
+                  : (c.durationSeconds ? `${c.durationSeconds}s` : 'duration unknown')}
+                {c.note ? ` · ${c.note}` : ''}
+              </span>
+              {c.kind === 'image' ? (
+                <a href={c.imageUrl} target="_blank" rel="noopener noreferrer">View it</a>
+              ) : c.previewUrl && c.encoded ? (
+                <a href={c.previewUrl} target="_blank" rel="noopener noreferrer">Watch it back</a>
+              ) : <span className="adv-creative-meta">still encoding</span>}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default function Advertise() {
+  const user = useAppStore((s) => s.user);
+  const [form, setForm] = useState(() => ({ ...EMPTY_FORM, hiveAccount: user || '' }));
+  const [submitting, setSubmitting] = useState(false);
+  const [receipt, setReceipt] = useState(null);
+  const [lookupRef, setLookupRef] = useState('');
+  const [lookup, setLookup] = useState(null);
+  const [lookingUp, setLookingUp] = useState(false);
+  // Lifted so the flight panel can offer the spots the creative panel has loaded.
+  const [creativeList, setCreativeList] = useState([]);
+
+  const { data: inventory, isLoading, error } = useQuery({
+    queryKey: ['advertise-inventory'],
+    queryFn: fetchInventory,
+    staleTime: INVENTORY_STALE_MS,
+    retry: false,
+  });
+
+  // The rate card also carries the slot length, which is the limit the upload
+  // control enforces. One source for it rather than a number typed into the UI.
+  const { data: pricing } = useQuery({
+    queryKey: ['advertise-pricing'],
+    queryFn: fetchPricing,
+    staleTime: INVENTORY_STALE_MS,
+    retry: false,
+  });
+
+  // Offer the markets we can actually deliver rather than a full country list —
+  // picking a market with no audience here helps nobody.
+  const marketOptions = useMemo(
+    () => (inventory?.audience?.countries || []).filter((c) => c.code !== 'unknown').slice(0, 12),
+    [inventory],
+  );
+
+  const set = (key) => (e) => setForm((f) => ({ ...f, [key]: e.target.value }));
+
+  const toggleMarket = (code) => setForm((f) => ({
+    ...f,
+    markets: f.markets.includes(code) ? f.markets.filter((m) => m !== code) : [...f.markets, code],
+  }));
+
+  const conceptLeft = 20 - form.creativeConcept.trim().length;
+
+  // Closed testing. Gated here rather than at the route so a typed-in URL is shut
+  // too, not just a link nobody is showing yet. The checker refuses writes from
+  // accounts outside the beta regardless — this is the courtesy, not the lock.
+  //
+  // MUST stay below every hook above: `user` arrives asynchronously, so an early
+  // return placed higher would run a different number of hooks before and after
+  // login and React would tear the component down instead of revealing the page.
+  if (!adsEnabledFor(user)) return <NotFound />;
+
+  async function onSubmit(e) {
+    e.preventDefault();
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      const payload = {
+        hiveAccount: form.hiveAccount.trim().toLowerCase().replace(/^@/, ''),
+        projectName: form.projectName.trim(),
+        website: form.website.trim() || undefined,
+        contact: form.contact.trim(),
+        category: form.category,
+        creativeConcept: form.creativeConcept.trim(),
+        markets: form.markets,
+      };
+      const budget = parseFloat(form.budgetHbd);
+      if (Number.isFinite(budget) && budget > 0) payload.budgetHbd = budget;
+
+      const res = await submitApplication(payload);
+      setReceipt(res);
+      setForm({ ...EMPTY_FORM, hiveAccount: user || '' });
+      toast.success('Application received');
+    } catch (err) {
+      // The backend returns the reference on a duplicate, which is exactly what
+      // someone re-submitting has lost — surface it instead of a bare error.
+      if (err.status === 409 && err.body?.reference) {
+        setReceipt({ reference: err.body.reference, status: err.body.status, message: err.message });
+        toast.info(err.message);
+      } else {
+        toast.error(err.message || 'Could not submit the application');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function onLookup(e) {
+    e.preventDefault();
+    const ref = lookupRef.trim();
+    if (!ref || lookingUp) return;
+    setLookingUp(true);
+    setLookup(null);
+    try {
+      setLookup(await fetchApplication(ref));
+    } catch (err) {
+      toast.error(err.status === 404 ? 'No application with that reference' : (err.message || 'Lookup failed'));
+    } finally {
+      setLookingUp(false);
+    }
+  }
+
+  return (
+    <div className="advertise-page">
+      <header className="adv-header">
+        <MdCampaign className="adv-header-icon" aria-hidden="true" />
+        <div>
+          <h1>Advertise on 3Speak</h1>
+          <p className="adv-lede">
+            Put a short spot inside videos on 3Speak, paid in HBD or HIVE. Every advertiser
+            is reviewed by hand, so tell us who you are and what you want to run.
+          </p>
+        </div>
+      </header>
+
+      <section className="adv-section">
+        <h2>What you would be buying</h2>
+        <InventoryPanel data={inventory} isLoading={isLoading} error={error} />
+      </section>
+
+      <section className="adv-section">
+        <h2>How it is priced</h2>
+        <p>
+          Spots are sold as a flat booking — your spot runs across the network for a fixed
+          period, at a fixed price in HBD. We do not sell by the thousand impressions: at
+          this scale that would mean quoting numbers too small to mean anything, and it
+          rewards padding the count instead of finding the right audience.
+        </p>
+        <p>
+          You are quoted against the forecast above and reported against what actually
+          played. If delivery falls short of the forecast, the difference comes back as
+          credit on your next booking.
+        </p>
+      </section>
+
+      <section className="adv-section">
+        <h2>Apply</h2>
+        {receipt ? (
+          <div className="adv-receipt">
+            <StatusBadge status={receipt.status || 'pending'} />
+            <p>{receipt.message || 'Your application is with us.'}</p>
+            <p className="adv-reference">
+              Your reference: <code>{receipt.reference}</code>
+            </p>
+            <p className="adv-fine">
+              Keep it — it is the only way to check back on this application, and we do not
+              ask for an account name to look one up.
+            </p>
+            <button type="button" className="adv-secondary" onClick={() => setReceipt(null)}>
+              Submit another
+            </button>
+          </div>
+        ) : (
+          <form className="adv-form" onSubmit={onSubmit}>
+            <div className="adv-field">
+              <label htmlFor="adv-account">Hive account</label>
+              <input
+                id="adv-account"
+                value={form.hiveAccount}
+                onChange={set('hiveAccount')}
+                placeholder="yourproject"
+                autoComplete="off"
+                required
+              />
+              <span className="adv-hint">The account the booking will be paid from.</span>
+            </div>
+
+            <div className="adv-field">
+              <label htmlFor="adv-project">Project</label>
+              <input id="adv-project" value={form.projectName} onChange={set('projectName')} required />
+            </div>
+
+            <div className="adv-field">
+              <label htmlFor="adv-website">Website <span className="adv-optional">optional</span></label>
+              <input id="adv-website" type="url" value={form.website} onChange={set('website')} placeholder="https://" />
+            </div>
+
+            <div className="adv-field">
+              <label htmlFor="adv-contact">How we reach you</label>
+              <input
+                id="adv-contact"
+                value={form.contact}
+                onChange={set('contact')}
+                placeholder="Discord, Telegram, email — whatever you actually read"
+                required
+              />
+            </div>
+
+            <div className="adv-field">
+              <label htmlFor="adv-category">Category</label>
+              <select id="adv-category" value={form.category} onChange={set('category')} required>
+                <option value="" disabled>Choose one</option>
+                {AD_CATEGORIES.map((c) => <option key={c.id} value={c.id}>{c.label}</option>)}
+              </select>
+            </div>
+
+            <div className="adv-field">
+              <label htmlFor="adv-budget">Budget in HBD <span className="adv-optional">optional</span></label>
+              <input
+                id="adv-budget"
+                type="number"
+                min="0"
+                step="1"
+                inputMode="decimal"
+                value={form.budgetHbd}
+                onChange={set('budgetHbd')}
+                placeholder="250"
+              />
+              <span className="adv-hint">A rough figure is enough — it tells us which slots to quote.</span>
+            </div>
+
+            {marketOptions.length > 0 && (
+              <div className="adv-field adv-field-wide">
+                <span className="adv-label">Markets <span className="adv-optional">optional</span></span>
+                <div className="adv-chips">
+                  {marketOptions.map((c) => (
+                    <button
+                      key={c.code}
+                      type="button"
+                      className={`adv-chip${form.markets.includes(c.code) ? ' selected' : ''}`}
+                      aria-pressed={form.markets.includes(c.code)}
+                      onClick={() => toggleMarket(c.code)}
+                    >
+                      {countryName(c.code)} <span className="adv-chip-share">{c.sharePct}%</span>
+                    </button>
+                  ))}
+                </div>
+                <span className="adv-hint">Leave all unselected to run everywhere.</span>
+              </div>
+            )}
+
+            <div className="adv-field adv-field-wide">
+              <label htmlFor="adv-concept">What do you want to run?</label>
+              <textarea
+                id="adv-concept"
+                rows={5}
+                value={form.creativeConcept}
+                onChange={set('creativeConcept')}
+                placeholder="The spot itself, who it is aimed at, and roughly when you would want it live."
+                required
+              />
+              <span className="adv-hint">
+                {conceptLeft > 0 ? `${conceptLeft} more characters` : 'Enough to go on, thanks'}
+              </span>
+            </div>
+
+            <div className="adv-actions">
+              <button type="submit" className="adv-primary" disabled={submitting}>
+                {submitting ? 'Sending…' : 'Send application'}
+              </button>
+              <span className="adv-fine">Reviewed by a person. We do not accept everyone.</span>
+            </div>
+          </form>
+        )}
+      </section>
+
+      <section className="adv-section">
+        <h2>Check an application</h2>
+        <form className="adv-lookup" onSubmit={onLookup}>
+          <label className="adv-visually-hidden" htmlFor="adv-ref">Application reference</label>
+          <input
+            id="adv-ref"
+            value={lookupRef}
+            onChange={(e) => setLookupRef(e.target.value)}
+            placeholder="Your reference"
+            autoComplete="off"
+          />
+          <button type="submit" className="adv-secondary" disabled={lookingUp || !lookupRef.trim()}>
+            {lookingUp ? 'Checking…' : 'Check'}
+          </button>
+        </form>
+        {lookup && (
+          <div className="adv-lookup-result">
+            <StatusBadge status={lookup.status} />
+            <p><strong>{lookup.projectName}</strong> · @{lookup.hiveAccount}</p>
+            {lookup.note ? <p className="adv-lookup-note">{lookup.note}</p> : null}
+            {lookup.status === 'approved' && (
+              <>
+                <CreativePanel
+                  reference={lookupRef.trim()}
+                  account={lookup.hiveAccount}
+                  maxSeconds={pricing?.maxCreativeSeconds}
+                  onCreatives={setCreativeList}
+                />
+                <CampaignPanel
+                  reference={lookupRef.trim()}
+                  pricing={pricing}
+                  creatives={creativeList}
+                />
+              </>
+            )}
+          </div>
+        )}
+      </section>
+
+      <section className="adv-section adv-creators">
+        <h2>If you are a creator</h2>
+        <p>
+          Spots run across the network by default, and a share of what they earn goes to the
+          creator whose video carried them and to the community it was posted in. You can turn
+          ads off for your own videos at any time — a video with ads switched off is removed
+          from the availability figures above as well, so nothing is sold that we have promised
+          not to use.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/src/page/Advertise.scss
+++ b/src/page/Advertise.scss
@@ -1,0 +1,727 @@
+@use "../mixins.scss" as mix;
+
+.advertise-page {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 20px 16px 80px;
+  color: var(--text-primary);
+
+  @include mix.respond(phone) {
+    padding: 12px 12px 100px;
+  }
+
+  /* ── header ─────────────────────────────────────────────── */
+  .adv-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 14px;
+    margin-bottom: 28px;
+
+    .adv-header-icon {
+      flex-shrink: 0;
+      font-size: 38px;
+      color: var(--accent-primary);
+
+      @include mix.respond(phone) { font-size: 30px; }
+    }
+
+    h1 {
+      margin: 0 0 6px;
+      font-size: 26px;
+      font-weight: 700;
+
+      @include mix.respond(phone) { font-size: 21px; }
+    }
+  }
+
+  .adv-lede {
+    margin: 0;
+    color: var(--text-secondary);
+    line-height: 1.55;
+    max-width: 60ch;
+  }
+
+  /* ── sections ───────────────────────────────────────────── */
+  .adv-section {
+    margin-bottom: 40px;
+
+    h2 {
+      margin: 0 0 14px;
+      font-size: 18px;
+      font-weight: 700;
+    }
+
+    > p {
+      margin: 0 0 12px;
+      color: var(--text-secondary);
+      line-height: 1.6;
+      max-width: 66ch;
+    }
+  }
+
+  .adv-fine {
+    margin: 10px 0 0;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--text-muted);
+    max-width: 66ch;
+  }
+
+  .adv-panel {
+    padding: 18px;
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    background: var(--card-bg);
+  }
+
+  .adv-panel-muted {
+    color: var(--text-muted);
+    font-size: 14px;
+    line-height: 1.5;
+  }
+
+  /* ── inventory ──────────────────────────────────────────── */
+  .adv-inventory {
+    display: flex;
+    flex-direction: column;
+    gap: 26px;
+  }
+
+  .adv-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 12px;
+  }
+
+  .adv-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 16px 18px;
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    background: var(--card-bg);
+
+    .adv-stat-value {
+      font-size: 28px;
+      font-weight: 700;
+      line-height: 1.1;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .adv-stat-label {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text-secondary);
+    }
+
+    .adv-stat-note {
+      font-size: 12px;
+      color: var(--text-muted);
+    }
+  }
+
+  .adv-slots h3,
+  .adv-countries h3 {
+    margin: 0 0 10px;
+    font-size: 15px;
+    font-weight: 700;
+  }
+
+  .adv-table-wrap {
+    overflow-x: auto;
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    background: var(--card-bg);
+  }
+
+  .adv-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14px;
+
+    th,
+    td {
+      text-align: left;
+      padding: 11px 14px;
+      border-bottom: 1px solid var(--divider);
+      white-space: nowrap;
+    }
+
+    th {
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--text-muted);
+    }
+
+    .num {
+      text-align: right;
+      font-variant-numeric: tabular-nums;
+    }
+
+    tbody tr:last-child td { border-bottom: none; }
+
+    .adv-row-muted td {
+      color: var(--text-muted);
+    }
+  }
+
+  .adv-tag {
+    display: inline-block;
+    margin-left: 8px;
+    padding: 1px 7px;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    font-size: 11px;
+    text-transform: none;
+    letter-spacing: 0;
+    color: var(--text-muted);
+  }
+
+  .adv-country-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+
+    li {
+      display: grid;
+      grid-template-columns: minmax(90px, 150px) 1fr 48px;
+      align-items: center;
+      gap: 12px;
+      font-size: 14px;
+
+      @include mix.respond(phone) {
+        grid-template-columns: minmax(80px, 110px) 1fr 42px;
+        gap: 8px;
+        font-size: 13px;
+      }
+    }
+  }
+
+  .adv-country-name {
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .adv-country-bar {
+    display: block;
+    height: 8px;
+    border-radius: 999px;
+    background: var(--bg-tertiary);
+    overflow: hidden;
+
+    span {
+      display: block;
+      height: 100%;
+      border-radius: 999px;
+      background: var(--accent-primary);
+    }
+  }
+
+  .adv-country-share {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-muted);
+  }
+
+  .adv-note {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    margin: 0;
+    padding: 14px 16px;
+    border-left: 3px solid var(--accent-primary);
+    border-radius: 0 8px 8px 0;
+    background: var(--bg-secondary);
+    font-size: 13px;
+    line-height: 1.55;
+    color: var(--text-secondary);
+
+    svg {
+      flex-shrink: 0;
+      margin-top: 2px;
+      font-size: 17px;
+      color: var(--accent-primary);
+    }
+
+    strong { color: var(--text-primary); }
+  }
+
+  /* ── form ───────────────────────────────────────────────── */
+  .adv-form {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
+
+    @include mix.respond(phone) {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  }
+
+  .adv-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+
+    label,
+    .adv-label {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    input,
+    select,
+    textarea {
+      width: 100%;
+      padding: 10px 12px;
+      border: 1px solid var(--input-border);
+      border-radius: 8px;
+      background: var(--input-bg);
+      color: var(--text-primary);
+      font-family: inherit;
+      font-size: 14px;
+
+      &:focus {
+        outline: none;
+        border-color: var(--input-focus);
+      }
+
+      &:focus-visible {
+        outline: 2px solid var(--accent-primary);
+        outline-offset: 1px;
+      }
+    }
+
+    textarea {
+      resize: vertical;
+      line-height: 1.55;
+    }
+  }
+
+  .adv-field-wide {
+    grid-column: 1 / -1;
+  }
+
+  .adv-optional {
+    font-weight: 400;
+    color: var(--text-muted);
+  }
+
+  .adv-hint {
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.45;
+  }
+
+  .adv-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .adv-chip {
+    padding: 6px 12px;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+    font-size: 13px;
+    cursor: pointer;
+
+    &:hover { background: var(--bg-hover); }
+
+    &:focus-visible {
+      outline: 2px solid var(--accent-primary);
+      outline-offset: 2px;
+    }
+
+    &.selected {
+      border-color: var(--accent-primary);
+      background: var(--accent-light);
+      color: var(--text-primary);
+    }
+
+    .adv-chip-share {
+      margin-left: 6px;
+      font-variant-numeric: tabular-nums;
+      color: var(--text-muted);
+    }
+  }
+
+  .adv-actions {
+    grid-column: 1 / -1;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 14px;
+
+    .adv-fine { margin: 0; }
+  }
+
+  .adv-primary,
+  .adv-secondary {
+    padding: 10px 20px;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+
+    &:focus-visible {
+      outline: 2px solid var(--accent-primary);
+      outline-offset: 2px;
+    }
+
+    &:disabled {
+      opacity: 0.55;
+      cursor: not-allowed;
+    }
+  }
+
+  .adv-primary {
+    border: none;
+    background: var(--accent-primary);
+    color: var(--text-inverse);
+
+    &:hover:not(:disabled) { background: var(--accent-hover); }
+  }
+
+  .adv-secondary {
+    border: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--text-primary);
+
+    &:hover:not(:disabled) { background: var(--bg-hover); }
+  }
+
+  /* ── receipt + status ───────────────────────────────────── */
+  .adv-receipt {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 20px;
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    background: var(--card-bg);
+
+    p { margin: 0; color: var(--text-secondary); line-height: 1.55; }
+  }
+
+  .adv-reference code {
+    padding: 2px 8px;
+    border-radius: 6px;
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    font-size: 14px;
+    user-select: all;
+  }
+
+  .adv-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px;
+    border-radius: 999px;
+    font-size: 13px;
+    font-weight: 600;
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+
+    svg { font-size: 16px; }
+  }
+
+  .adv-status-approved { color: #1e8f5e; }
+  .adv-status-rejected { color: #c0392b; }
+
+  /* ── lookup ─────────────────────────────────────────────── */
+  .adv-lookup {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+
+    input {
+      flex: 1 1 220px;
+      min-width: 0;
+      padding: 10px 12px;
+      border: 1px solid var(--input-border);
+      border-radius: 8px;
+      background: var(--input-bg);
+      color: var(--text-primary);
+      font-family: inherit;
+      font-size: 14px;
+
+      &:focus-visible {
+        outline: 2px solid var(--accent-primary);
+        outline-offset: 1px;
+      }
+    }
+  }
+
+  .adv-lookup-result {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    margin-top: 14px;
+    padding: 16px 18px;
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    background: var(--card-bg);
+
+    p { margin: 0; color: var(--text-secondary); }
+  }
+
+  .adv-lookup-note {
+    font-size: 14px;
+    line-height: 1.55;
+  }
+
+  /* ── creators ───────────────────────────────────────────── */
+  .adv-creators {
+    padding: 18px 20px;
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    background: var(--bg-secondary);
+
+    h2 { font-size: 16px; }
+    > p:last-child { margin-bottom: 0; }
+  }
+
+  .adv-visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  /* ── the advertiser's spot ──────────────────────────────── */
+  .adv-creatives {
+    width: 100%;
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: 1px solid var(--border-color);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+
+    h3 { margin: 0; font-size: 15px; font-weight: 700; }
+    .adv-fine { margin: 0; }
+  }
+
+  .adv-upload-row { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+
+  .adv-upload-btn {
+    display: inline-block;
+    cursor: pointer;
+    border: none;
+
+    &.disabled { opacity: 0.55; cursor: not-allowed; }
+  }
+
+  .adv-upload-error {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.45;
+    color: var(--accent-primary);
+  }
+
+  .adv-creative-list {
+    list-style: none;
+    margin: 4px 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+
+    li {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 10px;
+      padding: 10px 12px;
+      border: 1px solid var(--border-color);
+      border-radius: 8px;
+      background: var(--bg-secondary);
+      font-size: 13px;
+    }
+  }
+
+  .adv-creative-status {
+    padding: 2px 9px;
+    border-radius: 999px;
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+
+  .adv-creative-ready { color: #1e8f5e; }
+  .adv-creative-rejected { color: #c0392b; }
+
+  .adv-creative-meta { color: var(--text-muted); }
+
+
+  /* ── flights ────────────────────────────────────────────── */
+  .adv-campaigns {
+    width: 100%;
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: 1px solid var(--border-color);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+
+    h3 { margin: 0; font-size: 15px; font-weight: 700; }
+  }
+
+  .adv-book {
+    display: flex;
+    align-items: flex-end;
+    flex-wrap: wrap;
+    gap: 12px;
+
+    .adv-field { flex: 0 1 150px; }
+  }
+
+  .adv-book-total {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 13px;
+    color: var(--text-secondary);
+  }
+
+  .adv-campaign-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+
+    li {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      padding: 14px;
+      border: 1px solid var(--border-color);
+      border-radius: 10px;
+      background: var(--bg-secondary);
+      font-size: 13px;
+    }
+  }
+
+  .adv-campaign-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .adv-campaign-name { font-weight: 700; color: var(--text-primary); }
+
+  .adv-campaign-blocked {
+    align-self: flex-start;
+    padding: 3px 9px;
+    border-radius: 6px;
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    font-size: 12px;
+  }
+
+  .adv-pay {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    padding-top: 8px;
+    border-top: 1px dashed var(--border-color);
+
+    code {
+      padding: 1px 6px;
+      border-radius: 4px;
+      background: var(--bg-tertiary);
+      user-select: all;
+    }
+
+    select {
+      padding: 7px 10px;
+      border: 1px solid var(--input-border);
+      border-radius: 8px;
+      background: var(--input-bg);
+      color: var(--text-primary);
+      font-family: inherit;
+      font-size: 13px;
+    }
+  }
+
+  .adv-delivery {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding-top: 8px;
+    border-top: 1px dashed var(--border-color);
+    color: var(--text-secondary);
+  }
+
+  .adv-refund { color: var(--accent-primary); font-weight: 600; }
+
+
+  /* The closed-trial notice sits above the figures it qualifies. */
+  .adv-note-trial {
+    order: -1;
+    border-left-color: var(--text-muted);
+  }
+
+
+  /* "Have us make the video" — a one-off add-on to the flight. */
+  .adv-production {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px 14px;
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    background: var(--bg-secondary);
+  }
+
+  .adv-check {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--text-secondary);
+    cursor: pointer;
+
+    input {
+      width: 16px;
+      height: 16px;
+      margin-top: 1px;
+      flex: none;
+      accent-color: var(--accent-primary);
+      cursor: pointer;
+    }
+
+    strong { color: var(--text-primary); }
+  }
+
+}

--- a/src/page/ProfilePage.jsx
+++ b/src/page/ProfilePage.jsx
@@ -34,7 +34,6 @@ import { fetchScheduledPosts, normalizeScheduledForCard } from "../utils/schedul
 import { LineSpinner, Quantum } from "ldrs/react";
 import "ldrs/react/Quantum.css";
 
-import icon from "../../public/images/stack.png";
 import { UPLOAD_TOKEN, UPLOAD_URL } from "../utils/config";
 import "./ProfilePage.scss";
 import checker from "../../public/images/checker.png";
@@ -49,6 +48,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import ProfileHeader from "../components/ProfileHeader/ProfileHeader";
 import ProfileStats from "../components/ProfileHeader/ProfileStats";
 import ProfileOverview from "../components/Userprofilepage/ProfileOverview";
+import ProfileEmptyState from "../components/Userprofilepage/ProfileEmptyState";
 import ProfileEditModal from "../components/WelcomePrompt/ProfileEditModal";
 import { FiEdit2 } from "react-icons/fi";
 
@@ -673,10 +673,7 @@ function ProfilePage() {
           isLoading ? (
             <BarLoader />
           ) : videoListItems.length === 0 ? (
-            <div className="empty-wrap">
-              <img src={icon} alt="empty" />
-              <span>No Video Data Available</span>
-            </div>
+            <ProfileEmptyState kind="video" isOwnProfile username={user} />
           ) : (
             <Card3 videos={videoListItems} loading={isFetchingNextPage} getContentForVideo={getContentForVideo} isWatched={isWatched} getViewCount={getViewCount} />
           )
@@ -684,10 +681,7 @@ function ProfilePage() {
           isShortsLoading ? (
             <BarLoader />
           ) : shortsVideos.length === 0 ? (
-            <div className="empty-wrap">
-              <img src={icon} alt="empty" />
-              <span>No Shorts Available</span>
-            </div>
+            <ProfileEmptyState kind="shorts" isOwnProfile username={user} />
           ) : (
             <Card3 videos={shortsVideos} loading={isFetchingNextShortsPage} linkPrefix="/shorts" linkQuery={`&user=${user}`} getViewCount={getViewCount} shortsGrid />
           )
@@ -698,7 +692,7 @@ function ProfilePage() {
             <Card3 videos={gatedVideos} getViewCount={getViewCount} />
           )
         ) : show === "audio" ? (
-          <UserAudioList user={user} />
+          <UserAudioList user={user} isOwnProfile />
         ) : show === "streams" ? (
           <ProfileStreams user={user} getViewCount={getViewCount} />
         ) : show === "community" ? (
@@ -732,13 +726,12 @@ function ProfilePage() {
                 </div>
                 {/* Regular playlists (excluding Watch Later) */}
                 {playlists.filter(p => p.name !== WATCH_LATER_NAME).length === 0 && watchedCount === 0 && !playlists.find(p => p.name === WATCH_LATER_NAME) ? (
-                  <div className="empty-wrap">
-                    <img src={icon} alt="empty" />
-                    <span>No Playlists Yet</span>
-                    <button className="create-playlist-btn-empty" onClick={() => setShowCreateModal(true)}>
-                      <IoMdAdd /> Create Your First Playlist
-                    </button>
-                  </div>
+                  <ProfileEmptyState
+                    kind="playlists"
+                    isOwnProfile
+                    username={user}
+                    onAction={() => setShowCreateModal(true)}
+                  />
                 ) : (
                   <PlaylistCard playlists={playlists.filter(p => p.name !== WATCH_LATER_NAME)} loading={playlistsLoading} showPrivacyBadge={true} />
                 )}

--- a/src/page/Short.jsx
+++ b/src/page/Short.jsx
@@ -162,6 +162,13 @@ function renderCaption(text) {
 
 // Track watch DURATION for a short (non-polluting — never increments the view
 // counter). On first play we open a server-measured session
+// NO ADS ON SHORTS, deliberately. This player never asks /m/session, so no spot is
+// ever stitched into a short. The only slot that could fit is pre-roll, and putting
+// a 15-second ad in front of a 12-second short is the same mistake as pre-rolling a
+// video half the audience abandons inside 15 seconds — it would deliver an
+// impression to someone who never wanted the content. If shorts ever carry ads it
+// needs its own slot type, not the mid-roll rules borrowed.
+//
 // (POST /api/watch/start); the timeupdate handler heartbeats while it plays
 // (/api/watch/beat). The backend records watched seconds + % with the viewer IP
 // into `view-durations`. Uses the embed *asset* permlink (video.permlink) — the
@@ -2543,10 +2550,10 @@ const VideoShort = () => {
       <Helmet>
         <title>
           {currentVideo?.title
-            ? `${currentVideo.title} | 3Speak`
+            ? `3S | ${currentVideo.title}`
             : currentVideo?.author
-              ? `Short by @${currentVideo.author} | 3Speak`
-              : 'Shorts | 3Speak'}
+              ? `3S | Short by @${currentVideo.author}`
+              : '3S | Shorts'}
         </title>
       </Helmet>
 

--- a/src/page/Short.jsx
+++ b/src/page/Short.jsx
@@ -364,6 +364,12 @@ const VideoShort = () => {
   const recordedShortsViewsRef = useRef(new Set()); // author/permlink already view-counted
   // Active short's watch-duration session (server-measured heartbeat, non-polluting).
   const shortWatchRef = useRef({ sid: null, token: null, beatMs: 5000, lastBeatAt: 0, key: null, starting: false });
+  // Watch time only counts while this tab is the one in front. A short left
+  // playing in a background tab used to beat exactly like a watched one. There
+  // is no long-form exception here (the one in useWatchDuration covers videos
+  // past 20 minutes, where background listening is the actual use case) — a
+  // short playing out of sight is a forgotten tab, not an audience.
+  const shortVisibleRef = useRef(typeof document === 'undefined' || document.visibilityState !== 'hidden');
   const videoContainerRef = useRef(null);
   const playerRef = useRef(null); // Single persistent SDK Player instance
   const videoElRef = useRef(null); // Single persistent <video> element ref
@@ -487,6 +493,29 @@ const VideoShort = () => {
       return navigator.userActivation.hasBeenActive;
     }
     return userGestureRef.current;
+  }, []);
+
+  // Stop crediting watch time while the tab is in the background, and flush what
+  // was watched up to the moment it went away.
+  useEffect(() => {
+    const onVisibility = () => {
+      const hidden = document.visibilityState === 'hidden';
+      shortVisibleRef.current = !hidden;
+      if (hidden) shortWatchBeat(shortWatchRef, currentTimeRef.current);
+      // Back in front: re-anchor the throttle so the next beat hands the server
+      // no gap to credit for time nobody was watching.
+      else shortWatchRef.current.lastBeatAt = Date.now();
+    };
+    const onPageHide = () => {
+      shortVisibleRef.current = false;
+      shortWatchBeat(shortWatchRef, currentTimeRef.current);
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('pagehide', onPageHide);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('pagehide', onPageHide);
+    };
   }, []);
 
   useEffect(() => {
@@ -2277,8 +2306,10 @@ const VideoShort = () => {
       // Watch-duration heartbeat while genuinely playing (throttled to beatMs;
       // the server measures the real wall-clock gap between beats + which part
       // of the timeline was watched, for the heatmap).
+      // The player keeps firing these while the tab is hidden, so visibility is
+      // checked here rather than inferred from playback.
       const W = shortWatchRef.current;
-      if (!paused && W.sid && Date.now() - W.lastBeatAt >= W.beatMs) {
+      if (!paused && shortVisibleRef.current && W.sid && Date.now() - W.lastBeatAt >= W.beatMs) {
         shortWatchBeat(shortWatchRef, currentTime);
       }
 

--- a/src/page/Watch.jsx
+++ b/src/page/Watch.jsx
@@ -27,6 +27,7 @@ import { MdVideocam, MdChatBubble } from 'react-icons/md';
 import { batchGetReputations, LOW_REP_THRESHOLD } from '../utils/reputation';
 import { batchCheckHidden, isCreatorHidden } from '../utils/hiddenCreators';
 import { usePlayer } from '@mantequilla-soft/3speak-player/react';
+import { createAdBreak } from '../lib/adBreak';
 import { useGatedPlayback } from '../hooks/useGatedPlayback';
 import GuestListEditor from '../components/gated/GuestListEditor';
 import { ThreeSpeakApi } from '@mantequilla-soft/3speak-player';
@@ -414,12 +415,29 @@ function Watch({ v2 = false }) {
   // is the non-polluting path (mirrors the player's /play route), so preview
   // playback never inflates production view counts. See useWatchDuration.
   const sdkApiRef = useRef(new ThreeSpeakApi(getPlayerUrl()));
+  // Server-side ad insertion. Holds the mapping from the player's (stitched)
+  // timeline back to content time — see lib/adBreak.js for why that matters.
+  const adBreakRef = useRef(createAdBreak());
+  const [sponsorVisible, setSponsorVisible] = useState(false);
+  // Disclosure. Required by EU and US advertising rules, and driven off the same
+  // clock the tracker reads so it can never disagree with what is on screen.
+  useEffect(() => {
+    const ab = adBreakRef.current;
+    if (!ab.active) { if (sponsorVisible) setSponsorVisible(false); return; }
+    const inside = ab.isInside(Number(playerState?.currentTime) || 0);
+    if (inside !== sponsorVisible) setSponsorVisible(inside);
+  }, [playerState?.currentTime, sponsorVisible]);
+
   useWatchDuration({
     api: sdkApiRef.current,
     author,
     permlink,
     playerState,
     enabled: !scheduled,
+    // Report CONTENT time. Without this a stitched spot's seconds are credited as
+    // watch time on the creator's video.
+    mapPosition: (t) => adBreakRef.current.contentTime(t),
+    premium: adBreakRef.current.isPremiumViewer,
   });
 
   // Also record a normal view once playback actually starts (increments the view
@@ -596,24 +614,62 @@ function Watch({ v2 = false }) {
       return () => { active = false; };
     }
 
-    loadVideo(playerLoadId).catch(err => {
-      // A live OpenPods post has no VOD source to resolve — the live player
-      // handles playback separately, so a load failure here is expected. Don't
-      // show "unavailable" or report the stream post as a dead video.
-      if (isLiveRef.current) return;
-      console.error('[Watch] Failed to load video:', err);
-      // The player backend couldn't resolve ANY playable stream — e.g. /api/embed
-      // and /api/watch both 404 for a very old post whose media isn't indexed. No
-      // hls source is ever created, so the player's fatal onError never fires — show
-      // the "no longer available" hint from here instead of leaving a blank player.
-      // `active` guards against a stale load rejecting after we've moved to another video.
-      if (active) setPlaybackFailed(true);
-      // Also tell the checker (as the fatal path does): a post whose stream can't be
-      // resolved is dead weight in feeds. The checker re-decides from its OWN doc — it
-      // only shadow-bans a settled, published, no-stream archive video, never a
-      // still-encoding one — so this sloppy client report is safe.
-      reportVideoUnavailable(author, permlink, videoDetails?.playUrl || null);
-    });
+    // Ask whether this playback carries a sponsor spot. The source is resolved
+    // here rather than letting the SDK do it, because the stitcher needs the
+    // content manifest URL to splice against. Anything short of a clear yes falls
+    // through to the ordinary path — no ad is always better than no video.
+    //
+    // Gated (paid) videos never reach this: they load on their own branch above.
+    // Someone who paid for content should no more see an ad than a Pro subscriber.
+    const viewer = (useAppStore.getState().user || '').toLowerCase() || null;
+    adBreakRef.current.reset();
+    setSponsorVisible(false);
+    (async () => {
+      try {
+        const source = await sdkApiRef.current.fetchSource(author, permlink);
+        if (!active || !source?.url) throw new Error('no source');
+        const meta = await resolveVideoMeta(sdkApiRef.current, author, permlink);
+        const spot = await adBreakRef.current.request({
+          owner: meta?.owner || author,
+          permlink: meta?.permlink || permlink,
+          viewer,
+          manifestUrl: source.url,
+        });
+        if (!active) return;
+        if (spot) {
+          // Original stays as the next fallback, so a stitcher outage degrades to
+          // ordinary playback rather than a dead player.
+          await loadVideo({
+            url: spot.manifestUrl,
+            fallbacks: [source.url, ...(source.fallbacks || [])],
+            poster: source.poster,
+          });
+          adBreakRef.current.resolve();
+          return;
+        }
+      } catch { /* no spot, or we could not resolve one — play it plainly */ }
+      if (!active) return;
+
+      // The ordinary path, unchanged in behaviour: let the SDK resolve and load.
+      loadVideo(playerLoadId).catch(err => {
+        // A live OpenPods post has no VOD source to resolve — the live player
+        // handles playback separately, so a load failure here is expected. Don't
+        // show "unavailable" or report the stream post as a dead video.
+        if (isLiveRef.current) return;
+        console.error('[Watch] Failed to load video:', err);
+        // The player backend couldn't resolve ANY playable stream — e.g. /api/embed
+        // and /api/watch both 404 for a very old post whose media isn't indexed. No
+        // hls source is ever created, so the player's fatal onError never fires — show
+        // the "no longer available" hint from here instead of leaving a blank player.
+        // `active` guards against a stale load rejecting after we've moved on.
+        if (active) setPlaybackFailed(true);
+        // Also tell the checker (as the fatal path does): a post whose stream can't be
+        // resolved is dead weight in feeds. The checker re-decides from its OWN doc — it
+        // only shadow-bans a settled, published, no-stream archive video, never a
+        // still-encoding one — so this sloppy client report is safe.
+        reportVideoUnavailable(author, permlink, videoDetails?.playUrl || null);
+      });
+    })();
     return () => { active = false; };
     // `playbackAttempt` is in the deps purely so "Try again" re-runs this load.
     // `gatedTick` re-runs this load once the gate has answered. The gate state
@@ -1616,6 +1672,11 @@ function Watch({ v2 = false }) {
         onRetryPlayback={retryPlayback}
         mediaLoading={!isLive && mediaLoading}
         videoRef={videoRef}
+        sponsorLabel={sponsorVisible ? (
+          adBreakRef.current.info?.advertiser
+            ? `${adBreakRef.current.info.label} · ${adBreakRef.current.info.advertiser}`
+            : (adBreakRef.current.info?.label || 'Sponsored')
+        ) : null}
         wrapperRef={wrapperRef}
         playlistData={showPlaylist ? playlistData : null}
         onClosePlaylist={() => setShowPlaylist(false)}

--- a/src/page/Watch.jsx
+++ b/src/page/Watch.jsx
@@ -22,6 +22,7 @@ import { useGridColumns, useShortsPerRow } from '../hooks/useGridMetrics';
 import { useStreamChatMirror } from '../hooks/useStreamChatMirror';
 import { getFeedSeed } from '../utils/feedSeed';
 import ReactionPlayer from '../components/ReactionPlayer/ReactionPlayer';
+import WatchTabs from '../components/playVideo/WatchTabs';
 import { MdVideocam, MdChatBubble } from 'react-icons/md';
 import { batchGetReputations, LOW_REP_THRESHOLD } from '../utils/reputation';
 import { batchCheckHidden, isCreatorHidden } from '../utils/hiddenCreators';
@@ -1764,28 +1765,43 @@ function Watch({ v2 = false }) {
             <div className="live-chat-column__body" ref={setLiveChatSlot} />
           </div>
         )}
-        {!isLive && isReactionPlayerVisible && reactions.length > 0 && (
-          <ReactionPlayer
-            reactions={reactions}
-            selectedIndex={selectedReactionIndex}
-            onSelectReaction={handleSelectReaction}
-            onClose={() => setReactionsVisible(false)}
-            size={reactionSize}
+        {/* Reactions and the transcript share the top of this column. With no
+            transcript to offer (or on a phone, where it just gets in the way)
+            this renders the reaction panel alone, exactly as it did before. */}
+        {!isLive && (
+          <WatchTabs
+            author={author}
+            permlink={permlink}
             currentTime={playerState.currentTime}
-            duration={playerState.duration}
-            mainIsPlaying={!playerState.paused}
-            onReactionPlay={pause}
+            onSeek={seek}
+            reactionPanel={
+              <>
+                {isReactionPlayerVisible && reactions.length > 0 && (
+                  <ReactionPlayer
+                    reactions={reactions}
+                    selectedIndex={selectedReactionIndex}
+                    onSelectReaction={handleSelectReaction}
+                    onClose={() => setReactionsVisible(false)}
+                    size={reactionSize}
+                    currentTime={playerState.currentTime}
+                    duration={playerState.duration}
+                    mainIsPlaying={!playerState.paused}
+                    onReactionPlay={pause}
+                  />
+                )}
+                {!isReactionPlayerVisible && reactions.length > 0 && (
+                  <button className="show-reactions-btn" onClick={() => setReactionsVisible(true)}>
+                    Show Reactions ({reactionCountLabel})
+                  </button>
+                )}
+                {reactions.length === 0 && (
+                  <button className="show-reactions-btn" onClick={handleAddReaction}>
+                    Add Reaction
+                  </button>
+                )}
+              </>
+            }
           />
-        )}
-        {!isLive && !isReactionPlayerVisible && reactions.length > 0 && (
-          <button className="show-reactions-btn" onClick={() => setReactionsVisible(true)}>
-            Show Reactions ({reactionCountLabel})
-          </button>
-        )}
-        {!isLive && reactions.length === 0 && (
-          <button className="show-reactions-btn" onClick={handleAddReaction}>
-            Add Reaction
-          </button>
         )}
 
         {suggestedVideos.length > 0 && (

--- a/src/sw.js
+++ b/src/sw.js
@@ -9,6 +9,58 @@ import { createHandlerBoundToURL } from 'workbox-precaching';
 self.skipWaiting();
 clientsClaim();
 
+// ── Web push ──
+// FIRST, deliberately. An exception anywhere during evaluation kills the whole
+// worker — the registration appears for a moment and then vanishes — and every
+// line below this one is caching, which is a nice-to-have. Notifications are
+// not: if Workbox fails to set itself up in some browser, push must still work.
+// The caching block is wrapped for the same reason.
+// The payload is written by the checker (services/pushNotify.js): a title, a
+// line of body, the path to open, and a tag. The tag is what stops the same
+// video buzzing twice on one device — the browser replaces a notification that
+// already carries it rather than stacking another.
+self.addEventListener('push', (event) => {
+  let data = {};
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch {
+    // A push with a non-JSON body is not ours; show nothing rather than a
+    // notification full of garbage.
+    return;
+  }
+  if (!data.title) return;
+
+  event.waitUntil(
+    self.registration.showNotification(data.title, {
+      body: data.body || '',
+      icon: '/3speak.jpeg',
+      badge: '/3speak.jpeg',
+      tag: data.tag || undefined,
+      data: { url: data.url || '/' },
+    }),
+  );
+});
+
+// Clicking one focuses a tab that already has 3Speak open and navigates it,
+// rather than piling up a new tab every time.
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const target = (event.notification.data && event.notification.data.url) || '/';
+  event.waitUntil((async () => {
+    const all = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+    for (const client of all) {
+      if (new URL(client.url).origin === self.location.origin) {
+        await client.focus();
+        if ('navigate' in client) await client.navigate(target);
+        return;
+      }
+    }
+    await self.clients.openWindow(target);
+  })());
+});
+
+
+try {
 // Precache all assets injected by vite-plugin-pwa
 precacheAndRoute(self.__WB_MANIFEST);
 cleanupOutdatedCaches();
@@ -17,12 +69,21 @@ cleanupOutdatedCaches();
 // the cached SPA shell: the hivesigner callback, and the server-rendered Spotlight
 // link pages (/links/<user> and legacy /@<user>/links) which are standalone HTML
 // from the API, NOT part of the React app.
-const navHandler = createHandlerBoundToURL('/index.html');
-registerRoute(
-  new NavigationRoute(navHandler, {
-    denylist: [/^\/hivesigner\.html/, /^\/links\//, /^\/@[^/]+\/links\/?$/],
-  })
-);
+// createHandlerBoundToURL THROWS when its URL isn't in the precache manifest,
+// and in dev that manifest is empty (`precacheAndRoute([])`) — which killed the
+// whole worker at evaluation time, so nothing registered and push had no
+// registration to attach to. There is no SPA shell to fall back to in dev
+// anyway: the dev server serves it live.
+try {
+  const navHandler = createHandlerBoundToURL('/index.html');
+  registerRoute(
+    new NavigationRoute(navHandler, {
+      denylist: [/^\/hivesigner\.html/, /^\/links\//, /^\/@[^/]+\/links\/?$/],
+    })
+  );
+} catch {
+  // Dev, or a build with no precached shell: skip the fallback, keep the worker.
+}
 
 // Runtime cache: JS, CSS, fonts
 registerRoute(
@@ -72,3 +133,8 @@ const shareTargetRoute = new Route(
   'POST'
 );
 registerRoute(shareTargetRoute);
+
+} catch (err) {
+  // Offline caching is gone for this session; the worker (and push) survive.
+  console.error('[sw] caching setup failed, continuing without it:', err);
+}

--- a/src/utils/checkLatestVersion.js
+++ b/src/utils/checkLatestVersion.js
@@ -58,7 +58,12 @@ export async function reloadForUpdate() {
     }
     if ("serviceWorker" in navigator) {
       const regs = await navigator.serviceWorker.getRegistrations();
-      await Promise.all(regs.map((r) => r.unregister()));
+      // Same exception as main.jsx: the notifications worker holds the push
+      // subscription and caches nothing, so wiping it here would quietly
+      // unsubscribe someone as a side effect of taking an update.
+      await Promise.all(
+        regs.filter((r) => !r.scope.endsWith("/push-scope/")).map((r) => r.unregister()),
+      );
     }
   } catch {
     // ignore — reload anyway

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -212,6 +212,25 @@ const ALWAYS_ON_TEST_USERS = ['badadib', 'meno', 'tibfox', 'coolmole'];
 const isTestUser = (user) => !!user && ALWAYS_ON_TEST_USERS.includes(String(user).toLowerCase());
 const openpodsEnabledFor = (user) => ENABLE_OPENPODS || isTestUser(user);
 
+// Advertising (the /advertise page and the creator's ad opt-out in Settings).
+// OFF by default — set VITE_ENABLE_ADS=true to open it to everyone. Until then the
+// team accounts above see it, plus anyone listed in VITE_ADS_BETA_USERS so testers
+// can be added without a code change.
+//
+// This flag only decides what the UI SHOWS. It is not a security boundary: anyone
+// can read a Vite bundle or set a localStorage key. The gate that actually holds is
+// ADS_STAGE / ADS_BETA_USERS on the checker, which refuses to record an application
+// or an ad setting for an account outside the beta — and can enforce it because both
+// of those requests carry a Hive signature.
+const ENABLE_ADS = import.meta.env.VITE_ENABLE_ADS === 'true';
+const ADS_BETA_USERS = new Set(
+  (import.meta.env.VITE_ADS_BETA_USERS || '')
+    .split(',').map((s) => s.trim().toLowerCase()).filter(Boolean),
+);
+const adsEnabledFor = (user) => ENABLE_ADS
+  || isTestUser(user)
+  || (!!user && ADS_BETA_USERS.has(String(user).toLowerCase()));
+
 // Hosts whose live streams / rooms are kept OUT of the discovery feeds
 // (discover, follow, new). Same spirit as the checker's LEADERBOARD_EXCLUDED_USERS
 // — the account still works normally and its streams stay reachable by direct
@@ -294,6 +313,8 @@ export {
   OPENPODS_STANDALONE,
   ENABLE_OPENPODS,
   openpodsEnabledFor,
+  ENABLE_ADS,
+  adsEnabledFor,
   FEED_EXCLUDED_HOSTS,
   ENABLE_CAMERA_RECORD,
   cameraRecordEnabledFor,

--- a/src/utils/webPush.js
+++ b/src/utils/webPush.js
@@ -1,0 +1,216 @@
+import { CHECKER_URL } from './config';
+
+/**
+ * Browser side of push notifications.
+ *
+ * Three separate things have to line up, and they fail in different ways:
+ *   1. the browser supports push at all (iOS only does inside an installed PWA)
+ *   2. the user granted permission (a hard "denied" cannot be re-asked from JS)
+ *   3. a PushSubscription exists and the server knows about it
+ * `getPushState()` reports all three so the UI can say which one is missing
+ * rather than showing a toggle that silently does nothing.
+ */
+
+// The fallback worker gets a scope of its own, deliberately.
+//
+// A service worker does NOT need to control any pages to receive push events —
+// it only needs to exist. And registering it at '/' put it in a fight it always
+// loses: vite-plugin-pwa registers ITS dev worker at '/' on every page load,
+// and two different scripts cannot share a scope, so each load replaced the
+// other. Every replacement drops the push subscription tied to the old
+// registration, which is why a subscription would save correctly and then come
+// back `410 Gone` from the push service minutes later.
+const PUSH_SCOPE = '/push-scope/';
+
+export const pushSupported = () => (
+  typeof window !== 'undefined'
+  && 'serviceWorker' in navigator
+  && 'PushManager' in window
+  && 'Notification' in window
+);
+
+// VAPID keys travel as base64url; PushManager wants raw bytes.
+function urlBase64ToUint8Array(base64) {
+  const padded = `${base64}${'='.repeat((4 - (base64.length % 4)) % 4)}`
+    .replace(/-/g, '+')
+    .replace(/_/g, '/');
+  const raw = atob(padded);
+  return Uint8Array.from([...raw].map((c) => c.charCodeAt(0)));
+}
+
+/**
+ * The active service worker registration, or null.
+ *
+ * `navigator.serviceWorker.ready` NEVER RESOLVES when nothing is registered —
+ * it does not reject, it simply hangs. Awaiting it unguarded is what made the
+ * first version of this silently do nothing on the Vite dev server (which
+ * serves no worker at all): permission was granted, then the promise sat there
+ * forever with no error and no toast. So `ready` is raced against a short
+ * timeout and only ever used as a late-registration fallback.
+ */
+/** A registration that can receive push, preferring our own dedicated one. */
+async function registration() {
+  if (!pushSupported()) return null;
+  const dedicated = await navigator.serviceWorker.getRegistration(PUSH_SCOPE);
+  if (dedicated) return dedicated;
+  const root = await navigator.serviceWorker.getRegistration('/');
+  // Only trust the app's root worker when it actually got somewhere: in dev on
+  // Firefox it is an ES module the browser cannot evaluate, and a half-dead
+  // registration is worse than none because subscribe() on it fails silently.
+  if (root && root.active) return root;
+  return null;
+}
+
+/**
+ * A registration, registering one ourselves if the page hasn't.
+ *
+ * The app registers its worker on load, but that can leave nothing usable here:
+ * an earlier build whose worker threw during evaluation leaves a dead
+ * registration behind, and a tab opened before the fix never retries. Rather
+ * than telling someone to hard-reload, try the registration ourselves.
+ *
+ * Two candidate URLs because the worker is served from different paths in a
+ * build and under the Vite dev server, and this code cannot tell which it is
+ * running in. The wrong one rejects harmlessly (dev serves the SPA shell at
+ * /sw.js, which is not a worker) and we fall through to the other.
+ */
+async function ensureRegistration() {
+  const existing = await registration();
+  if (existing) return existing;
+  const candidates = [
+    // Production: the real, bundled worker already at the root scope.
+    ['/sw.js', { scope: '/' }],
+    // Anything else: our own classic, dependency-free worker, parked at a scope
+    // nothing else claims. Works in every browser including Firefox, which has
+    // no ES-module service worker support and so cannot run the dev worker.
+    ['/push-sw.js', { scope: PUSH_SCOPE }],
+  ];
+  for (const [url, opts] of candidates) {
+    try {
+      const reg = await navigator.serviceWorker.register(url, opts);
+      if (reg) {
+        // A registration is not usable the instant it is created.
+        if (!reg.active) await new Promise((r) => setTimeout(r, 700));
+        return reg;
+      }
+    } catch {
+      // Wrong path for this build, or the script failed to evaluate; try the next.
+    }
+  }
+  return null;
+}
+
+export async function getPushState() {
+  if (!pushSupported()) return { supported: false, permission: 'unsupported', subscribed: false };
+  const reg = await ensureRegistration();
+  const sub = reg ? await reg.pushManager.getSubscription() : null;
+  // `worker` distinguishes "this browser can't" from "this build doesn't ship
+  // one", which are very different problems with very different fixes.
+  return { supported: true, worker: !!reg, permission: Notification.permission, subscribed: !!sub };
+}
+
+export async function enablePush(username) {
+  if (!pushSupported()) throw new Error('This browser does not support notifications.');
+  if (!username) throw new Error('Log in first so we know whose creators to follow.');
+
+  const permission = await Notification.requestPermission();
+  if (permission !== 'granted') throw new Error('Notifications are blocked for this site.');
+
+  const keyRes = await fetch(`${CHECKER_URL}/push/vapid-key`);
+  if (!keyRes.ok) throw new Error('Notifications are not switched on yet.');
+  const { publicKey } = await keyRes.json();
+
+  const reg = await ensureRegistration();
+  if (!reg) {
+    throw new Error(
+      'Could not start the background worker notifications need. A reload usually fixes it.',
+    );
+  }
+
+  // Reuse an existing subscription rather than making a second one: a browser
+  // hands out one per registration, and re-subscribing with a different key
+  // throws instead of replacing it.
+  const subscription = (await reg.pushManager.getSubscription())
+    || (await reg.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(publicKey),
+    }));
+
+  const res = await fetch(`${CHECKER_URL}/push/subscribe`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, subscription: subscription.toJSON() }),
+  });
+  if (!res.ok) throw new Error('Could not save your notification settings.');
+  return true;
+}
+
+/**
+ * Re-tell the server about a subscription the browser already has.
+ *
+ * The two sides can drift apart in one direction that the UI cannot show: the
+ * sender DELETES rows the push service reports as gone (404/410), which is
+ * correct — but the browser may still hold a perfectly good subscription
+ * afterwards, e.g. after the worker was unregistered and re-registered. The
+ * toggle reads local state, so it says "On" while the server has no way to
+ * reach you, and there is nothing for the user to click to fix it.
+ *
+ * Cheap to just re-assert on load: the endpoint is an upsert keyed by
+ * (username, endpoint), so a row that already exists is only touched.
+ */
+export async function syncPushSubscription(username) {
+  if (!pushSupported() || !username) return false;
+  const reg = await registration();
+  const sub = reg ? await reg.pushManager.getSubscription() : null;
+  if (!sub) return false;
+  try {
+    await fetch(`${CHECKER_URL}/push/subscribe`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, subscription: sub.toJSON() }),
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function disablePush(username) {
+  const reg = await registration();
+  const sub = reg ? await reg.pushManager.getSubscription() : null;
+  if (sub) {
+    // Tell the server before dropping it locally — once unsubscribed we no
+    // longer have the endpoint to tell it about, and the row would linger.
+    await fetch(`${CHECKER_URL}/push/unsubscribe`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, endpoint: sub.endpoint }),
+    }).catch(() => {});
+    await sub.unsubscribe().catch(() => {});
+  }
+  return true;
+}
+
+/** What this person wants to be told about. Defaults to everything on. */
+export async function getPushPrefs(username) {
+  if (!username) return { kinds: [], prefs: {} };
+  try {
+    const res = await fetch(`${CHECKER_URL}/push/prefs?username=${encodeURIComponent(username)}`);
+    if (!res.ok) return { kinds: [], prefs: {} };
+    const data = await res.json();
+    return { kinds: data.kinds || [], prefs: data.prefs || {} };
+  } catch {
+    return { kinds: [], prefs: {} };
+  }
+}
+
+export async function setPushPrefs(username, prefs) {
+  const res = await fetch(`${CHECKER_URL}/push/prefs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, prefs }),
+  });
+  if (!res.ok) throw new Error('Could not save your notification choices.');
+  const data = await res.json();
+  return data.prefs || {};
+}

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.78.37';
+export const APP_VERSION = '1.78.41';

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.78.41';
+export const APP_VERSION = '1.78.42';

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.78.44';
+export const APP_VERSION = '1.78.46';

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.78.42';
+export const APP_VERSION = '1.78.43';

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.78.46';
+export const APP_VERSION = '1.78.47';

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.78.43';
+export const APP_VERSION = '1.78.44';

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.78.47';
+export const APP_VERSION = '1.78.48';

--- a/vite.config.js
+++ b/vite.config.js
@@ -40,6 +40,12 @@ export default defineConfig({
       strategies: "injectManifest",
       srcDir: "src",
       filename: "sw.js",
+      // OFF on purpose. Push does not need it: utils/webPush.js falls back to
+      // public/push-sw.js (classic, notifications only) at its own scope, which
+      // registers in dev in every browser — including Firefox, which cannot
+      // evaluate the ES-module dev worker this option would serve. Leaving it
+      // off keeps Workbox precaching out of dev, where it only causes stale
+      // modules and confusing HMR.
       devOptions: { enabled: false },
       manifest: {
         name: "3Speak",


### PR DESCRIPTION
This pull request introduces several improvements and new features to both the frontend and backend of the application, with a focus on enhancing SEO metadata, improving service worker compatibility for notifications, expanding API capabilities, and enriching the Open Graph (OG) server's structured data output. The most significant changes include updating branding in meta tags, adding a fallback service worker for Firefox, introducing a new API endpoint for ad preference signatures, providing clearer error messages for image uploads, and significantly enriching the OG server's output with transcripts and comments.

**SEO and Branding Updates:**
- Updated the page `<title>`, Open Graph, and Twitter meta tags in `index.html` to use the new branding: "3S | Real People - Real Stories". [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L25-R26) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L54-R54) [[3]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L65-R65)

**Service Worker Improvements:**
- Added a minimal, classic service worker (`public/push-sw.js`) to support notification push in Firefox during development, addressing the browser's lack of ES-module service worker support.

**Backend API Enhancements:**
- Introduced a new endpoint `/api/ads/opt-out-signature` in `server/index.cjs` that allows creators using HiveSigner or Butter Auth to set their ad preferences server-side, ensuring only a boolean is accepted and securely constructing the signed message. Also added environment variables for ad revenue splits to maintain consistency with the checker service. [[1]](diffhunk://#diff-546d8ea40577568b90ed41739d01efc62fa56bb2d1f21f994393e22460973023R28-R36) [[2]](diffhunk://#diff-546d8ea40577568b90ed41739d01efc62fa56bb2d1f21f994393e22460973023R1035-R1093)
- Improved image upload error handling to distinguish between quota exhaustion and other errors, returning a specific error and status code when the shared upload quota is exhausted.

**Open Graph (OG) Server Enrichments:**
- Enhanced the OG server (`server/og-server.cjs`) to:
  - Fetch and inline video transcripts more reliably, including a fallback to a server-side subtitle proxy if the CDN is cold. Only one language is inlined, with others declared as available. [[1]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aR343-R375) [[2]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aL349-R477)
  - Fetch, filter, and rank top-level Hive comments for inclusion in structured data and the rendered HTML, using payout and vote count as quality signals, and stripping all links and formatting to avoid SEO spam. [[1]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aR40-R44) [[2]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aL349-R477)
  - Add transcript language, subtitle language availability, comment count, and top comments to the JSON-LD structured data and the rendered HTML, improving SEO and discoverability. [[1]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aR499-R502) [[2]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aR538-R568) [[3]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aL459-R601) [[4]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aR743-R756) [[5]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aR770-R773)
  - Updated fallback OG HTML to reflect the new branding.

**Most Important Changes:**

**Branding and SEO:**
- Updated branding in all relevant meta tags in `index.html` and fallback OG HTML to "3S | Real People - Real Stories". [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L25-R26) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L54-R54) [[3]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L65-R65) [[4]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aL469-R611)

**Service Worker Compatibility:**
- Added `public/push-sw.js`, a classic service worker for notification support in Firefox during development.

**API and Error Handling:**
- Added `/api/ads/opt-out-signature` endpoint for securely signing ad preference changes for creators using delegated sign-in methods, with strict input validation and error handling. [[1]](diffhunk://#diff-546d8ea40577568b90ed41739d01efc62fa56bb2d1f21f994393e22460973023R28-R36) [[2]](diffhunk://#diff-546d8ea40577568b90ed41739d01efc62fa56bb2d1f21f994393e22460973023R1035-R1093)
- Improved image upload error handling to clearly indicate when the shared quota is exhausted, returning a specific error message and status code.

**OG Server Data Enrichment:**
- Enhanced transcript fetching with fallback to a proxy, and inlined only one language for SEO clarity; declared additional subtitle languages in structured data. [[1]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aR343-R375) [[2]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aL349-R477) [[3]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aR499-R502) [[4]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aR538-R568) [[5]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aR743-R756) [[6]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aR770-R773)
- Added top-level, high-quality comments to both the OG structured data and HTML output, stripping all links and formatting for safety and SEO. [[1]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aR40-R44) [[2]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aL349-R477) [[3]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aR499-R502) [[4]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aR538-R568) [[5]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aL459-R601) [[6]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aR743-R756) [[7]](diffhunk://#diff-220ca79b27801fbb0bb63e48274cdab3407a7d8e0e2fe5301eab6f8e4251b69aR770-R773)