### PR TITLE
Feat/august freaks

### DIFF
--- a/src/changelog.js
+++ b/src/changelog.js
@@ -7,6 +7,12 @@
 // 1.0.0 — that way they see all of these when develop is pushed to production.
 export const CHANGELOG = [
   {
+    version: '1.78.50',
+    date: '2026-08-22',
+    summary:
+      'Publishing right as an upload finishes now waits for the server to catch up instead of asking you to press Post again.',
+  },
+  {
     version: '1.78.49',
     date: '2026-08-22',
     summary:

--- a/src/components/embed-studio/EmbedVideoUploadStep1.jsx
+++ b/src/components/embed-studio/EmbedVideoUploadStep1.jsx
@@ -384,13 +384,22 @@ function EmbedVideoUploadStep1() {
                         <span>Black-hole the single-request fallback too — total blackout, every transport dead. Only useful with the box above ticked. Expect: all three tiers tried in order, then a clean <em>Request timed out</em> failure. Nothing can upload under this by construction; it verifies we FAIL LOUDLY rather than hang.</span>
                       </label>
 
-                      <label style={{ display: 'flex', gap: '8px', alignItems: 'flex-start', cursor: 'pointer' }}>
+                      <label style={{ display: 'flex', gap: '8px', alignItems: 'flex-start', cursor: 'pointer', marginBottom: '5px' }}>
                         <input
                           type="checkbox"
                           checked={faults.chunkFailRate > 0}
                           onChange={(e) => applyFault({ chunkFailRate: e.target.checked ? 0.5 : 0 })}
                         />
                         <span>Flaky link — drop 50% of chunks. Expect: retries + /status resync, upload still completes.</span>
+                      </label>
+
+                      <label style={{ display: 'flex', gap: '8px', alignItems: 'flex-start', cursor: 'pointer' }}>
+                        <input
+                          type="checkbox"
+                          checked={!!faults.forceWeakLink}
+                          onChange={(e) => applyFault({ forceWeakLink: e.target.checked })}
+                        />
+                        <span>Weak-link profile — pretend the phone reports a thin uplink. Expect: the chunked path switches to <strong>256KB chunks across 5 parallel POSTs</strong> instead of one at a time (watch the Network tab: five <code>/upload/chunk</code> in flight together). This does <em>not</em> slow anything down; it selects the profile that a real mobile link would get, which is otherwise unreachable on a healthy line. Tick <em>Flaky link</em> too to also exercise retry + resync with several workers running.</span>
                       </label>
 
                       <p style={{ margin: '6px 0 0', opacity: 0.75 }}>

--- a/src/context/EmbedUploadContext.jsx
+++ b/src/context/EmbedUploadContext.jsx
@@ -1316,16 +1316,40 @@ export function EmbedUploadProvider({ children }) {
       if (deferral?.finalizeToken && deferral?.permlink) {
         const finalizeBase = (chosenEmbedBaseRef.current || EMBED_API_URL || '').replace(/\/+$/, '');
         addMessage(gated ? 'Starting encrypted encode…' : 'Starting encode…');
-        await axios.post(
-          `${finalizeBase}/video/${deferral.permlink}/encode`,
-          { gated: !!gated, ...(gated && gatedAllowlist.length ? { allowlist: gatedAllowlist } : {}) },
-          {
-            headers: {
-              Authorization: `Bearer ${deferral.finalizeToken}`,
-              'Content-Type': 'application/json',
-            },
-          },
-        );
+        // The upload's success response comes back BEFORE the server has pinned
+        // the file: post-finish answers immediately and then pins on setImmediate,
+        // so for a while the video is still `uploading` and commissioning replies
+        // 409 not_awaiting_encode (or not_pinned while the CID is still landing).
+        // That is "not yet", not "no", and the wait scales with file size — a
+        // 105MB short raced it by ~3s. Failing the publish there made the user
+        // click Post a second time to get the same upload commissioned, so poll
+        // instead. Only these two codes retry: 401/403/404 are real and must
+        // surface immediately rather than being sat on for a minute and a half.
+        const FINALIZE_RETRY_MS = [1000, 2000, 3000, 5000, 5000, 8000, 8000, 10000, 12000, 15000, 20000];
+        for (let attempt = 0; ; attempt++) {
+          try {
+            // 2xx ends the loop: 201 commissioned, or 200 already_queued, which
+            // makes a repeat attempt after a lost response harmless.
+            await axios.post(
+              `${finalizeBase}/video/${deferral.permlink}/encode`,
+              { gated: !!gated, ...(gated && gatedAllowlist.length ? { allowlist: gatedAllowlist } : {}) },
+              {
+                headers: {
+                  Authorization: `Bearer ${deferral.finalizeToken}`,
+                  'Content-Type': 'application/json',
+                },
+              },
+            );
+            break;
+          } catch (encErr) {
+            const code = encErr?.response?.data?.code;
+            const notReady = encErr?.response?.status === 409
+              && (code === 'not_awaiting_encode' || code === 'not_pinned');
+            if (!notReady || attempt >= FINALIZE_RETRY_MS.length) throw encErr;
+            setStatusText('Finishing upload on the server…');
+            await new Promise(r => setTimeout(r, FINALIZE_RETRY_MS[attempt]));
+          }
+        }
       } else if (gated && !deferral?.gated) {
         // Not deferred, and the toggle went on after the token was minted. The
         // upload is already committed as public; encoding it now would publish

--- a/src/context/EmbedUploadContext.jsx
+++ b/src/context/EmbedUploadContext.jsx
@@ -17,6 +17,7 @@ import { setChannelTrailer } from '../utils/channelTrailer';
 import { enforceLockedBeneficiaries, getLockedBeneficiaries, chargesEncoder, LOCKED_FUND_ACCOUNT, LOCKED_ENCODER_ACCOUNT } from '../utils/beneficiaries';
 import { oaEnvelope, threespeakVideo, probeVideoOrientation, OA_ARTICLE, OA_MICROPOST, OA_COMMENT } from '../utils/openAttribute';
 import axios from 'axios';
+import { isWeakLinkForced } from '../utils/uploadFaults';
 
 // Hosts that support TUS resume (tusd-backed). The legacy embed.3speak.tv origin
 // does NOT — a leftover fingerprint there fails with "invalid or missing length
@@ -28,11 +29,34 @@ function endpointSupportsResume(endpoint) {
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+// sleep(), but a tab coming back to the foreground cuts it short. Android Chrome
+// suspends timers in background tabs, so a chunk that failed just before the user
+// switched away would otherwise sit on a backoff that never fires: one real upload
+// lost 23 minutes in a single gap that way, with zero requests reaching the server.
+// Waking on visibilitychange turns that dead time back into a retry.
+const sleepUntilVisible = (ms) => new Promise((resolve) => {
+  let done = false;
+  const finish = () => {
+    if (done) return;
+    done = true;
+    clearTimeout(timer);
+    try { document.removeEventListener('visibilitychange', onVis); } catch { /* ignore */ }
+    resolve();
+  };
+  const onVis = () => { if (document.visibilityState === 'visible') finish(); };
+  const timer = setTimeout(finish, ms);
+  try { document.addEventListener('visibilitychange', onVis); } catch { /* ignore */ }
+});
+
 // Browser connection hint. On a thin/flaky/metered uplink we shrink to small
 // SEQUENTIAL chunks: big parallel chunks contend for bandwidth and trip tusd's
 // ~60s body-read timeout (the ERR_READ_TIMEOUT / ERR_UPLOAD_INTERRUPTED cascade
 // that loses uploads on bad connections).
 function getConnectionProfile() {
+  // Test override (badadib only): the weak profile cannot be reached on a healthy
+  // line, so without this the multi-worker path could only be exercised by
+  // finding a genuinely bad mobile connection. See utils/uploadFaults.
+  if (isWeakLinkForced()) return { weak: true, effectiveType: 'forced', forced: true };
   const c = (typeof navigator !== 'undefined' &&
     (navigator.connection || navigator.mozConnection || navigator.webkitConnection)) || null;
   // No Network Information API (Firefox/Safari) → we can't measure the link, so
@@ -728,7 +752,30 @@ export function EmbedUploadProvider({ children }) {
     // is more round trips on a fast link, which is a trade the fallback should
     // happily make. Server floor is CHUNK_MIN_SIZE = 256KB.
     let chunkSize, parallel;
-    if (conn.weak) { chunkSize = 512 * 1024; parallel = 1; }
+    // Weak links get MORE streams, not fewer. This looks backwards but the
+    // sequential setting is what made them slow: one hung POST halts the whole
+    // upload, and a real 22MB upload spent 68 of its 87 minutes dead that way,
+    // every stall starting with a chunk that hung until the stall watchdog killed
+    // it. With several workers a hung stream costs a fraction of throughput
+    // instead of all of it. The old comment justifying `parallel = 1` was about
+    // TUS multi-stream PATCH contention and does not apply here: these are
+    // independent idempotent POSTs written to disjoint offsets server-side, and
+    // a resent chunk is a no-op. Chunks are small so each POST finishes quickly
+    // even at a quarter of the bandwidth (~57s at the rate measured above, well
+    // inside HARD_MS). 256KB is the server's CHUNK_MIN_SIZE floor.
+    // NOTE: unrelated to PATCH_BLOCKED — that stays exactly as it is and is what
+    // put us on this path to begin with.
+    //
+    // Why 5 and not more: embed2 speaks HTTP/1.1, and browsers allow 6 connections
+    // per origin. 5 uses that budget while leaving one free for the status/finish
+    // calls, which would otherwise queue behind chunk POSTs. Workers past 6 do not
+    // run — the browser just queues them — so a bigger number buys nothing.
+    // Raising the ceiling would mean HTTP/2, and that is a REGRESSION here: h2
+    // multiplexes every stream over ONE TCP connection, so a single lost packet
+    // head-of-line blocks all of them. Independent TCP connections are exactly
+    // what gives the stall isolation this change is for. HTTP/3 would give both,
+    // but this nginx (1.24.0) is built with http_v2 only, no quic/v3.
+    if (conn.weak) { chunkSize = 256 * 1024; parallel = 5; }
     else if (size > 500 * MB) { chunkSize = 4 * MB; parallel = 2; }
     else if (size > 50 * MB) { chunkSize = 2 * MB; parallel = 2; }
     else { chunkSize = 1 * MB; parallel = 1; }
@@ -886,10 +933,15 @@ export function EmbedUploadProvider({ children }) {
     const queue = [];
     for (let i = 0; i < totalChunks; i++) if (!received.has(i)) queue.push(i);
 
-    // Long tail on purpose: these are the networks that drop for a minute at a
-    // time. Total patience per chunk ~5min of backoff, and each attempt is itself
-    // stall-guarded, so a dead attempt costs STALL_MS, not forever.
-    const RETRY_DELAYS = [0, 2000, 5000, 10000, 20000, 30000, 45000, 60000, 60000, 60000];
+    // Retry a chunk for as long as it takes. There is no attempt ceiling: giving
+    // up threw away an upload that was often 90%+ done, and a resend is free
+    // because the server no-ops an index it already holds. Backoff plateaus at
+    // 30s rather than climbing to 60s — the old ladder spent minutes asleep on
+    // links that had already come back.
+    // CHUNK_BUDGET_MS is a backstop against a genuinely dead link, not a target:
+    // at a 30s plateau it allows ~60 attempts on one chunk before giving up.
+    const RETRY_DELAYS = [0, 2000, 5000, 10000, 20000, 30000];
+    const CHUNK_BUDGET_MS = 30 * 60 * 1000;
     const STALL_MS = 45000;    // no bytes moved at all -> abort this attempt, retry
     const HARD_MS = 280000;    // just under nginx client_body_timeout (300s)
     let failed = null;
@@ -902,10 +954,14 @@ export function EmbedUploadProvider({ children }) {
         let ok = false;
         let lastErr;
 
-        for (let attempt = 0; attempt < RETRY_DELAYS.length && !ok && !failed; attempt++) {
+        const chunkStartedAt = Date.now();
+        for (let attempt = 0; !ok && !failed; attempt++) {
+          if (attempt > 0 && Date.now() - chunkStartedAt > CHUNK_BUDGET_MS) break;
           if (attempt > 0) {
             setStatusText('Connection unstable — retrying…');
-            await sleep(RETRY_DELAYS[attempt]);
+            // Clamp: the loop now runs past the end of the ladder, and an
+            // undefined delay would make setTimeout fire immediately and spin.
+            await sleepUntilVisible(RETRY_DELAYS[Math.min(attempt, RETRY_DELAYS.length - 1)]);
             if (failed) break;
           }
           try {

--- a/src/utils/uploadFaults.js
+++ b/src/utils/uploadFaults.js
@@ -32,7 +32,29 @@ const DEFAULTS = {
   blackholeChunks: false,  // middlebox swallows the chunk-protocol POSTs → create/stall watchdogs → tier 3
   blackholeSimple: false,  // ALSO swallow the single-request last resort → total blackout, nothing can pass
   chunkFailRate: 0,        // 0..1 — flaky link: fail this share of chunk POSTs → should retry + resync
+  forceWeakLink: false,    // pretend navigator.connection reports a thin uplink
 };
+
+/**
+ * Is the weak-link profile being forced?
+ *
+ * Unlike the flags above this is NOT an XHR fault — nothing is intercepted. It
+ * only makes getConnectionProfile() report `weak`, which is what selects the
+ * small-chunk / multi-worker upload profile. That profile is otherwise
+ * unreachable on a healthy office line, so without this it could only ever be
+ * tested by finding a genuinely bad mobile connection.
+ *
+ * It deliberately does NOT slow anything down: browser request-level throttling
+ * cannot pace an XHR body (the panel says as much), so simulating real slowness
+ * is not on offer. What this DOES verify is the part that actually changed —
+ * that the weak profile fans out to several concurrent chunk POSTs and that the
+ * upload reassembles correctly. Tick it together with "flaky link" to also
+ * exercise retry + /status resync while several workers are in flight, which is
+ * the closest we can get to the conditions that cost a real upload 68 minutes.
+ */
+export function isWeakLinkForced() {
+  try { return !!getUploadFaults().forceWeakLink; } catch { return false; }
+}
 
 export function getUploadFaults() {
   try {
@@ -56,6 +78,8 @@ export function clearUploadFaults() {
   try { sessionStorage.removeItem(KEY); } catch { /* ignore */ }
 }
 
+// NB: forceWeakLink is deliberately absent — it patches nothing, so it must not
+// pull the XHR interceptor in on its own. Only real faults arm the patch.
 function isArmed(f) {
   return !!(f.blockPatch || f.blackholeChunks || f.blackholeSimple || f.chunkFailRate > 0);
 }

--- a/src/version.js
+++ b/src/version.js
@@ -4,4 +4,4 @@
 // utils/appVersion.js, which surfaces the previous version via the store's
 // `appUpdatedFrom` so a changelog / "what's new" prompt can be shown later.
 // First-time visitors (no stored version) never trigger that prompt.
-export const APP_VERSION = '1.78.49';
+export const APP_VERSION = '1.78.50';


### PR DESCRIPTION
This pull request introduces several improvements to the upload experience, especially around handling weak or flaky network conditions and improving the reliability and user experience of the video publishing workflow. The most important changes are summarized below.

**Improvements to upload reliability and network handling:**

* The upload logic now detects when a "weak link" profile is forced (for testing) and, in that case, uses smaller (256KB) chunks and uploads them in parallel across 5 streams. This better simulates real mobile conditions and improves stall isolation, making uploads more robust against network stalls. [[1]](diffhunk://#diff-68e8c5f60a59262c932bc2fc9c3d7883d415c71402fe0def050d1a1cd38dbce3R20) [[2]](diffhunk://#diff-68e8c5f60a59262c932bc2fc9c3d7883d415c71402fe0def050d1a1cd38dbce3L731-R778) [[3]](diffhunk://#diff-dea6d2e069b2c329e8aeafd0a6bbd58fe616a501105be3d51c3adde8c2bca681R35-R58)
* Added a new fault injection option to the upload UI to force the weak-link profile, allowing developers to test the multi-worker upload path even on healthy connections. This is exposed in the upload step UI and does not actually slow down the connection, only changes the chunking and parallelism. [[1]](diffhunk://#diff-53735a493d200f68f173a1929fdfac6394ad58b8be8b454a931ca6b4a33b11e0R396-R404) [[2]](diffhunk://#diff-dea6d2e069b2c329e8aeafd0a6bbd58fe616a501105be3d51c3adde8c2bca681R35-R58)

**Enhancements to retry and backoff strategies:**

* The chunk upload retry logic now uses a shorter backoff plateau (max 30s per attempt) and will keep retrying chunks for up to 30 minutes, rather than giving up after a fixed number of attempts. Retries are now also interrupted if the tab regains focus, avoiding long waits due to background tab timer throttling. [[1]](diffhunk://#diff-68e8c5f60a59262c932bc2fc9c3d7883d415c71402fe0def050d1a1cd38dbce3R32-R59) [[2]](diffhunk://#diff-68e8c5f60a59262c932bc2fc9c3d7883d415c71402fe0def050d1a1cd38dbce3L889-R944) [[3]](diffhunk://#diff-68e8c5f60a59262c932bc2fc9c3d7883d415c71402fe0def050d1a1cd38dbce3L905-R964)

**Publishing workflow improvements:**

* When publishing a video immediately after upload, the app now polls the server and waits for it to finish pinning the uploaded file, rather than requiring the user to press "Post" again if the server isn't ready. Only true errors are surfaced immediately; temporary "not ready" states are retried with increasing delays. [[1]](diffhunk://#diff-68e8c5f60a59262c932bc2fc9c3d7883d415c71402fe0def050d1a1cd38dbce3R1375-R1388) [[2]](diffhunk://#diff-68e8c5f60a59262c932bc2fc9c3d7883d415c71402fe0def050d1a1cd38dbce3R1399-R1408)

**UI and version updates:**

* Minor UI tweaks to the upload step to improve spacing and clarity for fault injection options.
* Bumped the app version to `1.78.50` and updated the changelog to reflect the improved publishing experience. [[1]](diffhunk://#diff-c1a80fbb2e96a42cd35c5a1e7c3d22df4a225970075327f9a65ddab9510f06a8L7-R7) [[2]](diffhunk://#diff-2b5b164299e9a44e90c14ae81c0182d162656fec55e07d328651882df8c9c689R9-R14)