### PR TITLE
chore(changelog): 1.78.49 — steadier uploads on patchy connections

### DIFF
--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.78.49',
+    date: '2026-08-22',
+    summary:
+      'Uploads are steadier on patchy mobile connections. If an upload switches to the more compatible method partway through, it now carries straight through to publishing, so your video lands the first time.',
+  },
+  {
     version: '1.78.48',
     date: '2026-08-22',
     summary:

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.78.48';
+export const APP_VERSION = '1.78.49';


### PR DESCRIPTION
This pull request updates the application to version `1.78.49` and adds a new changelog entry describing improvements to upload reliability on patchy mobile connections.

Version update:

* Bumped `APP_VERSION` in `src/version.js` from `1.78.48` to `1.78.49`, ensuring the app recognizes the new release.

Changelog:

* Added a new entry to `CHANGELOG` in `src/changelog.js` for version `1.78.49`, highlighting steadier uploads on unreliable mobile connections and improved handling when switching upload methods.